### PR TITLE
feat(app): realm-owned presentation forest with composite key registry and task-routed teardown (#555)

### DIFF
--- a/crates/flui-app/src/app/mod.rs
+++ b/crates/flui-app/src/app/mod.rs
@@ -15,6 +15,7 @@ pub mod direct;
 pub(crate) mod hot_reload;
 pub(crate) mod logging;
 pub(crate) mod presentation;
+pub(crate) mod presentation_forest;
 pub mod runner;
 pub(crate) mod runtime;
 pub(crate) mod semantics_host;

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -200,6 +200,29 @@ pub(crate) struct PresentationState {
     /// `RefCell` borrow and a `None` check per frame. Moved here from the
     /// retired `AppBinding` — per-window stats, not a process-wide concern.
     performance_overlay: RefCell<Option<PerformanceStats>>,
+    /// This presentation's own wake-only redraw mark (ADR-0043 §3's pump
+    /// segment). Set alongside the realm's own coalesced `needs_redraw` flag
+    /// by every presentation-scoped operation that isn't otherwise
+    /// re-derivable from live pipeline/build state (e.g. `attach_root_widget`
+    /// scheduling the very first build); cleared at the START of this
+    /// presentation's pump segment, before dirty is sampled, so a mark
+    /// arriving WHILE the segment runs sets the bit again instead of being
+    /// lost. This bit is wake-only, never the truth by itself: the segment's
+    /// real dirty predicate is `take_redraw_pending() ||
+    /// widgets().has_pending_builds() || <pipeline has_dirty_nodes>`
+    /// (`Self::has_pending_work`) — see `UiRealm::draw_frame_entered`'s
+    /// per-presentation loop.
+    redraw_pending: Cell<bool>,
+    /// Test-only oracle: how many times this presentation's own
+    /// build+layout+paint segment actually ran (`UiRealm::
+    /// draw_frame_for_presentation`), regardless of whether anything was
+    /// rebuilt or a scene reached present. This is the "flush count" the
+    /// isolation suite's sibling-independence tests read — a rebuild count
+    /// would not prove independence (a presentation with a settled, never-
+    /// rebuilding tree still flushes every segment it runs), and a
+    /// present-count would conflate this with GPU backend availability.
+    #[cfg(test)]
+    flush_count: Cell<u32>,
 }
 
 impl PresentationState {
@@ -305,6 +328,9 @@ impl PresentationState {
             frames_rendered: Cell::new(0),
             frames_dropped: Cell::new(0),
             performance_overlay: RefCell::new(None),
+            redraw_pending: Cell::new(false),
+            #[cfg(test)]
+            flush_count: Cell::new(0),
         };
         state.attach_surface();
         state
@@ -354,6 +380,9 @@ impl PresentationState {
             frames_rendered: Cell::new(0),
             frames_dropped: Cell::new(0),
             performance_overlay: RefCell::new(None),
+            redraw_pending: Cell::new(false),
+            #[cfg(test)]
+            flush_count: Cell::new(0),
         };
         state.attach_surface();
         state
@@ -530,6 +559,101 @@ impl PresentationState {
     /// Record a frame dropped due to a surface error.
     pub(crate) fn record_frame_dropped(&self) {
         self.frames_dropped.set(self.frames_dropped.get() + 1);
+    }
+
+    // ========================================================================
+    // Pump segment (ADR-0043 §3): per-presentation dirty predicate and wake bit
+    // ========================================================================
+
+    /// Mark this presentation's own wake-only redraw bit. See
+    /// [`Self::redraw_pending`]'s field doc.
+    pub(crate) fn mark_redraw_pending(&self) {
+        self.redraw_pending.set(true);
+    }
+
+    /// Read-and-clear this presentation's wake-only redraw bit — called at
+    /// the START of this presentation's pump segment, before dirty is
+    /// sampled, so a mark that arrives WHILE the segment runs sets the bit
+    /// again rather than being silently absorbed by this read.
+    pub(crate) fn take_redraw_pending(&self) -> bool {
+        self.redraw_pending.replace(false)
+    }
+
+    /// This presentation's own pump dirty predicate: would its build phase
+    /// do anything, or does its render pipeline have a dirty node to flush?
+    /// Deliberately excludes gesture-pending state — ticking gesture
+    /// deadlines happens once per pump, before any presentation's segment
+    /// runs, and gesture state never gates what a segment itself does (only
+    /// whether the OUTER runner wakes the loop at all); including it here
+    /// would not change any segment's observable outcome, only make this
+    /// predicate diverge from the exact condition the pipeline itself uses
+    /// to decide "nothing to flush".
+    #[must_use]
+    pub(crate) fn has_pending_work(&self) -> bool {
+        self.widgets.has_pending_builds()
+            || self.has_pending_layout_builder_work()
+            || self.renderer.root_pipeline_owner().with_mut(|owner| {
+                // Cross-thread dirty requests (`RepaintHandle`/
+                // `PipelineOwnerHandle` producers — background asset
+                // loaders, the frames-reenable redirty) sit in a channel
+                // until drained; `run_frame` itself always drains before its
+                // first phase, so an UNGATED call here would eventually see
+                // them regardless. This gate runs BEFORE `run_frame` now, so
+                // it must drain first or it would read a stale
+                // `has_dirty_nodes() == false` for a request that already
+                // landed in the channel and is sitting there un-applied.
+                // Non-blocking, idempotent (`try_recv`-based) — safe to call
+                // here even though `run_frame`'s own segment drains again
+                // immediately after.
+                owner.drain_pending_dirty();
+                owner.has_dirty_nodes()
+            })
+    }
+
+    /// Whether a registered `LayoutBuilder` seam entry
+    /// (`crates/flui-view/src/owner/layout_builder.rs`) exists.
+    ///
+    /// A live entry is pruned/serviced on every `run_frame_with_layout_
+    /// builders` pass regardless of whether anything else is dirty — a
+    /// stale entry never gets pruned, and a live one never gets its chance
+    /// to rebuild on a constraint change, unless that call still happens
+    /// with zero pending builds and zero dirty render nodes.
+    ///
+    /// Production has no way to populate this registry yet (the widget-side
+    /// entry point, `LayoutBuilder`, has not landed — `BuildOwner::
+    /// layout_builder_count` is a test-only accessor, planted only via
+    /// `register_layout_builder_for_test`), so this is unconditionally
+    /// `false` outside test builds: correct today because the registry is
+    /// provably always empty in production, not because the check is
+    /// skipped for convenience.
+    #[cfg(test)]
+    fn has_pending_layout_builder_work(&self) -> bool {
+        self.widgets
+            .with_build_owner(|owner| owner.layout_builder_count() > 0)
+    }
+
+    #[cfg(not(test))]
+    #[expect(
+        clippy::unused_self,
+        reason = "the &self receiver is intentional: this must stay a method with the \
+                  same signature as its #[cfg(test)] twin above, not an associated \
+                  function, or the two cfg arms would diverge in call-site shape"
+    )]
+    fn has_pending_layout_builder_work(&self) -> bool {
+        false
+    }
+
+    /// Record that this presentation's build+layout+paint segment ran. See
+    /// [`Self::flush_count`]'s field doc for the oracle this backs.
+    #[cfg(test)]
+    pub(crate) fn record_flush(&self) {
+        self.flush_count.set(self.flush_count.get() + 1);
+    }
+
+    /// This presentation's own flush count. Test-only oracle.
+    #[cfg(test)]
+    pub(crate) fn flush_count(&self) -> u32 {
+        self.flush_count.get()
     }
 
     /// Turn the performance overlay on or off. Enabling starts a fresh

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -659,7 +659,22 @@ impl PresentationState {
         }
     }
 
-    /// Begin deterministic owner-local teardown.
+    /// Begin deterministic owner-local teardown (ADR-0043 §5's per-presentation
+    /// ordering, the part of it this type alone can carry out): input/cursor
+    /// first, IME and focus deactivate next, THEN the root widget detaches
+    /// through this exact presentation's own `WidgetsBinding` — so any
+    /// `State::dispose()` hook a descendant runs sees focus/IME already
+    /// quiesced, never a live input surface mid-teardown. `GlobalKeyScope`
+    /// reclamation is not this method's job: it happens when this
+    /// presentation's `BuildOwner` itself drops (`GlobalKeyScope::
+    /// reclaim_owner`, wired through `BuildOwner`'s own `Drop`), which
+    /// dropping this `WidgetsBinding` triggers regardless of whether
+    /// `detach_root_widget` found a root to unmount.
+    ///
+    /// Callers that need dispose hooks to resolve `GlobalKey` lookups
+    /// correctly must run this inside the realm's own `enter()` (see
+    /// `UiRealm`'s `Drop` impl) — this method itself does not activate any
+    /// registry.
     pub(crate) fn close(&self) {
         match self.lifecycle.get() {
             PresentationLifecycle::Closing | PresentationLifecycle::Closed => return,
@@ -689,6 +704,11 @@ impl PresentationState {
         }
         self.focus.close();
         self.text_input.close();
+        // Detach LAST: a no-op if nothing was ever attached (many tests never
+        // mount a root), and otherwise unmounts through this presentation's
+        // OWN element tree only -- never a sibling's, since each
+        // PresentationState owns an exclusive WidgetsBinding.
+        self.widgets.detach_root_widget();
         self.lifecycle.set(PresentationLifecycle::Closed);
     }
 }
@@ -743,6 +763,29 @@ mod tests {
         presentation.close();
         presentation.close();
         assert_eq!(presentation.lifecycle(), PresentationLifecycle::Closed);
+    }
+
+    /// `close` must detach through this presentation's OWN `WidgetsBinding`
+    /// — the ADR-0043 teardown ordering this method now carries out, not
+    /// just the input/focus/IME steps that predate it.
+    #[test]
+    fn close_detaches_this_presentations_own_root_widget() {
+        let presentation = presentation();
+        presentation
+            .widgets()
+            .attach_root_widget(&flui_widgets::SizedBox::new(10.0, 10.0))
+            .expect("fresh presentation attaches its first root");
+        assert!(
+            presentation.widgets().root_element().is_some(),
+            "root must be attached before close"
+        );
+
+        presentation.close();
+
+        assert!(
+            presentation.widgets().root_element().is_none(),
+            "close must detach the root through this presentation's own binding"
+        );
     }
 
     /// If reverted: remove the lifecycle check from `dispatch_semantics_action`

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -7,10 +7,13 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 
 use flui_foundation::PresentationId;
-use flui_interaction::{FocusManager, GestureBinding, TextInputHandle, TextInputOwner};
+use flui_interaction::{
+    FocusManager, GestureBinding, InteractionDispatchHandle, TextInputHandle, TextInputOwner,
+};
 use flui_layer::{Layer, LayerTree, PerformanceOverlayLayer, PerformanceStats};
 #[cfg(test)]
 use flui_platform::traits::PlatformTextInput;
@@ -18,15 +21,55 @@ use flui_platform::{
     CursorIcon,
     traits::{CursorError, PlatformWindow},
 };
+use flui_rendering::binding::RendererBinding as _;
 use flui_rendering::pipeline::PipelineCell;
 #[cfg(test)]
 use flui_rendering::pipeline::PipelineOwner;
+use flui_scheduler::{AsyncDriver, PostFrameHandle, Scheduler};
 use flui_semantics::{SemanticsActionError, SemanticsActionRequest};
 use flui_types::HapticFeedback;
-#[cfg(feature = "hot-reload")]
-use flui_view::WidgetsBinding;
+use flui_view::{GlobalKeyScope, WidgetsBinding};
 
 use super::semantics_host::SemanticsHost;
+use crate::bindings::RenderingFlutterBinding;
+
+/// Realm-supplied capabilities threaded into a presentation at assembly
+/// time (ADR-0043 §1): [`Self::global_key_scope`] is installed FIRST — the
+/// underlying `BuildOwner::set_global_key_scope` setter panics with `BUG:`
+/// if called after this owner's own `GlobalKey` registration has begun —
+/// then the realm's shared dispatch handles, before this presentation's own
+/// focus/IME are wired into its fresh `WidgetsBinding`, all before
+/// attach/mount. See [`PresentationState::new`].
+pub(crate) struct RealmCapabilities<'a> {
+    /// The realm's cross-tree `GlobalKey` uniqueness domain (ADR-0043).
+    pub(crate) global_key_scope: GlobalKeyScope,
+    /// The realm's shared async-task driver (`build_owner.rs:296` is
+    /// realm-level; see the presentation-teardown contract for the
+    /// consequence of that when this presentation closes).
+    pub(crate) async_driver: AsyncDriver,
+    /// The realm's local post-frame callback lane.
+    pub(crate) post_frame_handle: PostFrameHandle,
+    /// The realm's interaction dispatch lane.
+    pub(crate) interaction_dispatch_handle: InteractionDispatchHandle,
+    /// The realm's own scheduler — borrowed only for the duration of
+    /// assembly; the constructed [`RenderingFlutterBinding`] keeps just a
+    /// `WeakScheduler` derived from it.
+    pub(crate) scheduler: &'a Scheduler,
+    /// The realm's platform wake capability, cloned into this
+    /// presentation's pipeline as its `on_need_visual_update` callback.
+    pub(crate) wake: Arc<dyn Fn() + Send + Sync>,
+}
+
+/// A realm-backed test window carrying an optional platform text-input
+/// capability — for `UiRealm::for_test_with_text_input`, which needs a real
+/// [`RealmCapabilities`]-assembled presentation (not the standalone
+/// [`PresentationState::new_for_test`] path), just with a test window.
+#[cfg(test)]
+pub(crate) fn test_platform_window(
+    platform_text_input: Option<Arc<dyn PlatformTextInput>>,
+) -> Arc<dyn PlatformWindow> {
+    Arc::new(TestPresentationWindow::new(platform_text_input))
+}
 
 #[cfg(test)]
 struct TestPresentationWindow {
@@ -127,6 +170,20 @@ pub(crate) struct PresentationState {
     /// renderer fan-out (production read) — announce/event delivery itself
     /// still has no production caller (see [`Self::semantics_host`]'s doc).
     semantics: SemanticsHost,
+    /// Owner-local widget framework state. One instance per presentation
+    /// (ADR-0043) — the realm-level singular binding this used to be
+    /// dissolves here; every widget-tree operation for this surface enters
+    /// through this presentation and activates this binding's own GlobalKey
+    /// registry (composed into the realm's whole-frame composite by
+    /// `UiRealm::enter`, never activated standalone in production).
+    widgets: WidgetsBinding,
+    /// Render tree, layout/paint pipeline coordination, and this
+    /// presentation's own semantics-enablement fan-out. Moved from the
+    /// retired realm-level singular `UiRealm::renderer`: `render_views`,
+    /// `first_frame_sent`, and the semantics-enabled listener are
+    /// per-presentation-window facts, not shareable once a realm hosts more
+    /// than one presentation.
+    renderer: RenderingFlutterBinding,
     /// Total frames rendered successfully for this presentation. Moved here
     /// from the retired `AppBinding`: per-window frame accounting, beside
     /// its consumer [`Self::performance_overlay`].
@@ -146,13 +203,13 @@ pub(crate) struct PresentationState {
 }
 
 impl PresentationState {
-    pub(crate) fn new(
-        id: PresentationId,
-        pipeline: PipelineCell,
-        window: Arc<dyn PlatformWindow>,
-    ) -> Self {
+    /// Assemble the gesture arena, wiring its mouse-tracker cursor callback
+    /// to `window` (shared by every constructor below — production and
+    /// test alike — since the callback shape never varies with capability
+    /// wiring).
+    fn build_gestures(id: PresentationId, window: &Arc<dyn PlatformWindow>) -> GestureBinding {
         let gestures = GestureBinding::new();
-        let cursor_window = Arc::downgrade(&window);
+        let cursor_window = Arc::downgrade(window);
         gestures
             .mouse_tracker()
             .set_cursor_change_callback(Rc::new(move |device_id, cursor| {
@@ -187,16 +244,113 @@ impl PresentationState {
                     }
                 }
             }));
-        let platform_text_input = window.text_input();
+        gestures
+    }
+
+    /// Assemble a presentation wired into a realm (ADR-0043 §1): installs
+    /// `capabilities.global_key_scope` FIRST, then the realm's shared
+    /// dispatch handles, before this presentation's own focus/IME are
+    /// wired to its fresh [`WidgetsBinding`] and [`RenderingFlutterBinding`]
+    /// — all before the caller ever attaches/mounts a root widget.
+    pub(crate) fn new(
+        id: PresentationId,
+        pipeline: PipelineCell,
+        window: Arc<dyn PlatformWindow>,
+        capabilities: RealmCapabilities<'_>,
+    ) -> Self {
+        let gestures = Self::build_gestures(id, &window);
+        let focus = FocusManager::new();
+        let text_input = TextInputOwner::new(window.text_input());
+
+        let widgets = WidgetsBinding::with_focus_manager(Rc::clone(&focus));
+        widgets.set_pipeline_owner(pipeline.clone());
+        widgets.with_build_owner_mut(|owner| {
+            owner.set_global_key_scope(capabilities.global_key_scope);
+            owner.set_async_driver(capabilities.async_driver);
+            owner.set_post_frame_handle(capabilities.post_frame_handle);
+            owner.set_interaction_dispatch_handle(capabilities.interaction_dispatch_handle);
+            owner.set_text_input_handle(text_input.handle());
+        });
+
+        let renderer =
+            RenderingFlutterBinding::new_with_pipeline(pipeline.clone(), capabilities.scheduler);
+
+        // Idle-wake wiring: a dirty mark (mark_needs_layout / mark_needs_paint)
+        // fires this callback so a quiescent event loop produces the frame.
+        // Reentrancy-safe: the callback fires while the CALLER holds the
+        // pipeline cell checked out, and `wake` only touches `Send + Sync`
+        // runtime-level state — never this presentation's own `widgets` /
+        // `renderer` / gesture state.
+        let visual_wake = capabilities.wake;
+        pipeline.with_mut(|owner| owner.set_on_need_visual_update(move || visual_wake()));
+
+        let semantics = SemanticsHost::new();
+        // Semantics-enabled fan-out -> this presentation's own SemanticsHost.
+        let semantics_flag = semantics.platform_semantics_enabled_handle();
+        renderer.add_semantics_enabled_listener(Arc::new(move |enabled| {
+            semantics_flag.store(enabled, Ordering::Relaxed);
+        }));
+
         let state = Self {
             id,
             lifecycle: Cell::new(PresentationLifecycle::Created),
             pipeline,
             window: Arc::downgrade(&window),
             gestures,
-            focus: FocusManager::new(),
-            text_input: TextInputOwner::new(platform_text_input),
-            semantics: SemanticsHost::new(),
+            focus,
+            text_input,
+            semantics,
+            widgets,
+            renderer,
+            frames_rendered: Cell::new(0),
+            frames_dropped: Cell::new(0),
+            performance_overlay: RefCell::new(None),
+        };
+        state.attach_surface();
+        state
+    }
+
+    /// Standalone assembly with no realm above it: this presentation's
+    /// `WidgetsBinding` lazily self-owns a private `GlobalKeyScope` on first
+    /// `GlobalKey` registration (never shared, so it never conflicts with
+    /// anything), and its `RenderingFlutterBinding` owns its own throwaway
+    /// `Scheduler` (see [`RenderingFlutterBinding::new_for_test_with_pipeline`]).
+    /// Used only by this module's own unit tests, which exercise
+    /// presentation-local behavior (gestures/focus/haptics/overlay) in
+    /// isolation; realm-backed tests use [`Self::new`] through
+    /// `UiRealm::for_test`, exactly like production.
+    #[cfg(test)]
+    pub(crate) fn new_for_test_with_window(
+        id: PresentationId,
+        pipeline: PipelineCell,
+        window: Arc<dyn PlatformWindow>,
+    ) -> Self {
+        let gestures = Self::build_gestures(id, &window);
+        let focus = FocusManager::new();
+        let text_input = TextInputOwner::new(window.text_input());
+
+        let widgets = WidgetsBinding::with_focus_manager(Rc::clone(&focus));
+        widgets.set_pipeline_owner(pipeline.clone());
+
+        let renderer = RenderingFlutterBinding::new_for_test_with_pipeline(pipeline.clone());
+
+        let semantics = SemanticsHost::new();
+        let semantics_flag = semantics.platform_semantics_enabled_handle();
+        renderer.add_semantics_enabled_listener(Arc::new(move |enabled| {
+            semantics_flag.store(enabled, Ordering::Relaxed);
+        }));
+
+        let state = Self {
+            id,
+            lifecycle: Cell::new(PresentationLifecycle::Created),
+            pipeline,
+            window: Arc::downgrade(&window),
+            gestures,
+            focus,
+            text_input,
+            semantics,
+            widgets,
+            renderer,
             frames_rendered: Cell::new(0),
             frames_dropped: Cell::new(0),
             performance_overlay: RefCell::new(None),
@@ -213,7 +367,19 @@ impl PresentationState {
     ) -> Self {
         let window: Arc<dyn PlatformWindow> =
             Arc::new(TestPresentationWindow::new(platform_text_input));
-        Self::new(id, pipeline, window)
+        Self::new_for_test_with_window(id, pipeline, window)
+    }
+
+    /// This presentation's own widget framework state.
+    #[must_use]
+    pub(crate) fn widgets(&self) -> &WidgetsBinding {
+        &self.widgets
+    }
+
+    /// This presentation's own render tree / pipeline coordination binding.
+    #[must_use]
+    pub(crate) fn renderer(&self) -> &RenderingFlutterBinding {
+        &self.renderer
     }
 
     #[must_use]
@@ -248,6 +414,17 @@ impl PresentationState {
     }
 
     #[must_use]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Self::new wires set_text_input_handle from the local \
+                      text_input binding directly (before self exists to call \
+                      this wrapper through); this accessor's one production \
+                      caller moved inline when assembly moved into this \
+                      constructor, kept for tests and any future external caller"
+        )
+    )]
     pub(crate) fn text_input_handle(&self) -> TextInputHandle {
         self.text_input.handle()
     }
@@ -255,10 +432,20 @@ impl PresentationState {
     /// This presentation's semantics enablement gate and platform
     /// accessibility delivery — the per-window home the retired
     /// `SemanticsBinding` singleton's enablement/announce/event state moved
-    /// into. `UiRealm::construct` reads this to wire the realm's renderer
+    /// into. `Self::new` reads the underlying flag directly (before `self`
+    /// exists to call this wrapper through) to wire the renderer's
     /// semantics-enabled fan-out; announce/event delivery itself still has
     /// no production caller (future platform-embedder wiring).
     #[must_use]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "this accessor's one production caller moved inline into \
+                      Self::new's own assembly; kept for tests and any future \
+                      external caller"
+        )
+    )]
     pub(crate) fn semantics_host(&self) -> &SemanticsHost {
         &self.semantics
     }
@@ -435,19 +622,15 @@ impl PresentationState {
         Ok(())
     }
 
-    /// Apply a hot-reload tier to this presentation and its realm-owned
-    /// element tree. Returns whether a redraw is required.
+    /// Apply a hot-reload tier to this presentation's own element tree.
+    /// Returns whether a redraw is required.
     #[cfg(feature = "hot-reload")]
-    pub(crate) fn apply_hot_reload(
-        &self,
-        widgets: &WidgetsBinding,
-        tier: flui_hot_reload::HotReloadTier,
-    ) -> bool {
+    pub(crate) fn apply_hot_reload(&self, tier: flui_hot_reload::HotReloadTier) -> bool {
         use flui_hot_reload::HotReloadTier;
 
         match tier {
             HotReloadTier::HotReload => {
-                widgets.perform_reassemble();
+                self.widgets.perform_reassemble();
                 self.pipeline
                     .with_mut(flui_rendering::pipeline::PipelineOwner::reassemble);
                 tracing::info!(
@@ -461,7 +644,7 @@ impl PresentationState {
                     { flui_foundation::diagnostics::PRESENTATION_ID } = self.id.as_u64(),
                     "HotRestart root remount is not implemented; applying reassemble"
                 );
-                widgets.perform_reassemble();
+                self.widgets.perform_reassemble();
                 self.pipeline
                     .with_mut(flui_rendering::pipeline::PipelineOwner::reassemble);
                 true
@@ -626,7 +809,7 @@ mod tests {
 
         let window = Arc::new(TestPresentationWindow::new(None));
         let platform_window: Arc<dyn PlatformWindow> = window.clone();
-        let presentation = PresentationState::new(
+        let presentation = PresentationState::new_for_test_with_window(
             PresentationId::new_gen(0, NonZeroU32::MIN),
             PipelineCell::new(PipelineOwner::new()),
             platform_window,
@@ -734,7 +917,7 @@ mod tests {
             // strong `Arc` in production); this test's own `window` binding
             // is what keeps it alive here, so pass a clone rather than
             // moving the only strong reference in.
-            let presentation = PresentationState::new(
+            let presentation = PresentationState::new_for_test_with_window(
                 PresentationId::new_gen(0, NonZeroU32::MIN),
                 PipelineCell::new(PipelineOwner::new()),
                 Arc::clone(&window),
@@ -760,7 +943,7 @@ mod tests {
         #[test]
         fn perform_haptic_feedback_with_no_active_window_is_a_silent_no_op() {
             let window: Arc<dyn PlatformWindow> = Arc::new(BareWindow);
-            let presentation = PresentationState::new(
+            let presentation = PresentationState::new_for_test_with_window(
                 PresentationId::new_gen(0, NonZeroU32::MIN),
                 PipelineCell::new(PipelineOwner::new()),
                 Arc::clone(&window),
@@ -775,7 +958,7 @@ mod tests {
         /// is also a silent no-op.
         #[test]
         fn perform_haptic_feedback_on_a_window_without_haptics_is_a_silent_no_op() {
-            let presentation = PresentationState::new(
+            let presentation = PresentationState::new_for_test_with_window(
                 PresentationId::new_gen(0, NonZeroU32::MIN),
                 PipelineCell::new(PipelineOwner::new()),
                 Arc::new(BareWindow),

--- a/crates/flui-app/src/app/presentation_forest.rs
+++ b/crates/flui-app/src/app/presentation_forest.rs
@@ -3,13 +3,13 @@
 //!
 //! Production topology is exactly one presentation per realm today: opening
 //! a second independent window installs a second REALM (`AppRuntime`'s
-//! `RealmId`-keyed map, #555 PR-1), not a second presentation inside an
-//! existing one. This type exists so that shape — the realm-level composite
-//! `GlobalKey` registry, the per-presentation pump/teardown/reassemble
-//! machinery — is written once, generally, over `Vec<PresentationState>`
-//! rather than hand-specialized to "exactly one", so a later slice (window
-//! grouping / `WindowPolicy`, #555 PR-4/5) can lift the ratchet below
-//! without re-deriving this plumbing.
+//! `RealmId`-keyed map), not a second presentation inside an existing one.
+//! This type exists so that shape — the realm-level composite `GlobalKey`
+//! registry, the per-presentation pump/teardown/reassemble machinery — is
+//! written once, generally, over `Vec<PresentationState>` rather than
+//! hand-specialized to "exactly one", so a later addressed-routing slice
+//! (window grouping / `WindowPolicy`) can lift the ratchet below without
+//! re-deriving this plumbing.
 //!
 //! Iteration order is insertion (mount) order: a plain `Vec`, never
 //! reordered. Pump, reassemble fan-out, and the composite registry all rely
@@ -29,8 +29,9 @@ use super::presentation::PresentationState;
 /// (`multi-presentation-forest-gate`, `docs/runtime-contract.toml`) as the
 /// mechanical 1×N ratchet: production topology stays exactly one
 /// presentation per realm until a later slice's addressed routing lifts it.
-/// [`Self::push_for_test`] is the only bypass, and only compiles under
-/// `cfg(test)`.
+/// `push_for_test` is the only bypass, and only compiles under `cfg(test)`
+/// (not linked from this doc: a plain `cfg(test)` item has no stable link
+/// target in a non-test doc build).
 pub(crate) struct PresentationForest {
     presentations: Vec<PresentationState>,
 }
@@ -50,13 +51,13 @@ impl PresentationForest {
     /// — there is no production call site for this today (opening a second
     /// window installs a second realm, not a second presentation), so this
     /// exists to fail loudly the moment one is added ahead of the addressed
-    /// routing (#555 PR-4/5) that makes a true forest safe to drive.
+    /// routing that makes a true forest safe to drive.
     #[cfg_attr(
         not(test),
         expect(
             dead_code,
             reason = "no production caller until the len()<=1 ratchet lifts \
-                      (#555 PR-4/5's addressed routing); push_for_test is the \
+                      (a later addressed-routing slice); push_for_test is the \
                       isolation-suite bypass"
         )
     )]
@@ -65,8 +66,8 @@ impl PresentationForest {
             self.presentations.is_empty(),
             "BUG: PresentationForest::install called while the ratchet is \
              still closed -- production topology is exactly one presentation \
-             per realm until #555 PR-4/5 lifts the len()<=1 gate; tests use \
-             push_for_test to bypass it deliberately"
+             per realm until a later addressed-routing slice lifts the \
+             len()<=1 gate; tests use push_for_test to bypass it deliberately"
         );
         self.presentations.push(presentation);
     }
@@ -106,7 +107,7 @@ impl PresentationForest {
         expect(
             dead_code,
             reason = "addressed lookup by id has no production caller until \
-                      #555 PR-4's addressed entry points land"
+                      a later addressed-routing slice's entry points land"
         )
     )]
     pub(crate) fn get(&self, id: PresentationId) -> Option<&PresentationState> {
@@ -118,10 +119,11 @@ impl PresentationForest {
         not(test),
         expect(
             dead_code,
-            reason = "no production caller until a presentation-close path \
-                      (#555 PR-4/5) removes a member from a genuine N>1 forest; \
-                      teardown of the realm's SOLE presentation today drops \
-                      the whole forest instead of removing a member from it"
+            reason = "no production caller until a later addressed-routing \
+                      slice's presentation-close path removes a member from \
+                      a genuine N>1 forest; teardown of the realm's SOLE \
+                      presentation today drops the whole forest instead of \
+                      removing a member from it"
         )
     )]
     pub(crate) fn remove(&mut self, id: PresentationId) -> Option<PresentationState> {

--- a/crates/flui-app/src/app/presentation_forest.rs
+++ b/crates/flui-app/src/app/presentation_forest.rs
@@ -1,0 +1,216 @@
+//! `PresentationForest` — the insertion-ordered collection of
+//! [`PresentationState`]s one `UiRealm` owns (ADR-0043 §1).
+//!
+//! Production topology is exactly one presentation per realm today: opening
+//! a second independent window installs a second REALM (`AppRuntime`'s
+//! `RealmId`-keyed map, #555 PR-1), not a second presentation inside an
+//! existing one. This type exists so that shape — the realm-level composite
+//! `GlobalKey` registry, the per-presentation pump/teardown/reassemble
+//! machinery — is written once, generally, over `Vec<PresentationState>`
+//! rather than hand-specialized to "exactly one", so a later slice (window
+//! grouping / `WindowPolicy`, #555 PR-4/5) can lift the ratchet below
+//! without re-deriving this plumbing.
+//!
+//! Iteration order is insertion (mount) order: a plain `Vec`, never
+//! reordered. Pump, reassemble fan-out, and the composite registry all rely
+//! on this — see their own docs for why mount order is the observable
+//! contract, not an implementation accident.
+
+use flui_foundation::PresentationId;
+
+use super::presentation::PresentationState;
+
+/// The insertion-ordered set of presentations one `UiRealm` owns.
+///
+/// # Ratchet
+///
+/// [`Self::install`] is the production entry point and panics if the forest
+/// already holds a presentation — registry-pinned
+/// (`multi-presentation-forest-gate`, `docs/runtime-contract.toml`) as the
+/// mechanical 1×N ratchet: production topology stays exactly one
+/// presentation per realm until a later slice's addressed routing lifts it.
+/// [`Self::push_for_test`] is the only bypass, and only compiles under
+/// `cfg(test)`.
+pub(crate) struct PresentationForest {
+    presentations: Vec<PresentationState>,
+}
+
+impl PresentationForest {
+    /// Construct a forest holding exactly one presentation — the only
+    /// production shape until the ratchet in [`Self::install`] lifts.
+    pub(crate) fn single(presentation: PresentationState) -> Self {
+        Self {
+            presentations: vec![presentation],
+        }
+    }
+
+    /// Install another presentation into this forest.
+    ///
+    /// **Ratchet:** panics with `BUG:` if the forest is not currently empty
+    /// — there is no production call site for this today (opening a second
+    /// window installs a second realm, not a second presentation), so this
+    /// exists to fail loudly the moment one is added ahead of the addressed
+    /// routing (#555 PR-4/5) that makes a true forest safe to drive.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "no production caller until the len()<=1 ratchet lifts \
+                      (#555 PR-4/5's addressed routing); push_for_test is the \
+                      isolation-suite bypass"
+        )
+    )]
+    pub(crate) fn install(&mut self, presentation: PresentationState) {
+        assert!(
+            self.presentations.is_empty(),
+            "BUG: PresentationForest::install called while the ratchet is \
+             still closed -- production topology is exactly one presentation \
+             per realm until #555 PR-4/5 lifts the len()<=1 gate; tests use \
+             push_for_test to bypass it deliberately"
+        );
+        self.presentations.push(presentation);
+    }
+
+    /// Isolation-suite-only bypass of [`Self::install`]'s ratchet, so a test
+    /// can drive a genuine multi-presentation realm ahead of the addressed
+    /// routing that makes doing so safe in production.
+    #[cfg(test)]
+    pub(crate) fn push_for_test(&mut self, presentation: PresentationState) {
+        self.presentations.push(presentation);
+    }
+
+    /// The number of presentations currently installed.
+    #[must_use]
+    pub(crate) fn len(&self) -> usize {
+        self.presentations.len()
+    }
+
+    /// This realm's primary (and, until the ratchet lifts, only) production
+    /// presentation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the forest is empty — a `UiRealm` never exists without at
+    /// least one presentation; an empty forest is a construction bug, not a
+    /// reachable runtime state.
+    #[must_use]
+    pub(crate) fn primary(&self) -> &PresentationState {
+        self.presentations
+            .first()
+            .expect("BUG: PresentationForest is never empty for a live UiRealm")
+    }
+
+    /// Look up a presentation by its exact generational id.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "addressed lookup by id has no production caller until \
+                      #555 PR-4's addressed entry points land"
+        )
+    )]
+    pub(crate) fn get(&self, id: PresentationId) -> Option<&PresentationState> {
+        self.presentations.iter().find(|p| p.id() == id)
+    }
+
+    /// Remove and return the presentation with the given id, if present.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "no production caller until a presentation-close path \
+                      (#555 PR-4/5) removes a member from a genuine N>1 forest; \
+                      teardown of the realm's SOLE presentation today drops \
+                      the whole forest instead of removing a member from it"
+        )
+    )]
+    pub(crate) fn remove(&mut self, id: PresentationId) -> Option<PresentationState> {
+        let index = self.presentations.iter().position(|p| p.id() == id)?;
+        Some(self.presentations.remove(index))
+    }
+
+    /// Iterate every presentation in mount (insertion) order.
+    ///
+    /// Mount order is the observable contract for pump processing, hot-reload
+    /// reassemble fan-out, and the realm composite registry's try-in-order
+    /// resolution — never re-sorted or reversed.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &PresentationState> {
+        self.presentations.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+    use std::sync::Arc;
+
+    use flui_platform::traits::PlatformTextInput;
+    use flui_rendering::pipeline::{PipelineCell, PipelineOwner};
+
+    use super::*;
+
+    fn presentation(generation: u32) -> PresentationState {
+        PresentationState::new_for_test(
+            PresentationId::new_gen(0, NonZeroU32::new(generation).expect("nonzero")),
+            PipelineCell::new(PipelineOwner::new()),
+            None::<Arc<dyn PlatformTextInput>>,
+        )
+    }
+
+    #[test]
+    fn single_holds_exactly_the_constructed_presentation() {
+        let p = presentation(1);
+        let id = p.id();
+        let forest = PresentationForest::single(p);
+
+        assert_eq!(forest.len(), 1);
+        assert_eq!(forest.primary().id(), id);
+    }
+
+    #[test]
+    #[should_panic(expected = "BUG: PresentationForest::install called")]
+    fn install_panics_once_the_forest_already_holds_a_presentation() {
+        let mut forest = PresentationForest::single(presentation(1));
+        forest.install(presentation(2));
+    }
+
+    #[test]
+    fn push_for_test_bypasses_the_ratchet() {
+        let mut forest = PresentationForest::single(presentation(1));
+        forest.push_for_test(presentation(2));
+
+        assert_eq!(forest.len(), 2);
+    }
+
+    #[test]
+    fn iter_yields_presentations_in_mount_order() {
+        let mut forest = PresentationForest::single(presentation(1));
+        forest.push_for_test(presentation(2));
+        forest.push_for_test(presentation(3));
+
+        let ids: Vec<_> = forest.iter().map(PresentationState::id).collect();
+        assert_eq!(
+            ids,
+            vec![
+                PresentationId::new_gen(0, NonZeroU32::new(1).expect("nonzero")),
+                PresentationId::new_gen(0, NonZeroU32::new(2).expect("nonzero")),
+                PresentationId::new_gen(0, NonZeroU32::new(3).expect("nonzero")),
+            ],
+            "mount order is insertion order, never re-sorted"
+        );
+    }
+
+    #[test]
+    fn get_and_remove_address_by_exact_presentation_id() {
+        let mut forest = PresentationForest::single(presentation(1));
+        let second = presentation(2);
+        let second_id = second.id();
+        forest.push_for_test(second);
+
+        assert!(forest.get(second_id).is_some());
+        let removed = forest.remove(second_id).expect("present");
+        assert_eq!(removed.id(), second_id);
+        assert!(forest.get(second_id).is_none());
+        assert_eq!(forest.len(), 1);
+    }
+}

--- a/crates/flui-app/src/app/presentation_forest.rs
+++ b/crates/flui-app/src/app/presentation_forest.rs
@@ -102,30 +102,20 @@ impl PresentationForest {
     }
 
     /// Look up a presentation by its exact generational id.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "addressed lookup by id has no production caller until \
-                      a later addressed-routing slice's entry points land"
-        )
-    )]
+    ///
+    /// Production caller: [`super::ui_realm::UiRealm::close_presentation_entered`]'s
+    /// step 2–3 phase resolves the presentation to close through this
+    /// before removing it via [`Self::remove`] below.
     pub(crate) fn get(&self, id: PresentationId) -> Option<&PresentationState> {
         self.presentations.iter().find(|p| p.id() == id)
     }
 
     /// Remove and return the presentation with the given id, if present.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "no production caller until a later addressed-routing \
-                      slice's presentation-close path removes a member from \
-                      a genuine N>1 forest; teardown of the realm's SOLE \
-                      presentation today drops the whole forest instead of \
-                      removing a member from it"
-        )
-    )]
+    ///
+    /// Production caller: [`super::ui_realm::UiRealm::close_presentation_entered`]'s
+    /// steps 4–6 — the only path today that removes a member from a genuine
+    /// `N>1` forest rather than dropping the whole forest at once (the
+    /// realm's own `Drop` still does the latter).
     pub(crate) fn remove(&mut self, id: PresentationId) -> Option<PresentationState> {
         let index = self.presentations.iter().position(|p| p.id() == id)?;
         Some(self.presentations.remove(index))

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -442,29 +442,56 @@ pub(super) enum PlatformToUi {
     Lifecycle(AppLifecycleState),
 }
 
-/// One queued unit of owner-thread work: either a typed cross-thread
-/// [`PlatformToUi`] event, or the co-located frame pump. `Frame` is
-/// deliberately NOT part of the cross-thread vocabulary above — it is
-/// same-thread by construction (the `WrongThread` guard in
-/// [`dispatch_platform_realm`] rejects it from anywhere else) and carries an
-/// owner-local closure, which a cross-thread payload must never do
-/// (ADR-0037 §3 forbids `Box<dyn FnOnce()>` on that boundary). The `Send`
-/// assertion above applies to `PlatformToUi` only; splitting the two types
-/// is what makes that assertion non-vacuous.
+/// One queued unit of owner-thread work: a typed cross-thread
+/// [`PlatformToUi`] event, the co-located frame pump, or a request to close
+/// one presentation out of this realm's forest. `Frame` and
+/// `ClosePresentation` are deliberately NOT part of the cross-thread
+/// vocabulary above — both are same-thread by construction (the
+/// `WrongThread` guard in [`dispatch_platform_realm`] rejects them from
+/// anywhere else); `Frame` carries an owner-local closure, which a
+/// cross-thread payload must never do (ADR-0037 §3 forbids `Box<dyn
+/// FnOnce()>` on that boundary), and `ClosePresentation` carries a plain
+/// `Copy` id specifically so it CAN cross the same `Send` boundary
+/// `PlatformToUi` does if a later slice needs that — nothing about it
+/// requires same-thread delivery the way a closure does.
+///
+/// `ClosePresentation` is handled specially by [`dispatch_platform_realm`]'s
+/// own drain loop, never by [`RealmTask::run`]: closing a presentation needs
+/// `&mut UiRealm` (removing it from the forest), which only exists for the
+/// brief window the realm sits checked out of `APP_RUNTIME` as an owned
+/// local — exactly the window the drain loop already has open, and the
+/// reason this variant exists instead of giving `PresentationForest`
+/// interior mutability to reach the same `&mut` from behind `run`'s shared
+/// `&UiRealm` receiver.
 // `pub(super)` (rather than private) so `AppRuntime`'s `queue` field, defined
 // in the sibling `runtime` module, can name this type.
 #[cfg(not(target_os = "ios"))]
 pub(super) enum RealmTask {
     Event(PlatformToUi),
     Frame(Box<dyn FnOnce(&super::ui_realm::UiRealm)>),
+    ClosePresentation(flui_foundation::PresentationId),
 }
 
 #[cfg(not(target_os = "ios"))]
 impl RealmTask {
+    /// Runs an `Event`/`Frame` task against the realm's shared capabilities.
+    ///
+    /// # Panics
+    /// Panics if called with `Self::ClosePresentation` — that variant never
+    /// reaches this method: [`dispatch_platform_realm`]'s drain loop matches
+    /// it out before calling `run`, since it needs `&mut UiRealm` instead of
+    /// this method's `&UiRealm` receiver. Not reachable from any other
+    /// caller — `run` has exactly one call site.
     fn run(self, realm: &super::ui_realm::UiRealm) {
         match self {
             Self::Event(event) => event.run(realm),
             Self::Frame(run) => run(realm),
+            Self::ClosePresentation(id) => unreachable!(
+                "BUG: RealmTask::ClosePresentation({id:?}) reached RealmTask::run -- \
+                 dispatch_platform_realm's drain loop must match this variant out before \
+                 calling run, so it can call close_presentation_entered with &mut UiRealm \
+                 instead"
+            ),
         }
     }
 }
@@ -1403,6 +1430,49 @@ fn uninstall_platform_realm(realm_id: RealmId) {
     drop(removed);
 }
 
+/// Requests that one presentation be closed and removed from `dispatcher`'s
+/// realm — a single window closing out of a realm that hosts more than one,
+/// without tearing down the realm itself (contrast [`uninstall_platform_realm`],
+/// which removes a whole realm). Request-shaped, like every other realm-map
+/// mutation in this module: this function only enqueues
+/// [`RealmTask::ClosePresentation`] and (if the realm is currently idle)
+/// drives the drain loop that runs it — it never runs the six teardown
+/// steps itself, and never returns anything about their outcome beyond
+/// whether the request was accepted for this dispatcher (see
+/// [`dispatch_platform_realm`]'s own `Err` variants).
+///
+/// The six steps run at Idle inside [`super::ui_realm::UiRealm::close_presentation_entered`],
+/// which only [`dispatch_platform_realm`]'s own drain loop calls, and only
+/// with the realm checked out as an owned local — so a dispose callback the
+/// closed presentation runs mid-teardown sees the exact same
+/// `dispatched_realm_id` TLS state (and therefore the exact same
+/// install/uninstall deferral discipline) any other dispatched frame or
+/// event callback sees. Production contract: async-at-Idle only — a caller
+/// needing the six steps to have actually run before proceeding must drive
+/// the dispatch loop to idle itself (a synchronous bypass would defeat the
+/// whole point of routing this through the dispatch seam).
+///
+/// No production embedder call site yet — no backend currently closes a
+/// single presentation out of a multi-presentation forest (this issue's
+/// later slice adds one); exercised directly by this module's own tests in
+/// the meantime.
+#[cfg(not(target_os = "ios"))]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "design-for-N presentation-close request path; no production embedder call \
+                  site closes one presentation out of a live multi-presentation forest yet -- \
+                  exercised by this module's own tests"
+    )
+)]
+fn close_presentation(
+    dispatcher: RealmDispatcher,
+    id: flui_foundation::PresentationId,
+) -> Result<(), RealmDispatchError> {
+    dispatch_platform_realm(dispatcher, RealmTask::ClosePresentation(id))
+}
+
 #[cfg(not(target_os = "ios"))]
 fn dispatch_platform_realm(
     dispatcher: RealmDispatcher,
@@ -1507,7 +1577,7 @@ fn dispatch_platform_realm(
         state.dispatched_realm_id = Some(realm_id);
         Ok(realm.map(|realm| (realm, first)))
     })?;
-    let Some((realm, first)) = checked_out else {
+    let Some((mut realm, first)) = checked_out else {
         return Ok(());
     };
 
@@ -1516,7 +1586,19 @@ fn dispatch_platform_realm(
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut next = Some(first);
         while let Some(event) = next {
-            realm.enter(|realm| event.run(realm));
+            // `ClosePresentation` is matched out here, before it would
+            // otherwise reach `RealmTask::run`'s `&UiRealm` receiver: closing
+            // a presentation removes it from the forest (`&mut UiRealm`),
+            // which is only available in this exact window -- `realm` sits
+            // here as an owned local, checked out of `APP_RUNTIME` for the
+            // whole dispatched task, so `&mut` falls out naturally instead of
+            // needing interior mutability on the forest itself.
+            match event {
+                RealmTask::ClosePresentation(id) => {
+                    realm.close_presentation_entered(id);
+                }
+                other => realm.enter(|realm| other.run(realm)),
+            }
             next = APP_RUNTIME.with(|slot| {
                 slot.borrow_mut()
                     .realms
@@ -3411,6 +3493,196 @@ mod realm_dispatch_tests {
         scheduler_a.drive_frame(web_time::Instant::now(), || {
             let _ = with_owner_platform(|_owner| ());
         });
+    }
+
+    /// The presentation-close dispatch seam (`close_presentation` ->
+    /// `dispatch_platform_realm` -> the special-cased `RealmTask::
+    /// ClosePresentation` branch -> `UiRealm::close_presentation_entered`)
+    /// runs presentation A's teardown with the exact same
+    /// `dispatched_realm_id` TLS state any other dispatched frame/event
+    /// callback runs under. One dispose hook on A proves both halves of
+    /// that claim:
+    ///
+    /// 1. it can RESOLVE a `GlobalKey` registered in SIBLING presentation
+    ///    B — the whole-frame composite `close_presentation_entered`'s own
+    ///    `self.enter(...)` activates for its step 2–3 phase spans every
+    ///    presentation still in the forest, not just the one being closed
+    ///    (the same fact `whole_frame_event_keeps_realm_global_key_scope_active`
+    ///    proves for an ordinary dispatched frame);
+    /// 2. an `install_realm_alongside` call it makes must DEFER — not
+    ///    apply immediately, not reenter `APP_RUNTIME` — exactly the
+    ///    discipline `frame_callback_opening_a_window_installs_second_realm_without_nested_dispatch`
+    ///    proves for an ordinary dispatched frame callback.
+    ///
+    /// Red-check performed by hand while writing this test (not left in the
+    /// tree): replacing the `close_presentation(dispatcher, a_id)` call
+    /// below with a direct `realm.close_presentation_entered(a_id)` reached
+    /// through a raw `APP_RUNTIME` borrow-and-take (bypassing
+    /// `dispatch_platform_realm` entirely, so `dispatched_realm_id` stays
+    /// `None` for the whole teardown) makes the `install_deferred`
+    /// assertion below fail: with no dispatch in flight,
+    /// `install_realm_alongside` applies the new realm IMMEDIATELY instead
+    /// of deferring, so this test observes it already installed at the
+    /// point it checks — proving the assertion is genuinely pinned to the
+    /// TLS deferral guard, not vacuously green regardless of which path
+    /// teardown takes.
+    #[test]
+    fn dispose_opening_a_window_mid_teardown_defers_and_does_not_reenter() {
+        #[derive(Clone)]
+        struct OpenWindowOnDisposeView {
+            key_in_sibling: flui_view::GlobalKey<()>,
+            new_window: std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
+            resolved_sibling_element: Rc<Cell<Option<flui_foundation::ElementId>>>,
+            install_deferred: Rc<Cell<Option<bool>>>,
+            opened_realm_id: Rc<Cell<Option<flui_foundation::RealmId>>>,
+        }
+
+        struct OpenWindowOnDisposeState {
+            key_in_sibling: flui_view::GlobalKey<()>,
+            new_window: std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
+            resolved_sibling_element: Rc<Cell<Option<flui_foundation::ElementId>>>,
+            install_deferred: Rc<Cell<Option<bool>>>,
+            opened_realm_id: Rc<Cell<Option<flui_foundation::RealmId>>>,
+        }
+
+        impl flui_view::StatefulView for OpenWindowOnDisposeView {
+            type State = OpenWindowOnDisposeState;
+
+            fn create_state(&self) -> Self::State {
+                OpenWindowOnDisposeState {
+                    key_in_sibling: self.key_in_sibling.clone(),
+                    new_window: std::sync::Arc::clone(&self.new_window),
+                    resolved_sibling_element: Rc::clone(&self.resolved_sibling_element),
+                    install_deferred: Rc::clone(&self.install_deferred),
+                    opened_realm_id: Rc::clone(&self.opened_realm_id),
+                }
+            }
+        }
+
+        impl flui_view::ViewState<OpenWindowOnDisposeView> for OpenWindowOnDisposeState {
+            fn build(
+                &self,
+                _view: &OpenWindowOnDisposeView,
+                _ctx: &dyn flui_view::BuildContext,
+            ) -> impl flui_view::IntoView {
+                flui_widgets::SizedBox::new(0.0, 0.0)
+            }
+
+            fn dispose(&mut self) {
+                // (1) Resolve a GlobalKey registered in the SIBLING
+                // presentation B: only possible if the whole-frame composite
+                // is still active for this dispose call, spanning every
+                // OTHER presentation the realm hosts (this presentation
+                // itself, mid-teardown, is deliberately excluded from that
+                // composite -- see `UiRealm::enter_for_close`'s doc).
+                self.resolved_sibling_element
+                    .set(self.key_in_sibling.current_element());
+
+                // (2) Attempt to open a second realm/window mid-teardown.
+                // Production contract: this must defer to loop idle, the
+                // same as any other dispatched callback's install request.
+                // `new_window` was pre-opened from the SAME shared platform
+                // instance realm A's own window came from -- a second,
+                // independently-constructed `HeadlessPlatform` here would
+                // mint an aliasing window id from its own zeroed counter,
+                // which `WindowRegistry` would then read as a collision
+                // against A's window rather than a genuinely distinct one.
+                let new_realm = super::super::ui_realm::UiRealm::for_test();
+                let new_realm_id = new_realm.realm_id();
+                let installed = install_realm_alongside(new_realm, &self.new_window);
+                assert!(
+                    installed.is_ok(),
+                    "install_realm_alongside must defer mid-teardown (Ok, not yet visible), \
+                     never fail"
+                );
+                self.opened_realm_id.set(Some(new_realm_id));
+                let visible_immediately =
+                    APP_RUNTIME.with(|slot| slot.borrow().realms.get(&new_realm_id).is_some());
+                self.install_deferred.set(Some(!visible_immediately));
+            }
+        }
+
+        impl View for OpenWindowOnDisposeView {
+            fn create_element(&self) -> flui_view::element::ElementKind {
+                flui_view::element::ElementKind::stateful(self)
+            }
+        }
+
+        // One shared platform instance for BOTH windows -- see
+        // `install_two_test_realms`'s doc for why two independent
+        // `headless_platform()` calls would risk an aliased window id.
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let window_for_new_realm = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create the second window");
+
+        let mut realm = super::super::ui_realm::UiRealm::for_test();
+        let a_id = realm.presentation_id();
+        let b_id = realm.install_second_presentation_for_test();
+
+        let key_in_sibling = flui_view::GlobalKey::<()>::new();
+        let element_in_sibling = flui_foundation::ElementId::new(1);
+        realm
+            .presentation_widgets_for_test(b_id)
+            .with_build_owner_mut(|owner| {
+                owner.register_global_key(key_in_sibling.id(), element_in_sibling);
+            });
+
+        let resolved_sibling_element = Rc::new(Cell::new(None));
+        let install_deferred = Rc::new(Cell::new(None));
+        let opened_realm_id = Rc::new(Cell::new(None));
+        let probe = OpenWindowOnDisposeView {
+            key_in_sibling,
+            new_window: window_for_new_realm,
+            resolved_sibling_element: Rc::clone(&resolved_sibling_element),
+            install_deferred: Rc::clone(&install_deferred),
+            opened_realm_id: Rc::clone(&opened_realm_id),
+        };
+        realm
+            .enter(|realm| realm.attach_root_widget(&probe))
+            .expect("A mounts the probe");
+        // `attach_root_widget` only SCHEDULES the initial build; the probe's
+        // concrete element (and therefore its `State`) is not actually
+        // constructed until a frame runs it, exactly the same reason
+        // `dispose_during_teardown_cannot_reach_sibling_or_dead_services`
+        // and `closing_presentation_a_leaves_sibling_layer_tree_identical`
+        // both draw a frame between mounting and closing.
+        let _ = realm.draw_frame(flui_rendering::constraints::BoxConstraints::tight(
+            flui_types::Size::new(
+                flui_types::geometry::px(20.0),
+                flui_types::geometry::px(20.0),
+            ),
+        ));
+
+        let dispatcher = install_platform_realm(realm, &window_a);
+
+        close_presentation(dispatcher, a_id).expect("A closes through the real dispatch seam");
+
+        assert_eq!(
+            resolved_sibling_element.get(),
+            Some(element_in_sibling),
+            "A's dispose hook must resolve B's GlobalKey through the whole-frame composite \
+             active during close_presentation_entered's step 2-3 phase"
+        );
+        assert_eq!(
+            install_deferred.get(),
+            Some(true),
+            "A's dispose-time install_realm_alongside request must defer -- not yet visible \
+             in the registry -- while A's own realm is still checked out for this dispatch"
+        );
+
+        let opened_realm_id = opened_realm_id
+            .get()
+            .expect("dispose must have attempted the install");
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&opened_realm_id).is_some()),
+            "the deferred install must land once A's close dispatch restores"
+        );
+
+        teardown_platform_realm();
     }
 }
 

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -1595,7 +1595,70 @@ fn dispatch_platform_realm(
             // needing interior mutability on the forest itself.
             match event {
                 RealmTask::ClosePresentation(id) => {
-                    realm.close_presentation_entered(id);
+                    if realm.is_sole_presentation(id) {
+                        // Closing the realm's ONLY presentation IS closing
+                        // the realm -- routing it through
+                        // close_presentation_entered would leave an empty
+                        // forest behind (every other method on this realm,
+                        // starting with `primary()`, assumes one always
+                        // exists). Request a full realm uninstall through
+                        // the SAME deferral machinery every other
+                        // realm-map mutation already uses:
+                        // `dispatched_realm_id` is `Some` for this whole
+                        // checkout, so this defers to `dispatch_platform_
+                        // realm`'s own tail (below), which runs
+                        // `apply_uninstall` only after `realm` is restored
+                        // to its slot -- `apply_uninstall` already removes
+                        // every one of this realm's `WindowRegistry`
+                        // entries before dropping the `RealmSlot` (see its
+                        // own doc), so step 1 is covered by the SAME path
+                        // a whole-realm close always used.
+                        let displaced = APP_RUNTIME
+                            .with(|slot| slot.borrow_mut().request_realm_uninstall(realm_id));
+                        drop(displaced);
+                    } else {
+                        // Step 1: unregister exactly THIS presentation's own
+                        // window mapping -- never a sibling's, and never
+                        // every window this realm owns (`WindowRegistry::
+                        // remove_realm` would be wrong here). `UiRealm`
+                        // itself has no access to the registry (AppRuntime
+                        // is its single authority, ADR-0037 §2), so this
+                        // runs here, in the one caller that does, before
+                        // handing off to close_presentation_entered's
+                        // steps 2-6. Without this, a stale platform event
+                        // for the closed presentation's original window
+                        // would still resolve to its now-dead
+                        // PresentationId instead of being refused.
+                        let address = flui_foundation::PresentationAddress {
+                            realm_id,
+                            presentation_id: id,
+                        };
+                        let unregistered = APP_RUNTIME
+                            .with(|slot| slot.borrow_mut().registry.remove_presentation(address));
+                        drop(unregistered);
+                        realm.close_presentation_entered(id);
+                        // Re-stamp this realm's tracked routable address
+                        // (`RealmSlot::address`) to the new primary that
+                        // survives the close. Without this, a dispatcher a
+                        // caller minted while `id` was still live would keep
+                        // comparing equal against the slot's now-stale
+                        // `presentation_id` at the top of this very
+                        // function, and a task dispatched through it would
+                        // run against `self.presentations.primary()` --
+                        // which is now the SIBLING, not the closed
+                        // presentation the caller thinks it addressed.
+                        // Re-stamping makes that exact dispatcher fail the
+                        // `StalePresentation` check instead, through the
+                        // SAME comparison every other stale-dispatcher case
+                        // already goes through -- no new gating mechanism,
+                        // just keeping this one fact current.
+                        let new_primary_id = realm.presentation_id();
+                        APP_RUNTIME.with(|slot| {
+                            if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&realm_id) {
+                                realm_slot.address.presentation_id = new_primary_id;
+                            }
+                        });
+                    }
                 }
                 other => realm.enter(|realm| other.run(realm)),
             }
@@ -3682,6 +3745,125 @@ mod realm_dispatch_tests {
             "the deferred install must land once A's close dispatch restores"
         );
 
+        // No `teardown_platform_realm()` here, deliberately -- same reason
+        // as `closing_a_presentation_unregisters_its_window_mapping`: this
+        // test's own `install_second_presentation_for_test` fixture bypasses
+        // the production ratchet to give B no window mapping of its own, so
+        // after A closes and the surviving realm's tracked address re-stamps
+        // to B, teardown's own self-check (every live realm's tracked
+        // address must resolve to at least one registered window) no
+        // longer holds -- a still-open design-for-N gap, not something this
+        // test can paper over. Each nextest test runs in its own process,
+        // so skipping teardown here leaks nothing another test could
+        // observe.
+    }
+
+    /// Closing presentation A (a sibling, B, stays open) must unregister
+    /// EXACTLY A's own window mapping -- and a caller still holding a
+    /// `RealmDispatcher` minted while A was live must be refused, never
+    /// silently delivered to B (the surviving primary) instead. Before the
+    /// `ClosePresentation` handling did both the window-registry removal
+    /// AND the `RealmSlot::address` re-stamp, a stale dispatcher would still
+    /// compare equal at the top of `dispatch_platform_realm` (the slot's
+    /// tracked `presentation_id` was never updated past A's original
+    /// install-time value) and the task would run against `self.
+    /// presentations.primary()` -- B, after A's removal shifts it into that
+    /// slot -- exactly the sibling-reach bug this test guards.
+    #[test]
+    fn closing_a_presentation_unregisters_its_window_mapping() {
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+
+        let mut realm = super::super::ui_realm::UiRealm::for_test();
+        let a_id = realm.presentation_id();
+        let _b_id = realm.install_second_presentation_for_test();
+
+        let dispatcher = install_platform_realm(realm, &window_a);
+        let realm_id = dispatcher.address.realm_id;
+
+        assert_eq!(
+            APP_RUNTIME.with(|slot| slot.borrow().registry.resolve(window_a.id())),
+            Some(flui_foundation::PresentationAddress {
+                realm_id,
+                presentation_id: a_id,
+            }),
+            "precondition: A's window starts mapped to A's own address"
+        );
+
+        close_presentation(dispatcher, a_id).expect("A closes through the real dispatch seam");
+
+        assert_eq!(
+            APP_RUNTIME.with(|slot| slot.borrow().registry.resolve(window_a.id())),
+            None,
+            "closing A must unregister its own window mapping -- leaving it mapped would let \
+             a stale platform event for that exact window keep resolving to A's now-dead \
+             PresentationId"
+        );
+
+        let delivered = Rc::new(Cell::new(false));
+        let delivered_in_task = Rc::clone(&delivered);
+        let result = dispatch_platform_realm(
+            dispatcher,
+            RealmTask::Frame(Box::new(move |_realm| {
+                delivered_in_task.set(true);
+            })),
+        );
+        assert!(
+            matches!(result, Err(RealmDispatchError::StalePresentation)),
+            "a dispatcher minted for the now-closed presentation must be refused as stale, \
+             got {result:?}"
+        );
+        assert!(
+            !delivered.get(),
+            "the stale task must never run -- delivering it would land on B (the surviving \
+             primary), exactly the sibling-reach bug this test guards"
+        );
+
+        // No `teardown_platform_realm()` here, deliberately: this test's own
+        // fixture (`install_second_presentation_for_test`) bypasses the
+        // production ratchet to give B no window mapping of its own -- the
+        // real, still-open design-for-N gap this whole test exists to probe
+        // one corner of, not something this test can paper over. Calling
+        // teardown would trip ITS OWN debug-only self-check (every live
+        // realm's tracked address must resolve to at least one registered
+        // window), which no longer holds once B, unregistered, becomes the
+        // realm's tracked primary. Each nextest test runs in its own
+        // process (see this crate's own `AGENTS.md`), so skipping teardown
+        // here leaks nothing another test could observe -- the process
+        // exit itself drops `APP_RUNTIME`, running `UiRealm::Drop`'s
+        // best-effort close loop for B as the natural fallback.
+    }
+
+    /// Closing a realm's SOLE presentation must not leave a live realm with
+    /// an empty `PresentationForest` (the next `primary()` call would panic
+    /// `"BUG: PresentationForest is never empty"`). `RealmTask::
+    /// ClosePresentation`'s handling routes this case into a full realm
+    /// uninstall instead of ever calling `close_presentation_entered` --
+    /// proven here by asserting the WHOLE realm disappears from the
+    /// registry, not just the one presentation.
+    #[test]
+    fn closing_the_sole_presentation_uninstalls_the_whole_realm() {
+        let dispatcher = install_test_realm();
+        let realm_id = dispatcher.address.realm_id;
+        let a_id = dispatcher.address.presentation_id;
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_id).is_some()),
+            "precondition: the realm is installed before closing its sole presentation"
+        );
+
+        close_presentation(dispatcher, a_id).expect("the close request is accepted");
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_id).is_none()),
+            "closing the realm's only presentation must uninstall the WHOLE realm -- a \
+             live realm with an empty forest is not a reachable state this codebase permits"
+        );
+
+        // Harmless no-op cleanup (the realm is already gone) -- matches
+        // every other test in this module for the same TLS-state hygiene.
         teardown_platform_realm();
     }
 }

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -445,15 +445,26 @@ pub(super) enum PlatformToUi {
 /// One queued unit of owner-thread work: a typed cross-thread
 /// [`PlatformToUi`] event, the co-located frame pump, or a request to close
 /// one presentation out of this realm's forest. `Frame` and
-/// `ClosePresentation` are deliberately NOT part of the cross-thread
-/// vocabulary above — both are same-thread by construction (the
-/// `WrongThread` guard in [`dispatch_platform_realm`] rejects them from
-/// anywhere else); `Frame` carries an owner-local closure, which a
-/// cross-thread payload must never do (ADR-0037 §3 forbids `Box<dyn
-/// FnOnce()>` on that boundary), and `ClosePresentation` carries a plain
-/// `Copy` id specifically so it CAN cross the same `Send` boundary
-/// `PlatformToUi` does if a later slice needs that — nothing about it
-/// requires same-thread delivery the way a closure does.
+/// `ClosePresentation` are both deliberately KEPT OUT of the cross-thread
+/// [`PlatformToUi`] vocabulary above, but for two different reasons — and
+/// this enum, `RealmTask` itself, never crosses a thread either way: it is
+/// owner-thread-only end to end (`AppRuntime`'s per-realm queue lives in
+/// owner-thread-only `RealmSlot` storage, drained only from
+/// [`dispatch_platform_realm`] on that same thread), the same as it was
+/// before `ClosePresentation` existed — `Frame`'s `Box<dyn FnOnce(&UiRealm)>`
+/// alone already makes the enum `!Send` in the general case, so nothing
+/// about adding `ClosePresentation` changes that.
+///
+/// `Frame` carries an owner-local closure, which a cross-thread payload must
+/// never do (ADR-0037 §3 forbids `Box<dyn FnOnce()>` on that boundary) — its
+/// exclusion is load-bearing today. `ClosePresentation`'s payload alone
+/// (`PresentationId`, a plain `Copy` id) happens to satisfy `Send` in
+/// isolation, same as [`PlatformToUi`]'s own fields do — but that is a
+/// property of the ID type, not a claim about this enum or this variant:
+/// `ClosePresentation` is excluded from `PlatformToUi` because
+/// [`dispatch_platform_realm`]'s own drain loop must special-case it (see
+/// below), not because its payload could not cross a thread if some later
+/// slice needed that.
 ///
 /// `ClosePresentation` is handled specially by [`dispatch_platform_realm`]'s
 /// own drain loop, never by [`RealmTask::run`]: closing a presentation needs
@@ -1636,28 +1647,42 @@ fn dispatch_platform_realm(
                         let unregistered = APP_RUNTIME
                             .with(|slot| slot.borrow_mut().registry.remove_presentation(address));
                         drop(unregistered);
-                        realm.close_presentation_entered(id);
+
                         // Re-stamp this realm's tracked routable address
-                        // (`RealmSlot::address`) to the new primary that
-                        // survives the close. Without this, a dispatcher a
-                        // caller minted while `id` was still live would keep
-                        // comparing equal against the slot's now-stale
-                        // `presentation_id` at the top of this very
-                        // function, and a task dispatched through it would
-                        // run against `self.presentations.primary()` --
-                        // which is now the SIBLING, not the closed
-                        // presentation the caller thinks it addressed.
-                        // Re-stamping makes that exact dispatcher fail the
-                        // `StalePresentation` check instead, through the
-                        // SAME comparison every other stale-dispatcher case
-                        // already goes through -- no new gating mechanism,
-                        // just keeping this one fact current.
-                        let new_primary_id = realm.presentation_id();
-                        APP_RUNTIME.with(|slot| {
-                            if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&realm_id) {
-                                realm_slot.address.presentation_id = new_primary_id;
-                            }
-                        });
+                        // (`RealmSlot::address`) to the surviving primary
+                        // BEFORE running `id`'s own teardown/dispose hooks
+                        // -- not after. `close_presentation_entered`'s step
+                        // 2-3 (below) can run a dispose hook that re-enters
+                        // this exact function with a dispatcher still
+                        // bearing `id`; ordering the re-stamp first means
+                        // that reentrant dispatch's `StalePresentation`
+                        // check (at the top of this function) already
+                        // compares against the NEW primary and correctly
+                        // refuses it right there. Re-stamping AFTER
+                        // disposal instead would leave a window where that
+                        // same reentrant dispatch still compares equal
+                        // (both sides still `id`), gets ACCEPTED by the
+                        // stale check, and is merely enqueued behind the
+                        // same-realm reentrancy guard -- only to run a
+                        // moment later, in this very drain loop, against
+                        // whatever survives the close: silently
+                        // misaddressed rather than refused. See
+                        // `UiRealm::primary_id_excluding`'s own doc for why
+                        // this is computable before the removal happens.
+                        // `None` is unreachable here: this branch runs only
+                        // when `is_sole_presentation(id)` was `false` above,
+                        // so at least one other presentation always exists.
+                        if let Some(surviving_primary_id) = realm.primary_id_excluding(id) {
+                            APP_RUNTIME.with(|slot| {
+                                if let Some(realm_slot) =
+                                    slot.borrow_mut().realms.get_mut(&realm_id)
+                                {
+                                    realm_slot.address.presentation_id = surviving_primary_id;
+                                }
+                            });
+                        }
+
+                        realm.close_presentation_entered(id);
                     }
                 }
                 other => realm.enter(|realm| other.run(realm)),
@@ -3834,6 +3859,133 @@ mod realm_dispatch_tests {
         // here leaks nothing another test could observe -- the process
         // exit itself drops `APP_RUNTIME`, running `UiRealm::Drop`'s
         // best-effort close loop for B as the natural fallback.
+    }
+
+    /// A dispose hook that re-enters `dispatch_platform_realm` DURING the
+    /// very close it is being disposed by -- using the dying presentation's
+    /// OWN dispatcher -- must be refused as stale
+    /// (`RealmDispatchError::StalePresentation`), never silently ACCEPTED
+    /// and enqueued to run later against whatever survives the close.
+    ///
+    /// Ordering-critical: `RealmSlot::address` must re-stamp to the
+    /// surviving primary BEFORE this presentation's own dispose hooks run
+    /// (`close_presentation_entered`'s step 2-3), not after. Re-stamping
+    /// only after disposal would leave a window where a dispose-time
+    /// reentrant dispatch bearing `id` still compares EQUAL against the
+    /// not-yet-updated address, passes the `StalePresentation` check, and
+    /// gets enqueued behind the same-realm reentrancy guard (`realm_slot.
+    /// draining` is `true` for the whole checkout) instead of refused --
+    /// only to run a moment later, in this very drain loop, against
+    /// whichever presentation survives: a task genuinely executing against
+    /// the wrong presentation, not merely an error a caller has to notice.
+    #[test]
+    fn dispose_time_reentrant_dispatch_with_the_dying_presentations_own_dispatcher_is_refused() {
+        #[derive(Clone)]
+        struct ReenterOnDisposeView {
+            dispatcher: Rc<Cell<Option<RealmDispatcher>>>,
+            reentrant_result: Rc<Cell<Option<Result<(), RealmDispatchError>>>>,
+            reentrant_task_ran: Rc<Cell<bool>>,
+        }
+
+        struct ReenterOnDisposeState {
+            dispatcher: Rc<Cell<Option<RealmDispatcher>>>,
+            reentrant_result: Rc<Cell<Option<Result<(), RealmDispatchError>>>>,
+            reentrant_task_ran: Rc<Cell<bool>>,
+        }
+
+        impl flui_view::StatefulView for ReenterOnDisposeView {
+            type State = ReenterOnDisposeState;
+
+            fn create_state(&self) -> Self::State {
+                ReenterOnDisposeState {
+                    dispatcher: Rc::clone(&self.dispatcher),
+                    reentrant_result: Rc::clone(&self.reentrant_result),
+                    reentrant_task_ran: Rc::clone(&self.reentrant_task_ran),
+                }
+            }
+        }
+
+        impl flui_view::ViewState<ReenterOnDisposeView> for ReenterOnDisposeState {
+            fn build(
+                &self,
+                _view: &ReenterOnDisposeView,
+                _ctx: &dyn flui_view::BuildContext,
+            ) -> impl flui_view::IntoView {
+                flui_widgets::SizedBox::new(0.0, 0.0)
+            }
+
+            fn dispose(&mut self) {
+                let dispatcher = self
+                    .dispatcher
+                    .get()
+                    .expect("dispatcher stashed before A's close was requested");
+                let ran = Rc::clone(&self.reentrant_task_ran);
+                let result = dispatch_platform_realm(
+                    dispatcher,
+                    RealmTask::Frame(Box::new(move |_realm| {
+                        ran.set(true);
+                    })),
+                );
+                self.reentrant_result.set(Some(result));
+            }
+        }
+
+        impl View for ReenterOnDisposeView {
+            fn create_element(&self) -> flui_view::element::ElementKind {
+                flui_view::element::ElementKind::stateful(self)
+            }
+        }
+
+        let mut realm = super::super::ui_realm::UiRealm::for_test();
+        let a_id = realm.presentation_id();
+        let _b_id = realm.install_second_presentation_for_test();
+
+        let dispatcher_slot = Rc::new(Cell::new(None));
+        let reentrant_result = Rc::new(Cell::new(None));
+        let reentrant_task_ran = Rc::new(Cell::new(false));
+        let probe = ReenterOnDisposeView {
+            dispatcher: Rc::clone(&dispatcher_slot),
+            reentrant_result: Rc::clone(&reentrant_result),
+            reentrant_task_ran: Rc::clone(&reentrant_task_ran),
+        };
+        realm
+            .enter(|realm| realm.attach_root_widget(&probe))
+            .expect("A mounts the probe");
+        // `attach_root_widget` only SCHEDULES the initial build -- see
+        // `dispose_opening_a_window_mid_teardown_defers_and_does_not_reenter`'s
+        // own comment for why a real frame must run before the probe's
+        // `State`, and therefore its `dispose()`, actually exists.
+        let _ = realm.draw_frame(flui_rendering::constraints::BoxConstraints::tight(
+            flui_types::Size::new(
+                flui_types::geometry::px(20.0),
+                flui_types::geometry::px(20.0),
+            ),
+        ));
+
+        let dispatcher = install_platform_realm(realm, &test_window());
+        dispatcher_slot.set(Some(dispatcher));
+
+        close_presentation(dispatcher, a_id).expect("A closes through the real dispatch seam");
+
+        assert!(
+            matches!(
+                reentrant_result.get(),
+                Some(Err(RealmDispatchError::StalePresentation))
+            ),
+            "a dispose-time re-dispatch bearing the dying presentation's OWN dispatcher must \
+             be refused as stale, got {:?}",
+            reentrant_result.get()
+        );
+        assert!(
+            !reentrant_task_ran.get(),
+            "the reentrant task must never run -- accepting it (even merely queued for later) \
+             means it eventually executes against whatever survives the close, misaddressed \
+             rather than refused"
+        );
+
+        // No `teardown_platform_realm()` here either, for the identical
+        // reason `closing_a_presentation_unregisters_its_window_mapping`
+        // skips it -- see that test's own closing comment.
     }
 
     /// Closing a realm's SOLE presentation must not leave a live realm with

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -864,14 +864,13 @@ impl AppRuntime {
     /// whatever `APP_RUNTIME` borrow is live — the same discipline
     /// `install_platform_realm`/`teardown_platform_realm` already follow for
     /// every other realm-owning drop in this module.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "uninstall_platform_realm is design-for-N mechanism with no production \
-                      embedder call site yet -- exercised by this crate's own tests"
-        )
-    )]
+    ///
+    /// Production caller: `dispatch_platform_realm`'s `RealmTask::
+    /// ClosePresentation` handling (`runner.rs`), when the presentation
+    /// being closed is the realm's only one — closing a realm's sole
+    /// presentation IS closing the realm, so that dispatch handling routes
+    /// here instead of ever leaving a live realm with an empty
+    /// `PresentationForest`.
     pub(super) fn request_realm_uninstall(&mut self, id: RealmId) -> Option<RealmSlot> {
         if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
             self.pending_realm_mutations

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -786,12 +786,17 @@ impl AppRuntime {
     }
 
     /// The un-deferred application of an `Uninstall` mutation.
+    ///
+    /// Registry removal runs first, matching `window_registry.rs`'s
+    /// module-doc invariant and `teardown_platform_realm`'s own ordering:
+    /// stop new routing before the returned `RealmSlot`'s queued
+    /// old-generation events are ever dropped (whenever the caller
+    /// eventually drops it — see this module's TLS-borrow-reentrancy
+    /// discipline for why that drop happens outside this function, not
+    /// inside it).
     fn apply_uninstall(&mut self, id: RealmId) -> Option<RealmSlot> {
-        let removed = self.realms.remove(&id);
-        if removed.is_some() {
-            self.registry.remove_realm(id);
-        }
-        removed
+        self.registry.remove_realm(id);
+        self.realms.remove(&id)
     }
 
     /// Requests installing a newly-constructed realm, registering `window`'s

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -802,6 +802,53 @@ impl UiRealm {
         self.presentations.len()
     }
 
+    /// This realm's `WidgetsBinding` for the presentation named `id` — for
+    /// the isolation test suite, which uses it to register a `GlobalKey`
+    /// directly into a NON-primary presentation without going through
+    /// [`Self::enter`] (registration itself needs no active composite; only
+    /// resolution via [`flui_view::GlobalKey::current_element`] does).
+    /// `pub(crate)` for the same cross-module reason as
+    /// [`Self::install_second_presentation_for_test`] above.
+    #[cfg(test)]
+    pub(crate) fn presentation_widgets_for_test(&self, id: PresentationId) -> &WidgetsBinding {
+        self.presentations
+            .get(id)
+            .expect("BUG: presentation_widgets_for_test called with an unknown id")
+            .widgets()
+    }
+
+    /// Assemble and install a second presentation sharing this realm's exact
+    /// `GlobalKeyScope` and realm-level dispatch handles.
+    ///
+    /// Bypasses `PresentationForest`'s production ratchet
+    /// (`PresentationForest::push_for_test`) deliberately — the
+    /// isolation-suite seam for exercising a genuine multi-presentation
+    /// realm ahead of the addressed routing that makes doing so safe in
+    /// production. `pub(crate)` (rather than confined to this module's own
+    /// `mod tests`) so `runner.rs`'s dispatch-seam tests can build the same
+    /// two-presentation fixture their real dispatch machinery drives.
+    #[cfg(test)]
+    pub(crate) fn install_second_presentation_for_test(&mut self) -> PresentationId {
+        let (_, presentation_id) = super::runtime::next_identity();
+        let pipeline = PipelineCell::new(PipelineOwner::new());
+        let window = super::presentation::test_platform_window(None);
+        let presentation = PresentationState::new(
+            presentation_id,
+            pipeline,
+            window,
+            RealmCapabilities {
+                global_key_scope: self.global_key_scope().clone(),
+                async_driver: self.scheduler.async_driver().clone(),
+                post_frame_handle: self.local_post_frame.post_frame_handle(),
+                interaction_dispatch_handle: self.interaction_lane.dispatch_handle(),
+                scheduler: &self.scheduler,
+                wake: Arc::clone(&self.wake),
+            },
+        );
+        self.presentations.push_for_test(presentation);
+        presentation_id
+    }
+
     /// This realm's own scheduler — the strong root. `runner.rs`'s
     /// realm-scoped lifecycle sites (`emit_lifecycle_transition`, the
     /// per-backend frame pumps) read through here instead of a process-global
@@ -849,6 +896,45 @@ impl UiRealm {
             self.interaction_lane.enter(|| {
                 let composite = GlobalKeyRegistryComposite::assemble(
                     self.presentations.iter().map(PresentationState::widgets),
+                );
+                composite.enter(|| f(self))
+            })
+        })
+    }
+
+    /// [`Self::enter`], but the composite excludes presentation `closing`.
+    ///
+    /// Used ONLY by [`Self::close_presentation_entered`]'s step 2–3 phase.
+    /// `PresentationState::close`'s final step (`detach_root_widget`) holds
+    /// `closing`'s own `WidgetsBindingInner` write lock for the entire
+    /// recursive subtree removal — the exclusive access that walk needs to
+    /// unmount every descendant. `GlobalKeyRegistryComposite`'s lookup tries
+    /// each member in insertion order regardless of which key is being
+    /// resolved (`build_composite`'s `for` loop runs until one member's
+    /// `lookup_element` returns `Some`, trying every earlier member first),
+    /// so if `closing` were composed in, a dispose hook's `GlobalKey::
+    /// current_element()` call — for ANY key, even one belonging to a
+    /// different presentation entirely — would have `closing`'s own lookup
+    /// closure try to re-acquire a read lock on the exact `RwLock` this call
+    /// already holds for writing, on the same thread: an unconditional
+    /// self-deadlock (`parking_lot::RwLock` is not reentrant), not a race.
+    /// Caught by this issue's own red-exploit test
+    /// (`dispose_opening_a_window_mid_teardown_defers_and_does_not_reenter`
+    /// in `runner.rs`, which hung before this exclusion existed).
+    ///
+    /// Excluding `closing` costs nothing real: every OTHER presentation
+    /// still resolves normally, and querying a presentation's OWN GlobalKey
+    /// while that exact presentation's registry is mid-teardown has no
+    /// principled answer anyway — the key is about to be unregistered by
+    /// the same call regardless of what a lookup returns for it right now.
+    fn enter_for_close<R>(&self, closing: PresentationId, f: impl FnOnce(&Self) -> R) -> R {
+        self.local_post_frame.enter(|| {
+            self.interaction_lane.enter(|| {
+                let composite = GlobalKeyRegistryComposite::assemble(
+                    self.presentations
+                        .iter()
+                        .filter(|presentation| presentation.id() != closing)
+                        .map(PresentationState::widgets),
                 );
                 composite.enter(|| f(self))
             })
@@ -1827,11 +1913,20 @@ impl UiRealm {
 
     /// Close and remove exactly one presentation from this realm's forest.
     ///
-    /// Must run at Idle, outside the dispatched-scheduler gate — the same
-    /// discipline every other realm-map mutation follows; callers reach this
-    /// only from an idle-only teardown path, never from inside a frame
-    /// transaction. A no-op (returns `false`) if `id` does not name a
-    /// presentation this realm currently hosts.
+    /// Called from `runner.rs`'s `dispatch_platform_realm` loop, which
+    /// special-cases `RealmTask::ClosePresentation` to call this with
+    /// `&mut self` directly (the realm sits checked out of `AppRuntime`'s
+    /// registry as an owned local at that point, so `&mut` is naturally
+    /// available — no other caller reaches this method). That same
+    /// dispatch has ALREADY set `dispatched_realm_id` for the whole
+    /// checkout, so a dispose callback this method's own step 3 runs is
+    /// covered by the identical TLS deferral guard every other realm-map
+    /// mutation already respects: one deferral authority, not a second one
+    /// to keep in sync with it. See `runner.rs::close_presentation` for the
+    /// request-shaped public entry point (`enqueue + wake`) that gets here.
+    ///
+    /// A no-op (returns `false`) if `id` does not name a presentation this
+    /// realm currently hosts.
     ///
     /// # Contract — six steps, in order
     ///
@@ -1846,13 +1941,22 @@ impl UiRealm {
     /// 2. IME detach + focus deactivate — [`PresentationState::close`]'s
     ///    first half.
     /// 3. `detach_root_widget` through this exact presentation's own
-    ///    `WidgetsBinding` — [`PresentationState::close`]'s second half.
-    ///    Every `State::dispose()` a descendant runs here still has its
-    ///    capabilities installed (nothing about the realm's shared dispatch
-    ///    handles has been touched), and routes only within THIS
-    ///    presentation's own tree: `RebuildHandle`/`ExternalBuildScheduler`
-    ///    are minted one-per-owner and never shared, so a dispose hook has
-    ///    no path to a sibling presentation's inbox even if it tries (see
+    ///    `WidgetsBinding` — [`PresentationState::close`]'s second half —
+    ///    run inside [`Self::enter_for_close`], so a `State::dispose()` a
+    ///    descendant runs here gets the SAME realm-shared capabilities
+    ///    (post-frame/interaction handles, TLS deferral) any other
+    ///    frame/lifecycle callback gets, and can resolve a `GlobalKey`
+    ///    living in any OTHER presentation this realm hosts. It cannot
+    ///    resolve one of its OWN keys through the registry mid-teardown —
+    ///    `enter_for_close` deliberately excludes `id` itself from the
+    ///    composite it assembles; see that method's own doc for the
+    ///    self-deadlock excluding it avoids. An install/uninstall request a
+    ///    dispose hook makes here defers through the dispatched-path TLS
+    ///    guard described above. Any BUILD SCHEDULING it does still routes
+    ///    only within THIS presentation's own tree:
+    ///    `RebuildHandle`/`ExternalBuildScheduler` are minted one-per-owner
+    ///    and never shared, so a dispose hook has no path to a sibling
+    ///    presentation's build inbox even if it tries (see
     ///    `dispose_during_teardown_cannot_reach_sibling_or_dead_services`).
     /// 4. **Async-task disposition:** the realm-level `AsyncDriver` is not
     ///    told about this closure — an in-flight task this presentation
@@ -1867,27 +1971,48 @@ impl UiRealm {
     ///    own `Drop`, once step 6 drops the last reference to it.
     /// 6. The removed `PresentationState` — and with it its `WidgetsBinding`
     ///    (whose drop triggers step 5), `RenderingFlutterBinding`, and every
-    ///    other owned resource — drops at the end of this function.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "no production caller until a later addressed-routing \
-                      slice's presentation-close path removes a member from \
-                      a genuine N>1 forest; today's sole caller (AppRuntime's \
-                      realm teardown) closes the whole realm, which drops \
-                      every presentation through UiRealm::Drop instead of \
-                      calling this method"
-        )
-    )]
-    pub(crate) fn close_presentation(&mut self, id: PresentationId) -> bool {
-        let Some(presentation) = self.presentations.remove(id) else {
+    ///    other owned resource — drops after [`Self::enter_for_close`]
+    ///    returns.
+    ///
+    /// # Why this is two calls, not one `&mut`-threaded closure
+    ///
+    /// [`Self::enter_for_close`] hands its closure `&Self` (shared) — every
+    /// existing caller only ever needed read access to the realm for the
+    /// duration of a frame/lifecycle callback, so it was never shaped to
+    /// also hand out `&mut`. Steps 2–3 only need `&PresentationState`
+    /// (`PresentationState::close` takes `&self`), so they run inside one
+    /// `self.enter_for_close(...)` call. Steps 4–6 (the actual `Vec`
+    /// removal + drop) need `&mut self.presentations`, which happens in a
+    /// SEPARATE, sequential statement after that call returns — not nested
+    /// inside it, so there is no borrow conflict and no need to reshape
+    /// `enter_for_close` itself or give `PresentationForest` interior
+    /// mutability.
+    pub(crate) fn close_presentation_entered(&mut self, id: PresentationId) -> bool {
+        let existed = self.enter_for_close(id, |realm| {
+            let Some(presentation) = realm.presentations.get(id) else {
+                return false;
+            };
+            // Steps 2 + 3, composite (minus `id` itself) + capabilities active.
+            presentation.close();
+            true
+        });
+        if !existed {
             return false;
-        };
-        // Steps 2 + 3.
-        presentation.close();
-        // Steps 5 + 6: dropping `presentation` here (end of scope) is both
-        // the reclaim trigger and the disposal itself.
+        }
+        // Steps 4-6: `self.enter_for_close(...)` above has already returned,
+        // so this is a plain, non-nested `&mut self.presentations` access.
+        // Dropping `removed` here (end of statement) is both the
+        // `GlobalKeyScope` reclaim trigger (step 5, via `BuildOwner::Drop`)
+        // and the disposal itself (step 6) — no active registry needed for
+        // either, since `GlobalKeyScope::reclaim_owner` is a plain
+        // data-structure operation.
+        let removed = self.presentations.remove(id);
+        debug_assert!(
+            removed.is_some(),
+            "BUG: presentation existed a moment ago (checked via self.enter_for_close above) \
+             and nothing between here and there could have removed it -- \
+             enter_for_close's closure only reads the forest"
+        );
         true
     }
 }
@@ -1967,35 +2092,6 @@ mod tests {
             1.0,
             Arc::new(AtomicBool::new(false)),
         )
-    }
-
-    /// Assemble and install a second presentation sharing `realm`'s exact
-    /// `GlobalKeyScope` and realm-level dispatch handles.
-    ///
-    /// Bypasses `PresentationForest`'s production ratchet
-    /// (`PresentationForest::push_for_test`) deliberately — the
-    /// isolation-suite seam for exercising a genuine multi-presentation
-    /// realm ahead of the addressed routing that makes doing so safe in
-    /// production.
-    fn install_second_presentation_for_test(realm: &mut UiRealm) -> PresentationId {
-        let (_, presentation_id) = crate::app::runtime::next_identity();
-        let pipeline = PipelineCell::new(PipelineOwner::new());
-        let window = crate::app::presentation::test_platform_window(None);
-        let presentation = PresentationState::new(
-            presentation_id,
-            pipeline,
-            window,
-            RealmCapabilities {
-                global_key_scope: realm.global_key_scope().clone(),
-                async_driver: realm.scheduler.async_driver().clone(),
-                post_frame_handle: realm.local_post_frame.post_frame_handle(),
-                interaction_dispatch_handle: realm.interaction_lane.dispatch_handle(),
-                scheduler: &realm.scheduler,
-                wake: Arc::clone(&realm.wake),
-            },
-        );
-        realm.presentations.push_for_test(presentation);
-        presentation_id
     }
 
     #[test]
@@ -4712,7 +4808,7 @@ mod tests {
             let mut realm = UiRealm::for_test();
             assert_eq!(realm.presentation_count(), 1);
 
-            install_second_presentation_for_test(&mut realm);
+            realm.install_second_presentation_for_test();
 
             assert_eq!(
                 realm.presentation_count(),
@@ -4729,7 +4825,7 @@ mod tests {
         #[test]
         fn composite_registry_resolves_keys_registered_in_either_presentation() {
             let mut realm = UiRealm::for_test();
-            let second_id = install_second_presentation_for_test(&mut realm);
+            let second_id = realm.install_second_presentation_for_test();
 
             let key_in_primary = flui_view::GlobalKey::<()>::new();
             let element_in_primary = flui_foundation::ElementId::new(1);
@@ -4775,7 +4871,7 @@ mod tests {
             use flui_hot_reload::HotReloadTier;
 
             let mut realm = UiRealm::for_test();
-            install_second_presentation_for_test(&mut realm);
+            realm.install_second_presentation_for_test();
 
             // Both presentations start with no root attached; `apply_hot_reload`
             // still calls `perform_reassemble`/`PipelineOwner::reassemble` on
@@ -4815,7 +4911,7 @@ mod tests {
         #[test]
         fn dropping_the_realm_closes_every_presentation() {
             let mut realm = UiRealm::for_test();
-            install_second_presentation_for_test(&mut realm);
+            realm.install_second_presentation_for_test();
 
             let lifecycles_before: Vec<_> = realm
                 .presentations
@@ -4855,7 +4951,7 @@ mod tests {
         #[test]
         fn sibling_presentations_flush_independently() {
             let mut realm = UiRealm::for_test();
-            let second_id = install_second_presentation_for_test(&mut realm);
+            let second_id = realm.install_second_presentation_for_test();
 
             // Mark ONLY the second presentation dirty — reaching its own
             // wake bit directly, the same seam a later addressed-routing
@@ -5031,7 +5127,7 @@ mod tests {
             // `realm` starts with exactly one presentation; call it "A" and
             // install a second, "B", to observe.
             let a_id = realm.presentation_id();
-            let b_id = install_second_presentation_for_test(&mut realm);
+            let b_id = realm.install_second_presentation_for_test();
 
             let captured = Rc::new(RefCell::new(None));
             let probe = AsyncCaptureProbeView {
@@ -5074,8 +5170,8 @@ mod tests {
             // Close A through the real consolidated teardown path —
             // production never cancels this realm-level `AsyncDriver`'s
             // in-flight tasks (see this test's own doc and
-            // `UiRealm::close_presentation`'s).
-            assert!(realm.close_presentation(a_id), "A was installed");
+            // `UiRealm::close_presentation_entered`'s).
+            assert!(realm.close_presentation_entered(a_id), "A was installed");
 
             let b_has_pending_builds = || {
                 realm
@@ -5180,11 +5276,11 @@ mod tests {
         }
 
         /// A `State::dispose()` hook running as part of `UiRealm::
-        /// close_presentation`'s teardown (step 3) schedules through its OWN
-        /// `RebuildHandle` — proving it reaches only its own (about to be
-        /// dropped) tree, never a live sibling's, by the same
+        /// close_presentation_entered`'s teardown (step 3) schedules through
+        /// its OWN `RebuildHandle` — proving it reaches only its own (about
+        /// to be dropped) tree, never a live sibling's, by the same
         /// `ExternalBuildScheduler`-is-minted-one-per-owner argument
-        /// `close_presentation`'s own doc makes. "Dead services" — this
+        /// `close_presentation_entered`'s own doc makes. "Dead services" — this
         /// presentation's OWN focus/IME, already closed by teardown step 2
         /// before step 3's detach runs — failing closed rather than
         /// panicking is covered by `presentation.rs`'s
@@ -5194,7 +5290,7 @@ mod tests {
         fn dispose_during_teardown_cannot_reach_sibling_or_dead_services() {
             let mut realm = UiRealm::for_test();
             let a_id = realm.presentation_id();
-            let b_id = install_second_presentation_for_test(&mut realm);
+            let b_id = realm.install_second_presentation_for_test();
 
             let handle_slot = Rc::new(RefCell::new(None));
             let disposed = Rc::new(Cell::new(false));
@@ -5236,13 +5332,13 @@ mod tests {
             );
 
             assert!(
-                realm.close_presentation(a_id),
+                realm.close_presentation_entered(a_id),
                 "A must have been installed and removable"
             );
 
             assert!(
                 disposed.get(),
-                "close_presentation's detach_root_widget must have run A's dispose hook"
+                "close_presentation_entered's detach_root_widget must have run A's dispose hook"
             );
             assert!(
                 !b_has_pending_builds(&realm, b_id),
@@ -5266,7 +5362,7 @@ mod tests {
         fn closing_presentation_a_leaves_sibling_layer_tree_identical() {
             let mut realm = UiRealm::for_test();
             let a_id = realm.presentation_id();
-            let b_id = install_second_presentation_for_test(&mut realm);
+            let b_id = realm.install_second_presentation_for_test();
 
             // Mount independent content on both presentations.
             realm
@@ -5296,7 +5392,7 @@ mod tests {
             });
 
             assert!(
-                realm.close_presentation(a_id),
+                realm.close_presentation_entered(a_id),
                 "A must have been installed and removable"
             );
 
@@ -5363,7 +5459,7 @@ mod tests {
                 "precondition: the handle works while A is still alive"
             );
 
-            assert!(realm.close_presentation(a_id), "A was installed");
+            assert!(realm.close_presentation_entered(a_id), "A was installed");
 
             assert!(
                 matches!(

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1078,8 +1078,17 @@ impl UiRealm {
     /// Request a redraw (flag only — does not poke the platform window).
     /// See [`Self::needs_redraw`]'s field doc for why this and
     /// [`Self::wake_frame`] share one underlying atomic with `AppRuntime`.
+    ///
+    /// Every current caller is a presentation-scoped operation
+    /// (`attach_root_widget*`, `handle_input_entered`) working on
+    /// `self.presentations.primary()` — no addressed routing exists yet
+    /// (a later slice's job) — so this also marks that presentation's own
+    /// pump wake bit (ADR-0043 §3), the signal
+    /// `UiRealm::draw_frame_entered`'s per-presentation loop reads at
+    /// segment start.
     pub(crate) fn request_redraw(&self) {
         self.needs_redraw.store(true, Ordering::Relaxed);
+        self.presentations.primary().mark_redraw_pending();
     }
 
     /// Whether a redraw is needed.
@@ -1220,19 +1229,19 @@ impl UiRealm {
             .with_mut(|owner| owner.set_device_pixel_ratio(device_pixel_ratio));
     }
 
-    /// Check if there is pending work: a pending build, pending gesture
-    /// motion/deadlines, or a dirty render node. The runner's wake gate
-    /// (`needs_redraw() || has_pending_work()`) reads this every frame.
+    /// Check if there is pending work in ANY presentation this realm hosts:
+    /// a pending build, pending gesture motion/deadlines, or a dirty render
+    /// node. The runner's wake gate (`needs_redraw() || has_pending_work()`)
+    /// reads this every frame. Production topology is exactly one
+    /// presentation, so this union is behaviorally identical to reading the
+    /// primary's own state directly; it generalizes to the isolation suite's
+    /// N>1 forests without needing a second code path.
     pub(crate) fn has_pending_work(&self) -> bool {
-        self.presentations.primary().widgets().has_pending_builds()
-            || self.gestures().has_pending_motion()
-            || self.gestures().has_pending_deadlines()
-            || self
-                .presentations
-                .primary()
-                .renderer()
-                .root_pipeline_owner()
-                .with(PipelineOwner::has_dirty_nodes)
+        self.presentations.iter().any(|presentation| {
+            presentation.has_pending_work()
+                || presentation.gestures().has_pending_motion()
+                || presentation.gestures().has_pending_deadlines()
+        })
     }
 
     // ========================================================================
@@ -1361,15 +1370,29 @@ impl UiRealm {
 
     /// The complete build+layout+paint pipeline for one frame.
     ///
-    /// **Frame-phase parity (critical):** this ordering — the vsync tick
-    /// block, the gesture-deadline tick, the build phase, the
-    /// layout/paint/scene-creation phase, and the pipeline-failure error
-    /// path — moves VERBATIM from the retired `AppBinding::draw_frame_entered`.
-    /// Reordering any of it is out of scope for the change that moved it
-    /// here; the frame-loop tests below are the parity oracle.
+    /// **Frame-phase parity (critical):** the realm-level pre-phase (vsync
+    /// tick, then gesture-deadline tick) MUST precede every presentation's
+    /// own segment, for the identical ordering argument the retired
+    /// `AppBinding::draw_frame_entered` depended on: both tick calls can
+    /// dirty render/build state a segment's dirty sample needs to observe.
+    /// Reordering the pre-phase is out of scope for the change that
+    /// introduced the per-presentation loop below; the frame-loop tests are
+    /// the parity oracle.
+    ///
+    /// **Per-presentation segment loop (ADR-0043 §3):** presentations are
+    /// processed once each, in mount order. Production topology is exactly
+    /// one presentation (`PresentationForest`'s ratchet), so this loop
+    /// degenerates to exactly today's single unconditional segment — see
+    /// [`Self::draw_frame_for_presentation`]'s doc for the proof that its
+    /// dirty gate cannot skip a segment the old, ungated code would have
+    /// run. Returns the LAST presentation's outcome (matches today's single-
+    /// presentation return value exactly; a genuine multi-presentation
+    /// caller reads each presentation's own render state directly rather
+    /// than this aggregate — addressed per-presentation return values are a
+    /// later slice's job).
     fn draw_frame_entered(&self, constraints: BoxConstraints) -> FramePaintOutcome {
-        // Vsync tick — MUST precede the build phase (Phase 1). See the
-        // retired `AppBinding::draw_frame_entered`'s doc for the full
+        // Vsync tick — MUST precede every presentation's build phase. See
+        // the retired `AppBinding::draw_frame_entered`'s doc for the full
         // disjoint-controller-set argument this ordering depends on.
         let now = self.now_secs();
         {
@@ -1384,11 +1407,16 @@ impl UiRealm {
             }
         }
 
-        // Gesture-deadline tick + keep-alive — also MUST precede the build
-        // phase, for the identical ordering argument as the vsync tick.
-        self.gestures().tick_deadlines();
-        if self.gestures().has_pending_deadlines() {
-            self.wake_frame();
+        // Gesture-deadline tick + keep-alive — also MUST precede every
+        // presentation's build phase, for the identical ordering argument as
+        // the vsync tick. Each presentation owns its own gesture arena, so
+        // this runs once per presentation rather than once per realm; at
+        // N=1 this is exactly today's single `self.gestures()` call.
+        for presentation in self.presentations.iter() {
+            presentation.gestures().tick_deadlines();
+            if presentation.gestures().has_pending_deadlines() {
+                self.wake_frame();
+            }
         }
 
         // The async-driver step lives in `Scheduler::handle_begin_frame`'s
@@ -1399,9 +1427,49 @@ impl UiRealm {
         // frame, on the right `Scheduler` instance, is enforced by the
         // scheduler itself.
 
+        let mut last_outcome = FramePaintOutcome::Idle;
+        for presentation in self.presentations.iter() {
+            // Segment start: clear this presentation's wake bit BEFORE
+            // sampling dirty, so a mark arriving WHILE this segment runs
+            // sets the bit again and lands next pump instead of being lost.
+            let woken = presentation.take_redraw_pending();
+            if !(woken || presentation.has_pending_work()) {
+                // Nothing to flush and nobody asked: skip this presentation's
+                // segment entirely. Bound: each presentation builds and
+                // flushes at most once per pump; this `continue` is what
+                // makes that true rather than merely documented.
+                continue;
+            }
+            last_outcome = Self::draw_frame_for_presentation(presentation, constraints);
+        }
+        last_outcome
+    }
+
+    /// One presentation's build+layout+paint segment — moves VERBATIM from
+    /// the retired `AppBinding::draw_frame_entered`'s Phase 1–4, now
+    /// parameterized by `presentation` instead of hard-wired to
+    /// `self.presentations.primary()`.
+    ///
+    /// **Why the caller's dirty gate cannot skip a segment this body would
+    /// have produced `Painted` for:** `run_frame_with_layout_builders`
+    /// itself returns `None` (this function's `Idle` outcome) whenever
+    /// nothing is dirty — that decision already lived inside the pipeline
+    /// before this loop existed. `Self::has_pending_work` (build pending OR
+    /// a dirty render node) is exactly the union of conditions that
+    /// decision depends on, so gating the CALL on the same union, one level
+    /// up, changes nothing observable: either both agree nothing is dirty
+    /// (skip here, `Idle` there — same outcome, cheaper), or either finds
+    /// real work and the segment runs exactly as it always did.
+    fn draw_frame_for_presentation(
+        presentation: &PresentationState,
+        constraints: BoxConstraints,
+    ) -> FramePaintOutcome {
+        #[cfg(test)]
+        presentation.record_flush();
+
         // Phase 1: Build (WidgetsBinding)
         {
-            let w = self.widgets();
+            let w = presentation.widgets();
             if w.has_pending_builds() {
                 w.draw_frame();
             }
@@ -1411,17 +1479,14 @@ impl UiRealm {
         // typestate-driven orchestrator.
         let mut pipeline_errored = false;
         let (layer_tree, link_registry) = {
-            self.presentations
-                .primary()
+            presentation
                 .renderer()
                 .root_pipeline_owner()
                 .with_mut(|owner| owner.set_root_constraints(Some(constraints)));
-            let result = self
+            let result = presentation
                 .widgets()
-                .run_frame_with_layout_builders(self.presentations.primary().pipeline());
-            let link_registry = self
-                .presentations
-                .primary()
+                .run_frame_with_layout_builders(presentation.pipeline());
+            let link_registry = presentation
                 .renderer()
                 .root_pipeline_owner()
                 .with_mut(PipelineOwner::take_link_registry);
@@ -1438,18 +1503,16 @@ impl UiRealm {
         // Production<->headless convergence point: service lazy-sliver child
         // requests accumulated by `run_frame`'s layout pass.
         {
-            let w = self.widgets();
-            w.service_child_requests(self.presentations.primary().pipeline());
+            let w = presentation.widgets();
+            w.service_child_requests(presentation.pipeline());
         }
 
         // Phase 4: Create Scene from LayerTree
         let size = constraints.constrain(Size::ZERO);
-        let frame_number = self.presentations.primary().frames_rendered() + 1;
+        let frame_number = presentation.frames_rendered() + 1;
 
         if let Some(mut layer_tree) = layer_tree {
-            self.presentations
-                .primary()
-                .attach_performance_overlay(&mut layer_tree);
+            presentation.attach_performance_overlay(&mut layer_tree);
 
             let root = layer_tree.root();
             let scene = Scene::with_links(
@@ -4712,6 +4775,113 @@ mod tests {
             // does not add -- production topology never removes a single
             // member from a live forest today, it only ever drops the whole
             // realm, which is what this test actually exercises.
+        }
+
+        fn segment_constraints() -> BoxConstraints {
+            BoxConstraints::tight(flui_types::Size::new(px(800.0), px(600.0)))
+        }
+
+        /// Oracle: FLUSH COUNTS (`PresentationState::flush_count`), never
+        /// rebuild counts — a presentation with a settled, never-rebuilding
+        /// tree still flushes every segment its own dirty state (or wake
+        /// bit) causes to run, and a presentation that was never dirtied
+        /// must NOT flush just because its sibling did.
+        #[test]
+        fn sibling_presentations_flush_independently() {
+            let mut realm = UiRealm::for_test();
+            let second_id = install_second_presentation_for_test(&mut realm);
+
+            // Mark ONLY the second presentation dirty — reaching its own
+            // wake bit directly, the same seam a later addressed-routing
+            // slice would call through (no addressed entry point exists
+            // yet).
+            realm
+                .presentations
+                .get(second_id)
+                .expect("second presentation installed")
+                .mark_redraw_pending();
+
+            let _ = realm.enter(|realm| realm.draw_frame_entered(segment_constraints()));
+
+            assert_eq!(
+                realm.presentations.primary().flush_count(),
+                0,
+                "the primary presentation was never marked dirty and must \
+                 not flush just because its sibling did"
+            );
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(second_id)
+                    .expect("still installed")
+                    .flush_count(),
+                1,
+                "the second presentation's own wake bit must cause exactly \
+                 one flush"
+            );
+
+            // A second pump with nothing newly dirty must flush neither —
+            // both presentations are now settled.
+            let _ = realm.enter(|realm| realm.draw_frame_entered(segment_constraints()));
+            assert_eq!(
+                realm.presentations.primary().flush_count(),
+                0,
+                "still never dirtied, still zero flushes"
+            );
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(second_id)
+                    .expect("still installed")
+                    .flush_count(),
+                1,
+                "a settled presentation must not flush again with nothing \
+                 new to do"
+            );
+        }
+
+        /// A mark arriving for a presentation while ITS OWN segment is
+        /// running must not be lost: the segment already cleared the bit at
+        /// its own START, so a mark landing anywhere between that clear and
+        /// the next pump's sample must survive to be observed there.
+        ///
+        /// This collapses the timing to a single thread (mark, run the
+        /// segment, mark again immediately after) rather than a literal
+        /// concurrent race — in a single-threaded pump there is no OTHER
+        /// window where a mark could land except between one segment
+        /// ending and the next beginning, or nested inside the segment's
+        /// own build via a real callback; both reduce to the same
+        /// observable property this test checks: the bit set after the
+        /// clear is not silently dropped.
+        #[test]
+        fn cross_presentation_dirty_during_a_segment_sets_wake_bit_and_lands_next_pump() {
+            let realm = UiRealm::for_test();
+            let presentation = realm.presentations.primary();
+
+            presentation.mark_redraw_pending();
+            let _ = realm.enter(|realm| realm.draw_frame_entered(segment_constraints()));
+            assert_eq!(
+                presentation.flush_count(),
+                1,
+                "the armed wake bit must cause exactly one flush"
+            );
+
+            // A mark arrives during (or immediately after) that segment —
+            // nothing else about the presentation is dirty (no widget tree
+            // was ever attached, so no pending builds; the render tree is
+            // empty, so no dirty nodes either): the wake bit is the ONLY
+            // dirty signal in play.
+            presentation.mark_redraw_pending();
+
+            let _ = realm.enter(|realm| realm.draw_frame_entered(segment_constraints()));
+            assert_eq!(
+                presentation.flush_count(),
+                2,
+                "the wake bit set after the first segment cleared its own \
+                 bit must not be lost -- it must cause a second flush on \
+                 the next pump, even though nothing else about the \
+                 presentation is dirty"
+            );
         }
     }
 }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1769,6 +1769,17 @@ impl Drop for UiRealm {
         // production topology is exactly one until the forest's ratchet
         // lifts, but this loop is already correct for N: nothing here
         // assumes `len() == 1`.
+        //
+        // Deliberately NOT wrapped in `enter()`: this runs during `Drop`,
+        // which can itself run during thread-local destruction (e.g. a
+        // realm still alive when its owning thread exits) where touching
+        // ANOTHER thread-local (the registry activation stack `enter()`
+        // pushes onto) aborts the process
+        // ("cannot access a Thread Local Storage value during or after
+        // destruction"). A `State::dispose()` hook that needs a `GlobalKey`
+        // lookup during realm teardown is out of scope for this fix; the
+        // registries this realm's `WidgetsBinding`s expose are simply
+        // inactive here, matching every other un-entered context.
         for presentation in self.presentations.iter() {
             presentation.close();
         }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -5250,4 +5250,129 @@ mod tests {
             );
         }
     }
+
+    // ========================================================================
+    // Closing one presentation must be structurally invisible to a
+    // surviving sibling (ADR-0043's end-state invariant)
+    // ========================================================================
+    mod closing_one_presentation_is_invisible_to_siblings {
+        use super::*;
+
+        /// Oracle: a LAYER-TREE COMPARE (`format!("{:?}", ...)` on the
+        /// produced `LayerTree`), never a rebuild/flush count — B's own
+        /// render output, not merely whether B ran, must be byte-for-byte
+        /// unaffected by A closing.
+        #[test]
+        fn closing_presentation_a_leaves_sibling_layer_tree_identical() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = install_second_presentation_for_test(&mut realm);
+
+            // Mount independent content on both presentations.
+            realm
+                .enter(|realm| realm.attach_root_widget(&flui_widgets::SizedBox::new(10.0, 10.0)))
+                .expect("A mounts");
+            realm
+                .enter(|realm| {
+                    realm
+                        .presentations
+                        .get(b_id)
+                        .expect("B installed")
+                        .widgets()
+                        .attach_root_widget(&flui_widgets::SizedBox::new(30.0, 30.0))
+                })
+                .expect("B mounts");
+
+            let constraints = BoxConstraints::tight(flui_types::Size::new(px(50.0), px(50.0)));
+            let b_layer_tree_before = realm.enter(|realm| {
+                let b = realm.presentations.get(b_id).expect("B installed");
+                match UiRealm::draw_frame_for_presentation(b, constraints) {
+                    FramePaintOutcome::Painted(scene) => format!("{:?}", scene.layer_tree()),
+                    FramePaintOutcome::Idle => panic!("B's first frame must paint, got Idle"),
+                    FramePaintOutcome::Errored => {
+                        panic!("B's first frame must paint, got Errored")
+                    }
+                }
+            });
+
+            assert!(
+                realm.close_presentation(a_id),
+                "A must have been installed and removable"
+            );
+
+            let b_layer_tree_after = realm.enter(|realm| {
+                let b = realm.presentations.get(b_id).expect("B still installed");
+                // The first draw already settled B (nothing left dirty), so
+                // an unconditional second draw would correctly report Idle
+                // regardless of A -- that would prove nothing about B's
+                // CONTENT. Force B's root render node dirty directly so this
+                // second draw genuinely re-produces its layer tree from
+                // scratch, the same content as the first draw, to compare
+                // against it (a rebuild alone is not enough: reconciling an
+                // unchanged `SizedBox` config is legitimately a no-op that
+                // marks nothing dirty).
+                b.pipeline().with_mut(|owner| {
+                    if let Some(root_id) = owner.root_id() {
+                        owner.mark_needs_paint(root_id);
+                    }
+                });
+                match UiRealm::draw_frame_for_presentation(b, constraints) {
+                    FramePaintOutcome::Painted(scene) => format!("{:?}", scene.layer_tree()),
+                    FramePaintOutcome::Idle => {
+                        panic!("B's post-A-close frame must still paint, got Idle")
+                    }
+                    FramePaintOutcome::Errored => {
+                        panic!("B's post-A-close frame must still paint, got Errored")
+                    }
+                }
+            });
+
+            assert_eq!(
+                b_layer_tree_before, b_layer_tree_after,
+                "B's own layer tree must be byte-for-byte identical before and \
+                 after A closes -- nothing about B's content changed, so \
+                 nothing about its render output may either"
+            );
+        }
+
+        /// A `RepaintHandle` obtained from presentation A's pipeline BEFORE
+        /// A closes, and still held afterward, must fail closed
+        /// (`DirtySendError::OwnerGone`) rather than panic when used — the
+        /// underlying `PipelineOwner`'s dirty-request channel receiver drops
+        /// along with A's `PresentationState`, so the handle's sender side
+        /// simply finds nobody listening.
+        #[test]
+        fn dropped_presentations_surviving_pipeline_handles_fail_closed() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+
+            let render_id = realm.presentations.primary().pipeline().with_mut(|owner| {
+                owner.insert::<flui_rendering::protocol::BoxProtocol>(Box::new(
+                    flui_objects::RenderColoredBox::red(10.0, 10.0),
+                ))
+            });
+            let repaint_handle = realm
+                .presentations
+                .primary()
+                .pipeline()
+                .with(|owner| owner.repaint_handle(render_id))
+                .expect("a freshly inserted node has a live repaint handle");
+
+            assert!(
+                repaint_handle.mark_needs_layout().is_ok(),
+                "precondition: the handle works while A is still alive"
+            );
+
+            assert!(realm.close_presentation(a_id), "A was installed");
+
+            assert!(
+                matches!(
+                    repaint_handle.mark_needs_layout(),
+                    Err(flui_rendering::pipeline::DirtySendError::OwnerGone)
+                ),
+                "a RepaintHandle surviving its presentation's teardown must \
+                 fail closed, not panic and not silently succeed"
+            );
+        }
+    }
 }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -385,17 +385,18 @@ pub(crate) struct UiRealm {
     /// installed into every presentation's `BuildOwner` at assembly time
     /// (`PresentationState::new`). Retained here (not just handed off once)
     /// so a later-installed presentation can share the same scope; read back
-    /// by [`Self::global_key_scope`] for the isolation test suite, which
-    /// bypasses `PresentationForest`'s production ratchet to assemble a
-    /// second presentation sharing this exact scope.
+    /// by the `cfg(test)`-only `global_key_scope` accessor below for the
+    /// isolation test suite, which bypasses `PresentationForest`'s production
+    /// ratchet to assemble a second presentation sharing this exact scope.
     #[cfg_attr(
         not(test),
         expect(
             dead_code,
-            reason = "no production reader until a presentation-install path \
-                      (#555 PR-4/5) needs to hand this same scope to a newly \
-                      assembled presentation; the isolation test suite reads \
-                      it back today via Self::global_key_scope"
+            reason = "no production reader until a later addressed-routing \
+                      slice's presentation-install path needs to hand this \
+                      same scope to a newly assembled presentation; the \
+                      isolation test suite reads it back today via \
+                      Self::global_key_scope"
         )
     )]
     global_key_scope: GlobalKeyScope,
@@ -836,7 +837,7 @@ impl UiRealm {
     /// Enter this realm's owner scope.
     ///
     /// A composite `GlobalKey` registry spanning every presentation this
-    /// realm hosts (ADR-0043 §1 RULING 1b) is active for the entire dynamic
+    /// realm hosts (ADR-0043 §1) is active for the entire dynamic
     /// extent of `f`, including lifecycle/build callbacks — whole-frame,
     /// exactly as a single presentation's own registry always was: post-frame
     /// callbacks, command drains, deferred arena resolutions, and hot-reload
@@ -1832,10 +1833,10 @@ mod tests {
     /// `GlobalKeyScope` and realm-level dispatch handles.
     ///
     /// Bypasses `PresentationForest`'s production ratchet
-    /// (`PresentationForest::push_for_test`) deliberately — this is the
-    /// isolation-suite seam #555 PR-3's plan names: a genuine
-    /// multi-presentation realm ahead of the addressed routing (#555
-    /// PR-4/5) that makes doing so safe in production.
+    /// (`PresentationForest::push_for_test`) deliberately — the
+    /// isolation-suite seam for exercising a genuine multi-presentation
+    /// realm ahead of the addressed routing that makes doing so safe in
+    /// production.
     fn install_second_presentation_for_test(realm: &mut UiRealm) -> PresentationId {
         let (_, presentation_id) = crate::app::runtime::next_identity();
         let pipeline = PipelineCell::new(PipelineOwner::new());
@@ -4556,7 +4557,7 @@ mod tests {
     }
 
     // ========================================================================
-    // Presentation forest — isolation suite (ADR-0043 §1, #555 PR-3)
+    // Presentation forest — isolation suite (ADR-0043 §1)
     //
     // Production topology is exactly one presentation per realm
     // (`PresentationForest`'s `install` ratchet); these tests bypass it via
@@ -4581,7 +4582,7 @@ mod tests {
             );
         }
 
-        /// The realm composite `enter()` activates (ADR-0043 §1 RULING 1b)
+        /// The realm composite `enter()` activates (ADR-0043 §1)
         /// must resolve a `GlobalKey` registered in EITHER presentation's own
         /// tree, not just the primary one — the correctness property
         /// `GlobalKeyRegistryComposite` exists for.
@@ -4693,13 +4694,13 @@ mod tests {
             // Drop (each PresentationState transitions to Closed on its own
             // drop -- see PresentationState::close/Drop); nothing left to
             // assert on here beyond "this did not panic", since the values
-            // themselves are gone. The meaningful oracle is
-            // `closing_presentation_a_leaves_sibling_layer_tree_identical`-
-            // style structural isolation, which the single-presentation
-            // production path already covers via existing render-frame
-            // tests; a genuine N>1 close-one-keep-one-running scenario needs
-            // the addressed teardown path #555 PR-4/5 adds and is out of
-            // this slice's scope.
+            // themselves are gone. Proving that closing ONE presentation
+            // structurally cannot disturb a SURVIVING sibling's own layer
+            // tree needs an addressed per-presentation teardown path (close
+            // exactly one member, keep the rest running) that this slice
+            // does not add -- production topology never removes a single
+            // member from a live forest today, it only ever drops the whole
+            // realm, which is what this test actually exercises.
         }
     }
 }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -799,6 +799,39 @@ impl UiRealm {
         self.presentations.len() == 1 && self.presentations.get(id).is_some()
     }
 
+    /// The presentation id that would become this realm's PRIMARY if `id`
+    /// were removed right now — WITHOUT actually removing it.
+    ///
+    /// `runner.rs`'s `RealmTask::ClosePresentation` handling reads this
+    /// BEFORE running `id`'s own teardown/dispose hooks (`close_presentation_
+    /// entered`'s step 2-3), not after: `RealmSlot::address.presentation_id`
+    /// must already name the SURVIVING primary by the time a dispose hook
+    /// could re-enter `dispatch_platform_realm` with `id`'s own dispatcher,
+    /// or that reentrant dispatch would still compare EQUAL against the
+    /// not-yet-updated address, pass the `StalePresentation` check, and get
+    /// enqueued (same-realm reentrancy) instead of refused — running later
+    /// in the same drain loop against whatever survives the close, silently
+    /// misaddressed rather than refused outright.
+    ///
+    /// Mirrors exactly what [`PresentationForest::remove`]'s `Vec::remove`
+    /// shift produces: if `id` is the CURRENT primary, the new primary is
+    /// whichever presentation is next in mount order; otherwise removing
+    /// `id` cannot move index 0 at all, so the primary is unchanged.
+    /// `None` only if `id` names the realm's only presentation — unreachable
+    /// from that same dispatch handling, which checks
+    /// [`Self::is_sole_presentation`] first and never reaches this call in
+    /// that case.
+    #[must_use]
+    pub(crate) fn primary_id_excluding(&self, id: PresentationId) -> Option<PresentationId> {
+        if self.presentations.primary().id() != id {
+            return Some(self.presentations.primary().id());
+        }
+        self.presentations
+            .iter()
+            .find(|presentation| presentation.id() != id)
+            .map(PresentationState::id)
+    }
+
     /// This realm's shared cross-tree `GlobalKey` uniqueness domain
     /// (ADR-0043 §1) — for the isolation test suite, which uses it to
     /// assemble a second presentation sharing this realm's exact scope,
@@ -1867,7 +1900,18 @@ impl UiRealm {
             match command {
                 #[cfg(feature = "hot-reload")]
                 UiCommand::HotReload(tier) => {
-                    if self.presentations.primary().apply_hot_reload(tier) {
+                    // Reuse the SAME fan-out `Self::apply_hot_reload` the
+                    // direct `perform_hot_reload_entered` path calls --
+                    // calling `self.presentations.primary().apply_hot_reload`
+                    // here instead (as this arm once did) reassembles only
+                    // the primary and silently skips every other
+                    // presentation, exactly the class of bug
+                    // `reassemble_fans_out_to_all_presentations_in_mount_
+                    // order` exists to catch on the direct path; this
+                    // inbox arm is the untested twin of that same call, and
+                    // the desktop worker's own hot-reload trigger goes
+                    // through THIS arm, not the direct one.
+                    if self.apply_hot_reload(tier) {
                         self.redraw_pending.store(true, Ordering::Release);
                     }
                     report.invoked += 1;
@@ -5009,6 +5053,85 @@ mod tests {
                     .has_pending_builds(),
                 "reassemble must mark B's mounted root dirty too -- fan-out must not skip \
                  or stop at the primary presentation"
+            );
+        }
+
+        /// The SAME fan-out property as `reassemble_fans_out_to_all_
+        /// presentations_in_mount_order`, but driven through the OTHER
+        /// production entry point: the closed-command inbox
+        /// (`command_sender().request_hot_reload` + `drain_commands`), the
+        /// path the desktop worker's own hot-reload trigger actually uses --
+        /// not `apply_hot_reload`/`perform_hot_reload_entered` called
+        /// directly. Before this arm reused `Self::apply_hot_reload`, it
+        /// called `self.presentations.primary().apply_hot_reload(tier)`
+        /// directly, reassembling only the primary and silently skipping
+        /// every sibling — the registry-pinned exploit's exact regression
+        /// class, on its untested twin path. Mutant-verified: reverting
+        /// `drain_commands`'s `UiCommand::HotReload` arm back to
+        /// `self.presentations.primary().apply_hot_reload(tier)` makes this
+        /// test fail on B's `has_pending_builds()` assertion; restoring the
+        /// `self.apply_hot_reload(tier)` fan-out call makes it pass again.
+        #[test]
+        #[cfg(feature = "hot-reload")]
+        fn hot_reload_via_the_command_inbox_fans_out_to_all_presentations_in_mount_order() {
+            use flui_hot_reload::HotReloadTier;
+
+            let mut realm = UiRealm::for_test();
+            let b_id = realm.install_second_presentation_for_test();
+
+            realm
+                .enter(|realm| realm.attach_root_widget(&flui_widgets::SizedBox::new(10.0, 10.0)))
+                .expect("A mounts");
+            realm
+                .enter(|realm| {
+                    realm
+                        .presentations
+                        .get(b_id)
+                        .expect("B installed")
+                        .widgets()
+                        .attach_root_widget(&flui_widgets::SizedBox::new(20.0, 20.0))
+                })
+                .expect("B mounts");
+
+            let constraints = BoxConstraints::tight(flui_types::Size::new(px(50.0), px(50.0)));
+            let _ = realm.draw_frame(constraints);
+            assert!(
+                !realm.widgets().has_pending_builds(),
+                "precondition: A's initial build must be drained before reassembling"
+            );
+            assert!(
+                !realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B installed")
+                    .widgets()
+                    .has_pending_builds(),
+                "precondition: B's initial build must be drained before reassembling"
+            );
+
+            realm
+                .command_sender()
+                .request_hot_reload(HotReloadTier::HotReload)
+                .expect("inbox has room");
+            let report = realm.drain_commands();
+            assert_eq!(
+                report.invoked, 1,
+                "the hot-reload command must be applied, not dropped as stale"
+            );
+
+            assert!(
+                realm.widgets().has_pending_builds(),
+                "the inbox path must mark A's mounted root dirty, exactly like the direct path"
+            );
+            assert!(
+                realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B installed")
+                    .widgets()
+                    .has_pending_builds(),
+                "the inbox path must mark B's mounted root dirty too -- it is the SAME \
+                 fan-out as the direct perform_hot_reload_entered path, not a narrower one"
             );
         }
 

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1824,6 +1824,72 @@ impl UiRealm {
         }
         report
     }
+
+    /// Close and remove exactly one presentation from this realm's forest.
+    ///
+    /// Must run at Idle, outside the dispatched-scheduler gate — the same
+    /// discipline every other realm-map mutation follows; callers reach this
+    /// only from an idle-only teardown path, never from inside a frame
+    /// transaction. A no-op (returns `false`) if `id` does not name a
+    /// presentation this realm currently hosts.
+    ///
+    /// # Contract — six steps, in order
+    ///
+    /// 1. **Unregistering this presentation's window mappings from the
+    ///    process-wide `WindowRegistry` is NOT this method's job.**
+    ///    `UiRealm` has no access to that registry (`AppRuntime`-owned,
+    ///    ADR-0037 §2's single authority) — the caller must have already
+    ///    removed the registry entry before calling this. Today's only
+    ///    caller is `AppRuntime`'s realm teardown (closing a realm's SOLE
+    ///    presentation closes the realm), which already does registry
+    ///    removal first (`apply_uninstall`/`teardown_platform_realm`).
+    /// 2. IME detach + focus deactivate — [`PresentationState::close`]'s
+    ///    first half.
+    /// 3. `detach_root_widget` through this exact presentation's own
+    ///    `WidgetsBinding` — [`PresentationState::close`]'s second half.
+    ///    Every `State::dispose()` a descendant runs here still has its
+    ///    capabilities installed (nothing about the realm's shared dispatch
+    ///    handles has been touched), and routes only within THIS
+    ///    presentation's own tree: `RebuildHandle`/`ExternalBuildScheduler`
+    ///    are minted one-per-owner and never shared, so a dispose hook has
+    ///    no path to a sibling presentation's inbox even if it tries (see
+    ///    `dispose_during_teardown_cannot_reach_sibling_or_dead_services`).
+    /// 4. **Async-task disposition:** the realm-level `AsyncDriver` is not
+    ///    told about this closure — an in-flight task this presentation
+    ///    spawned is NOT cancelled here, matching `PresentationState`'s own
+    ///    `Drop` (which also does not reach into the driver). Its eventual
+    ///    completion fails closed against the now-dropped tree for the same
+    ///    reason step 3's dispose hooks do:
+    ///    `async_completion_after_presentation_teardown_fails_closed_no_sibling_reach`
+    ///    is the proof.
+    /// 5. `GlobalKeyScope` claims still tagged to this presentation's
+    ///    `BuildOwner` are reclaimed, traced — automatic, via `BuildOwner`'s
+    ///    own `Drop`, once step 6 drops the last reference to it.
+    /// 6. The removed `PresentationState` — and with it its `WidgetsBinding`
+    ///    (whose drop triggers step 5), `RenderingFlutterBinding`, and every
+    ///    other owned resource — drops at the end of this function.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "no production caller until a later addressed-routing \
+                      slice's presentation-close path removes a member from \
+                      a genuine N>1 forest; today's sole caller (AppRuntime's \
+                      realm teardown) closes the whole realm, which drops \
+                      every presentation through UiRealm::Drop instead of \
+                      calling this method"
+        )
+    )]
+    pub(crate) fn close_presentation(&mut self, id: PresentationId) -> bool {
+        let Some(presentation) = self.presentations.remove(id) else {
+            return false;
+        };
+        // Steps 2 + 3.
+        presentation.close();
+        // Steps 5 + 6: dropping `presentation` here (end of scope) is both
+        // the reclaim trigger and the disposal itself.
+        true
+    }
 }
 
 impl Drop for UiRealm {
@@ -4881,6 +4947,306 @@ mod tests {
                  bit must not be lost -- it must cause a second flush on \
                  the next pump, even though nothing else about the \
                  presentation is dirty"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Async-task disposition audit (ADR-0043 §5) — a dropped presentation's
+    // in-flight AsyncDriver task must not reach a live sibling
+    // ========================================================================
+    mod async_completion_isolation {
+        use std::cell::RefCell;
+
+        use super::*;
+
+        /// Test-local view that captures its `RebuildHandle` and the realm's
+        /// `AsyncDriver` in `init_state` into a shared slot the test reads
+        /// back — the exact seam `flui_view::element::future_builder::
+        /// FutureBuilder` (the framework's own production async widget) uses,
+        /// minus the `AsyncSnapshot` state machine this test does not need.
+        #[derive(Clone)]
+        struct AsyncCaptureProbeView {
+            captured: Rc<RefCell<Option<(flui_view::RebuildHandle, flui_scheduler::AsyncDriver)>>>,
+        }
+
+        struct AsyncCaptureProbeState {
+            captured: Rc<RefCell<Option<(flui_view::RebuildHandle, flui_scheduler::AsyncDriver)>>>,
+        }
+
+        impl StatefulView for AsyncCaptureProbeView {
+            type State = AsyncCaptureProbeState;
+
+            fn create_state(&self) -> Self::State {
+                AsyncCaptureProbeState {
+                    captured: Rc::clone(&self.captured),
+                }
+            }
+        }
+
+        impl ViewState<AsyncCaptureProbeView> for AsyncCaptureProbeState {
+            fn init_state(&mut self, ctx: &dyn flui_view::BuildContext) {
+                if let Some(driver) = ctx.async_driver() {
+                    *self.captured.borrow_mut() = Some((ctx.rebuild_handle(), driver));
+                }
+            }
+
+            fn build(
+                &self,
+                _view: &AsyncCaptureProbeView,
+                _ctx: &dyn flui_view::BuildContext,
+            ) -> impl IntoView {
+                flui_widgets::SizedBox::new(0.0, 0.0)
+            }
+        }
+
+        impl flui_view::View for AsyncCaptureProbeView {
+            fn create_element(&self) -> flui_view::element::ElementKind {
+                flui_view::element::ElementKind::stateful(self)
+            }
+        }
+
+        /// The mandatory async-task-disposition audit: `AsyncDriver` is
+        /// realm-level (shared by every presentation in a realm), so an
+        /// in-flight task spawned from a presentation that later closes is
+        /// NOT cancelled — it keeps getting polled until it completes. Its
+        /// completion reaches back into a tree through a `RebuildHandle`,
+        /// which routes through `ExternalBuildScheduler` — an
+        /// `Arc<Mutex<HashMap<ElementId, _>>>` inbox minted fresh per
+        /// `BuildOwner` at construction, never shared or reused across
+        /// owners (`crates/flui-view/src/owner/build_owner.rs`'s
+        /// `external_scheduler`). A stale completion's `schedule()` call
+        /// therefore writes into ITS OWN (orphaned, since that `BuildOwner`
+        /// already dropped) inbox — there is no shared table keyed only by
+        /// raw `ElementId` for it to alias a live sibling's entry in, even
+        /// when the two owners' trees happen to reuse the same numeral (the
+        /// identical-numeral hazard `GlobalKeyRegistryComposite` exists for
+        /// is a DIFFERENT registry; this one was never shared to begin
+        /// with). This test proves it end to end rather than resting on
+        /// that code reading alone: no fix was needed here, and this test is
+        /// the evidence for that, not a description of one.
+        #[test]
+        fn async_completion_after_presentation_teardown_fails_closed_no_sibling_reach() {
+            let mut realm = UiRealm::for_test();
+            // `realm` starts with exactly one presentation; call it "A" and
+            // install a second, "B", to observe.
+            let a_id = realm.presentation_id();
+            let b_id = install_second_presentation_for_test(&mut realm);
+
+            let captured = Rc::new(RefCell::new(None));
+            let probe = AsyncCaptureProbeView {
+                captured: Rc::clone(&captured),
+            };
+            realm
+                .enter(|realm| realm.attach_root_widget(&probe))
+                .expect("A mounts the capture probe");
+            // `attach_root_widget` only creates the root element and
+            // schedules the first build -- `init_state` (where the probe
+            // captures its handles) does not run until that build pass
+            // actually happens, exactly like `a1_autowrap_causes_
+            // registration_after_build_pass` above.
+            let _ = realm.enter(|realm| {
+                realm.draw_frame_entered(BoxConstraints::tight(flui_types::Size::new(
+                    px(20.0),
+                    px(20.0),
+                )))
+            });
+
+            let (rebuild_handle, driver) = captured
+                .borrow_mut()
+                .take()
+                .expect("init_state must have captured both handles");
+
+            // Spawn on the REALM's shared driver — exactly what a real
+            // async widget on presentation A would have done. Nothing
+            // drives it to completion until explicitly polled below, well
+            // after A has already closed. `Arc<AtomicBool>`, not
+            // `Rc<Cell<bool>>`: `BoxedTask` requires `Send` (the driver is
+            // shared across threads even though polling only ever happens
+            // on the frame thread — see `AsyncDriver`'s own doc).
+            let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let ran_marker = Arc::clone(&ran);
+            let _token = driver.spawn_local(Box::pin(async move {
+                rebuild_handle.schedule(flui_foundation::RebuildReason::AsyncCompletion);
+                ran_marker.store(true, Ordering::Relaxed);
+            }));
+
+            // Close A through the real consolidated teardown path —
+            // production never cancels this realm-level `AsyncDriver`'s
+            // in-flight tasks (see this test's own doc and
+            // `UiRealm::close_presentation`'s).
+            assert!(realm.close_presentation(a_id), "A was installed");
+
+            let b_has_pending_builds = || {
+                realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B still installed")
+                    .widgets()
+                    .has_pending_builds()
+            };
+            assert!(
+                !b_has_pending_builds(),
+                "precondition: B has no pending build before A's stale task runs"
+            );
+
+            // Poll the driver to completion — A's task runs, its captured
+            // `RebuildHandle` schedules against A's own (now-orphaned)
+            // inbox.
+            realm
+                .scheduler()
+                .drive_frame(flui_scheduler::Instant::now(), || {});
+            assert!(
+                ran.load(Ordering::Relaxed),
+                "A's stale task must still run to completion"
+            );
+
+            assert!(
+                !b_has_pending_builds(),
+                "A's stale completion must not have reached B's build inbox"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Dispose-during-teardown isolation (ADR-0043 §5 step 3)
+    // ========================================================================
+    mod dispose_teardown_isolation {
+        use std::cell::{Cell, RefCell};
+
+        use super::*;
+
+        /// Captures its own `RebuildHandle` in `init_state` (capabilities are
+        /// installed then, per port-check trigger #22) and schedules through
+        /// it from `dispose`, exactly the shape a real widget's cleanup path
+        /// takes (e.g. cancelling a subscription and requesting one final
+        /// rebuild to reflect that).
+        #[derive(Clone)]
+        struct DisposeProbeView {
+            handle_slot: Rc<RefCell<Option<flui_view::RebuildHandle>>>,
+            disposed: Rc<Cell<bool>>,
+        }
+
+        struct DisposeProbeState {
+            handle_slot: Rc<RefCell<Option<flui_view::RebuildHandle>>>,
+            disposed: Rc<Cell<bool>>,
+            handle: Option<flui_view::RebuildHandle>,
+        }
+
+        impl StatefulView for DisposeProbeView {
+            type State = DisposeProbeState;
+
+            fn create_state(&self) -> Self::State {
+                DisposeProbeState {
+                    handle_slot: Rc::clone(&self.handle_slot),
+                    disposed: Rc::clone(&self.disposed),
+                    handle: None,
+                }
+            }
+        }
+
+        impl ViewState<DisposeProbeView> for DisposeProbeState {
+            fn init_state(&mut self, ctx: &dyn flui_view::BuildContext) {
+                let handle = ctx.rebuild_handle();
+                *self.handle_slot.borrow_mut() = Some(handle.clone());
+                self.handle = Some(handle);
+            }
+
+            fn build(
+                &self,
+                _view: &DisposeProbeView,
+                _ctx: &dyn flui_view::BuildContext,
+            ) -> impl IntoView {
+                flui_widgets::SizedBox::new(0.0, 0.0)
+            }
+
+            fn dispose(&mut self) {
+                // Capabilities installed at init_state are still valid here
+                // (nothing about this presentation's realm-shared dispatch
+                // handles has been touched by teardown step 3 alone) —
+                // schedule through this element's OWN handle, exactly a real
+                // cleanup hook would.
+                if let Some(handle) = &self.handle {
+                    handle.schedule(flui_foundation::RebuildReason::StateChange);
+                }
+                self.disposed.set(true);
+            }
+        }
+
+        impl flui_view::View for DisposeProbeView {
+            fn create_element(&self) -> flui_view::element::ElementKind {
+                flui_view::element::ElementKind::stateful(self)
+            }
+        }
+
+        /// A `State::dispose()` hook running as part of `UiRealm::
+        /// close_presentation`'s teardown (step 3) schedules through its OWN
+        /// `RebuildHandle` — proving it reaches only its own (about to be
+        /// dropped) tree, never a live sibling's, by the same
+        /// `ExternalBuildScheduler`-is-minted-one-per-owner argument
+        /// `close_presentation`'s own doc makes. "Dead services" — this
+        /// presentation's OWN focus/IME, already closed by teardown step 2
+        /// before step 3's detach runs — failing closed rather than
+        /// panicking is covered by `presentation.rs`'s
+        /// `text_input_handle_is_bound_to_the_owned_text_input_state`; this
+        /// test does not re-derive that, only the sibling-reach half.
+        #[test]
+        fn dispose_during_teardown_cannot_reach_sibling_or_dead_services() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = install_second_presentation_for_test(&mut realm);
+
+            let handle_slot = Rc::new(RefCell::new(None));
+            let disposed = Rc::new(Cell::new(false));
+            let probe = DisposeProbeView {
+                handle_slot: Rc::clone(&handle_slot),
+                disposed: Rc::clone(&disposed),
+            };
+            // Through the normal `UiRealm::attach_root_widget` auto-wrap
+            // (`FocusRoot`/`VsyncScope`/`GestureArenaScope`), so this probe
+            // is a DESCENDANT of the mounted root, not the root itself —
+            // exercising `WidgetsBinding::detach_root_widget`'s cascading
+            // `remove_subtree` teardown (not just a single-node `remove`),
+            // the same depth a real widget tree has.
+            realm
+                .enter(|realm| realm.attach_root_widget(&probe))
+                .expect("A mounts the dispose probe");
+            let _ = realm.enter(|realm| {
+                realm.draw_frame_entered(BoxConstraints::tight(flui_types::Size::new(
+                    px(20.0),
+                    px(20.0),
+                )))
+            });
+            assert!(
+                handle_slot.borrow().is_some(),
+                "init_state must have captured the rebuild handle"
+            );
+
+            fn b_has_pending_builds(realm: &UiRealm, b_id: PresentationId) -> bool {
+                realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B still installed")
+                    .widgets()
+                    .has_pending_builds()
+            }
+            assert!(
+                !b_has_pending_builds(&realm, b_id),
+                "precondition: B has no pending build before A tears down"
+            );
+
+            assert!(
+                realm.close_presentation(a_id),
+                "A must have been installed and removable"
+            );
+
+            assert!(
+                disposed.get(),
+                "close_presentation's detach_root_widget must have run A's dispose hook"
+            );
+            assert!(
+                !b_has_pending_builds(&realm, b_id),
+                "A's dispose-time schedule() must not have reached B's build inbox"
             );
         }
     }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -785,6 +785,20 @@ impl UiRealm {
         self.presentations.primary().id()
     }
 
+    /// True if `id` names this realm's ONLY currently-hosted presentation.
+    ///
+    /// `runner.rs`'s `RealmTask::ClosePresentation` handling reads this
+    /// BEFORE calling [`Self::close_presentation_entered`]: closing the
+    /// realm's sole presentation would leave the forest empty, and every
+    /// other method on this realm (`widgets()`, `presentation_id()`, a
+    /// future frame pump) assumes `PresentationForest::primary()` always
+    /// resolves — closing the last presentation is closing the REALM, and
+    /// must route there instead (see that match arm's own doc).
+    #[must_use]
+    pub(crate) fn is_sole_presentation(&self, id: PresentationId) -> bool {
+        self.presentations.len() == 1 && self.presentations.get(id).is_some()
+    }
+
     /// This realm's shared cross-tree `GlobalKey` uniqueness domain
     /// (ADR-0043 §1) — for the isolation test suite, which uses it to
     /// assemble a second presentation sharing this realm's exact scope,
@@ -1930,14 +1944,23 @@ impl UiRealm {
     ///
     /// # Contract — six steps, in order
     ///
-    /// 1. **Unregistering this presentation's window mappings from the
+    /// 1. **Unregistering this presentation's window mapping from the
     ///    process-wide `WindowRegistry` is NOT this method's job.**
     ///    `UiRealm` has no access to that registry (`AppRuntime`-owned,
     ///    ADR-0037 §2's single authority) — the caller must have already
-    ///    removed the registry entry before calling this. Today's only
-    ///    caller is `AppRuntime`'s realm teardown (closing a realm's SOLE
-    ///    presentation closes the realm), which already does registry
-    ///    removal first (`apply_uninstall`/`teardown_platform_realm`).
+    ///    removed the registry entry before calling this. The real (and
+    ///    today's only) caller is `dispatch_platform_realm`'s
+    ///    `RealmTask::ClosePresentation` handling in `runner.rs`, NOT
+    ///    `AppRuntime`'s realm-teardown path (`apply_uninstall`/
+    ///    `teardown_platform_realm` close a WHOLE realm and never call this
+    ///    method at all — a realm's own `Drop` closes every remaining
+    ///    presentation directly). That dispatch handling unregisters this
+    ///    exact presentation's own window mapping first when a SIBLING
+    ///    presentation is staying open, and routes to a full realm
+    ///    uninstall instead of calling this method at all when `id` names
+    ///    the realm's only presentation (seeing [`Self::is_sole_presentation`]
+    ///    return `true`) — this method's own contract never has to reason
+    ///    about leaving the forest empty.
     /// 2. IME detach + focus deactivate — [`PresentationState::close`]'s
     ///    first half.
     /// 3. `detach_root_widget` through this exact presentation's own
@@ -4863,47 +4886,130 @@ mod tests {
             });
         }
 
+        /// `PresentationState::new` wires `RealmCapabilities::
+        /// global_key_scope` into `BuildOwner::set_global_key_scope` FIRST —
+        /// before this presentation's own focus/IME wiring, before
+        /// attach/mount (see that constructor's own doc comment). The pin:
+        /// two presentations of ONE realm, sharing that exact scope,
+        /// mounting the IDENTICAL `GlobalKey` must conflict eagerly —
+        /// `GlobalKeyScope`'s cross-owner uniqueness domain — naming both
+        /// owner tags in the panic (`global_key_scope.rs::claim_and_register`'s
+        /// sole conflict branch).
+        ///
+        /// Unpinned before this test: deleting the `set_global_key_scope`
+        /// call from `PresentationState::new` leaves both the flui-view and
+        /// flui-app suites green, because each presentation's `BuildOwner`
+        /// then lazily creates its OWN private, single-tenant scope on first
+        /// use (`claim_and_register`'s `get_or_insert_with` fallback) — the
+        /// two owners never actually share one scope, so mounting the same
+        /// key in both silently succeeds in each instead of conflicting.
+        /// Mutant-verified: removing that one setter call from
+        /// `PresentationState::new` makes this test fail (no panic);
+        /// restoring it makes the eager panic fire again.
+        #[test]
+        #[should_panic(expected = "is already claimed by")]
+        fn duplicate_global_key_across_presentations_panics_eagerly_naming_both_owners() {
+            let mut realm = UiRealm::for_test();
+            let b_id = realm.install_second_presentation_for_test();
+
+            let key = flui_view::GlobalKey::<()>::new();
+            let element_in_a = flui_foundation::ElementId::new(1);
+            let element_in_b = flui_foundation::ElementId::new(2);
+
+            realm.widgets().with_build_owner_mut(|owner| {
+                owner.register_global_key(key.id(), element_in_a);
+            });
+
+            // B shares A's realm's exact GlobalKeyScope
+            // (install_second_presentation_for_test wires it that way, the
+            // same capability-threading order PresentationState::new uses
+            // in production) -- mounting the SAME key here must conflict
+            // eagerly, never silently succeed in a second, private scope.
+            realm
+                .presentation_widgets_for_test(b_id)
+                .with_build_owner_mut(|owner| {
+                    owner.register_global_key(key.id(), element_in_b);
+                });
+        }
+
         /// `UiRealm::apply_hot_reload` must reassemble EVERY presentation in
         /// mount order, not just the primary one.
+        ///
+        /// Oracle: `has_pending_builds()` on EACH presentation's own
+        /// `WidgetsBinding` after `apply_hot_reload` — `perform_reassemble`
+        /// (`BuildOwner::reassemble`) marks every MOUNTED element dirty, so a
+        /// presentation that was actually reassembled reports a pending
+        /// build; one that fan-out skipped does not. A membership check
+        /// alone (does the forest still contain both ids) is vacuous here:
+        /// it stays green even if fan-out silently reverted to
+        /// primary-only, since nothing removes a presentation from the
+        /// forest just because reassemble skipped it. Mutant-verified:
+        /// reverting `UiRealm::apply_hot_reload`'s loop to call
+        /// `self.presentations.primary().apply_hot_reload(tier)` alone (no
+        /// loop over the whole forest) makes this test fail on B's
+        /// `has_pending_builds()` assertion; restoring the loop makes it
+        /// pass again.
         #[test]
         #[cfg(feature = "hot-reload")]
         fn reassemble_fans_out_to_all_presentations_in_mount_order() {
             use flui_hot_reload::HotReloadTier;
 
             let mut realm = UiRealm::for_test();
-            realm.install_second_presentation_for_test();
+            let b_id = realm.install_second_presentation_for_test();
 
-            // Both presentations start with no root attached; `apply_hot_reload`
-            // still calls `perform_reassemble`/`PipelineOwner::reassemble` on
-            // each regardless of whether a root is mounted, so this proves the
-            // fan-out reaches both without asserting on any particular return
-            // value from an unmounted reassemble.
-            let mounted_order: std::cell::RefCell<Vec<flui_foundation::PresentationId>> =
-                std::cell::RefCell::new(Vec::new());
-            for presentation in realm.presentations.iter() {
-                mounted_order.borrow_mut().push(presentation.id());
-            }
-            let expected_order = mounted_order.into_inner();
-            assert_eq!(
-                expected_order.len(),
-                2,
-                "the forest must hold both presentations before reassembling"
+            // Mount independent content on BOTH presentations -- reassemble
+            // has nothing to mark dirty on an empty tree, so the oracle
+            // below needs a real mounted root on each.
+            realm
+                .enter(|realm| realm.attach_root_widget(&flui_widgets::SizedBox::new(10.0, 10.0)))
+                .expect("A mounts");
+            realm
+                .enter(|realm| {
+                    realm
+                        .presentations
+                        .get(b_id)
+                        .expect("B installed")
+                        .widgets()
+                        .attach_root_widget(&flui_widgets::SizedBox::new(20.0, 20.0))
+                })
+                .expect("B mounts");
+
+            // A fresh mount always starts with a pending initial build --
+            // drain both before reassembling, or the oracle below cannot
+            // tell "still pending from mount" apart from "reassemble
+            // actually re-marked it dirty".
+            let constraints = BoxConstraints::tight(flui_types::Size::new(px(50.0), px(50.0)));
+            let _ = realm.draw_frame(constraints);
+            assert!(
+                !realm.widgets().has_pending_builds(),
+                "precondition: A's initial build must be drained before reassembling"
+            );
+            assert!(
+                !realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B installed")
+                    .widgets()
+                    .has_pending_builds(),
+                "precondition: B's initial build must be drained before reassembling"
             );
 
-            // `apply_hot_reload` itself does not report per-presentation
-            // identity, so the oracle here is structural: it must not panic
-            // or skip a presentation, and every presentation's own pipeline
-            // must have run `PipelineOwner::reassemble` — observable via each
-            // presentation's pipeline still being usable afterward (a panic
-            // or an unreachable presentation would fail this test outright).
             let _ = realm.apply_hot_reload(HotReloadTier::HotReload);
 
-            for presentation in realm.presentations.iter() {
-                assert!(
-                    expected_order.contains(&presentation.id()),
-                    "reassemble must not have dropped or skipped a presentation"
-                );
-            }
+            assert!(
+                realm.widgets().has_pending_builds(),
+                "reassemble must mark A's mounted root dirty"
+            );
+            assert!(
+                realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B installed")
+                    .widgets()
+                    .has_pending_builds(),
+                "reassemble must mark B's mounted root dirty too -- fan-out must not skip \
+                 or stop at the primary presentation"
+            );
         }
 
         /// Dropping the realm closes EVERY presentation it hosts, not just

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -45,13 +45,14 @@ use flui_rendering::pipeline::{PipelineCell, PipelineOwner};
 use flui_scheduler::{AppLifecycleState, LocalPostFrameLane, Scheduler, SchedulerPhase};
 use flui_semantics::SemanticsActionRequest;
 use flui_types::{HapticFeedback, Size, geometry::px};
-use flui_view::WidgetsBinding;
+use flui_view::{GlobalKeyRegistryComposite, GlobalKeyScope, WidgetsBinding};
 use flui_widgets::{FocusRoot, GestureArenaScope, NavigatorCommand, VsyncScope};
 use parking_lot::Mutex;
 #[cfg(test)]
 use parking_lot::RwLock;
 
-use super::presentation::PresentationState;
+use super::presentation::{PresentationState, RealmCapabilities};
+use super::presentation_forest::PresentationForest;
 use super::runtime::RealmServices;
 use crate::bindings::RenderingFlutterBinding;
 
@@ -376,32 +377,36 @@ impl UiCommandSender {
 /// access goes through [`UiCommandSender`] only.
 pub(crate) struct UiRealm {
     realm_id: RealmId,
-    /// Owner-local widget framework state. It is deliberately absent from any
-    /// process-global host; every widget-tree operation enters through this
-    /// realm and activates this binding's GlobalKey registry.
-    widgets: WidgetsBinding,
     /// Owner-local callback queue, activated with the realm's other TLS scope.
     local_post_frame: LocalPostFrameLane,
     /// Owner-local interaction callback storage, activated with the realm scope.
     interaction_lane: InteractionLane,
-    /// The current UI-owner presentation domain.
-    ///
-    /// The realm has one presentation until the element tree becomes a forest
-    /// with root-scoped capabilities. The nominal identity exists now so no
-    /// command or resource needs to overload `RealmId` or a native window id.
-    presentation: PresentationState,
-    /// Render tree, layout/paint pipeline coordination, and per-realm
-    /// semantics-enablement fan-out. A direct value, not `RwLock`-wrapped:
-    /// every field `RenderingFlutterBinding` itself owns already carries its
-    /// own interior mutability (`RwLock`/`AtomicBool`), so an outer lock
-    /// here would only ever be uncontended — this realm is the single
-    /// owner-thread-confined caller, never shared across threads. Moved
-    /// here from the retired `AppBinding`: the renderer's per-field
-    /// disposition (render_views, semantics fan-out, first-frame-deferral
-    /// counters) is per-realm state, not a process-wide concern — sharing
-    /// it across realms once `AppRuntime` hosts more than one was exactly
-    /// the hazard this placement designs out.
-    renderer: RenderingFlutterBinding,
+    /// This realm's cross-tree `GlobalKey` uniqueness domain (ADR-0043 §1),
+    /// installed into every presentation's `BuildOwner` at assembly time
+    /// (`PresentationState::new`). Retained here (not just handed off once)
+    /// so a later-installed presentation can share the same scope; read back
+    /// by [`Self::global_key_scope`] for the isolation test suite, which
+    /// bypasses `PresentationForest`'s production ratchet to assemble a
+    /// second presentation sharing this exact scope.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "no production reader until a presentation-install path \
+                      (#555 PR-4/5) needs to hand this same scope to a newly \
+                      assembled presentation; the isolation test suite reads \
+                      it back today via Self::global_key_scope"
+        )
+    )]
+    global_key_scope: GlobalKeyScope,
+    /// The insertion-ordered set of UI-owner presentation domains this realm
+    /// hosts (ADR-0043 §1 — `PresentationForest`). Production topology stays
+    /// exactly one presentation per realm until the forest's own ratchet
+    /// lifts; see [`PresentationForest`]'s doc. Everything that builds, lays
+    /// out, focuses, or presents for one surface lives in and dies with its
+    /// own `PresentationState` inside this forest — the realm owns only
+    /// what is genuinely cross-tree (this struct's other fields).
+    presentations: PresentationForest,
     /// Controller registry for implicit animations (`VsyncScope`-driven).
     /// Moved here from the retired `AppBinding` — an interim home: a later
     /// scheduler-owning change re-homes controllers to `UpdateScheduler`,
@@ -477,7 +482,8 @@ impl std::fmt::Debug for UiRealm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UiRealm")
             .field("realm_id", &self.realm_id)
-            .field("presentation_id", &self.presentation.id())
+            .field("presentation_id", &self.presentations.primary().id())
+            .field("presentation_count", &self.presentations.len())
             .field("pending_commands", &self.rx.len())
             .field(
                 "redraw_pending",
@@ -629,91 +635,81 @@ impl UiRealm {
         needs_redraw: Arc<AtomicBool>,
     ) -> Result<Self, UiRealmError> {
         assert!(capacity > 0, "UiRealm inbox capacity must be non-zero");
-        let (realm_id, presentation_id) = super::runtime::next_identity();
-        let pipeline = PipelineCell::new(PipelineOwner::new());
-        pipeline.with_mut(|owner| owner.set_device_pixel_ratio(device_pixel_ratio));
-        let presentation = PresentationState::new(presentation_id, pipeline, window);
+        let identity = super::runtime::next_identity();
         let services = RealmServices::construct();
         Self::construct(
             capacity,
             wake,
-            realm_id,
-            presentation,
+            identity,
+            window,
+            Some(device_pixel_ratio),
             services,
             needs_redraw,
         )
     }
 
-    /// Builds the realm from already-resolved pieces. Takes `services:
-    /// RealmServices` — a fresh `Scheduler` plus the
-    /// `local_post_frame_lane()`/`async_driver()` handles derived from it —
-    /// built by the caller (`RealmServices::construct`, in `runtime.rs`),
-    /// which is what makes `UiRealm` perform zero `::instance()` calls and
-    /// gives every realm its own scheduler strong root instead of sharing a
-    /// process-global one.
+    /// Builds the realm from already-resolved pieces: identity, the
+    /// presentation's window, and `services: RealmServices` — a fresh
+    /// `Scheduler` plus the `local_post_frame_lane()`/`async_driver()`
+    /// handles derived from it, built by the caller (`RealmServices::
+    /// construct`, in `runtime.rs`), which is what makes `UiRealm` perform
+    /// zero `::instance()` calls and gives every realm its own scheduler
+    /// strong root instead of sharing a process-global one.
+    ///
+    /// `device_pixel_ratio` is `None` only for the `#[cfg(test)]`
+    /// constructors, which never touched it before this function existed
+    /// (`PipelineOwner::new`'s own default applies) — preserved exactly,
+    /// not silently changed to an explicit `1.0`.
+    ///
+    /// Assembles this realm's SOLE (production ratchet: `PresentationForest`
+    /// enforces `len() <= 1`) presentation via [`PresentationState::new`],
+    /// which installs the scope, the realm's shared dispatch handles, and
+    /// this presentation's own focus/IME before anything attaches or mounts
+    /// (ADR-0043 §1).
     fn construct(
         capacity: usize,
         wake: Arc<dyn Fn() + Send + Sync>,
-        realm_id: RealmId,
-        presentation: PresentationState,
+        (realm_id, presentation_id): (RealmId, PresentationId),
+        window: Arc<dyn PlatformWindow>,
+        device_pixel_ratio: Option<f32>,
         services: RealmServices,
         needs_redraw: Arc<AtomicBool>,
     ) -> Result<Self, UiRealmError> {
         let (tx, rx) = bounded(capacity);
         let redraw_pending = Arc::new(AtomicBool::new(false));
-        let presentation_id = presentation.id();
         let RealmServices {
             local_post_frame,
             async_driver,
             scheduler,
         } = services;
         let interaction_lane = InteractionLane::try_new()?;
-        let widgets = WidgetsBinding::with_focus_manager(presentation.focus_manager());
-        widgets.set_pipeline_owner(presentation.pipeline().clone());
-        widgets.with_build_owner_mut(|owner| {
-            owner.set_async_driver(async_driver);
-            owner.set_post_frame_handle(local_post_frame.post_frame_handle());
-            owner.set_interaction_dispatch_handle(interaction_lane.dispatch_handle());
-            owner.set_text_input_handle(presentation.text_input_handle());
-        });
+        let global_key_scope = GlobalKeyScope::new();
 
-        // Renderer, sharing the SAME PipelineOwner as the presentation (one
-        // fact, one place) — moved here from the retired
-        // `AppBinding::new`/`RenderingFlutterBinding::new_with_pipeline` pair.
-        // Wired to THIS realm's own scheduler, never a process-global one.
-        let renderer =
-            RenderingFlutterBinding::new_with_pipeline(presentation.pipeline().clone(), &scheduler);
+        let pipeline = PipelineCell::new(PipelineOwner::new());
+        if let Some(device_pixel_ratio) = device_pixel_ratio {
+            pipeline.with_mut(|owner| owner.set_device_pixel_ratio(device_pixel_ratio));
+        }
 
-        // Idle-wake wiring: a dirty mark (mark_needs_layout / mark_needs_paint)
-        // fires this callback so a quiescent event loop produces the frame —
-        // moved verbatim from `AppBinding::new`. Reentrancy-safe: the callback
-        // fires while the CALLER holds the pipeline cell checked out, and
-        // `wake` only touches `Send + Sync` runtime-level state — never this
-        // realm's own `widgets`/`renderer`.
-        let visual_wake = Arc::clone(&wake);
-        presentation
-            .pipeline()
-            .with_mut(|owner| owner.set_on_need_visual_update(move || visual_wake()));
-
-        // Semantics-enabled fan-out -> this presentation's own `SemanticsHost`:
-        // now that the renderer and the presentation are co-located on one
-        // `UiRealm`, the listener can capture a cheap `Arc<AtomicBool>`
-        // clone of the host's enablement flag directly, instead of the flag
-        // having nowhere to route to.
-        let semantics_flag = presentation
-            .semantics_host()
-            .platform_semantics_enabled_handle();
-        renderer.add_semantics_enabled_listener(Arc::new(move |enabled| {
-            semantics_flag.store(enabled, Ordering::Relaxed);
-        }));
+        let presentation = PresentationState::new(
+            presentation_id,
+            pipeline,
+            window,
+            RealmCapabilities {
+                global_key_scope: global_key_scope.clone(),
+                async_driver,
+                post_frame_handle: local_post_frame.post_frame_handle(),
+                interaction_dispatch_handle: interaction_lane.dispatch_handle(),
+                scheduler: &scheduler,
+                wake: Arc::clone(&wake),
+            },
+        );
 
         Ok(Self {
             realm_id,
-            widgets,
             local_post_frame,
             interaction_lane,
-            presentation,
-            renderer,
+            global_key_scope,
+            presentations: PresentationForest::single(presentation),
             vsync_slot: Mutex::new(Vsync::new()),
             start: web_time::Instant::now(),
             needs_redraw,
@@ -743,10 +739,8 @@ impl UiRealm {
     pub(crate) fn for_test_with_text_input(
         platform_text_input: Option<Arc<dyn PlatformTextInput>>,
     ) -> Self {
-        let (realm_id, presentation_id) = super::runtime::next_identity();
-        let pipeline = PipelineCell::new(PipelineOwner::new());
-        let presentation =
-            PresentationState::new_for_test(presentation_id, pipeline, platform_text_input);
+        let identity = super::runtime::next_identity();
+        let window = super::presentation::test_platform_window(platform_text_input);
         // The no-op `wake` still must set THIS SAME `needs_redraw` flag —
         // in production the two are the same fact through AppRuntime's
         // `frame_wake_callback` (see `Self::needs_redraw`'s field doc); a
@@ -761,8 +755,9 @@ impl UiRealm {
         Self::construct(
             DEFAULT_COMMAND_CAPACITY,
             wake,
-            realm_id,
-            presentation,
+            identity,
+            window,
+            None,
             RealmServices::construct(),
             needs_redraw,
         )
@@ -770,10 +765,11 @@ impl UiRealm {
     }
 
     /// Test-only: a clone of this realm's exact `PipelineCell` — the same
-    /// one its `renderer` and `widgets` share (one fact, one place).
+    /// one its primary presentation's `renderer` and `widgets` share (one
+    /// fact, one place).
     #[cfg(test)]
     pub(crate) fn pipeline_for_test(&self) -> PipelineCell {
-        self.presentation.pipeline().clone()
+        self.presentations.primary().pipeline().clone()
     }
 
     /// This incarnation's generational realm identity.
@@ -785,7 +781,24 @@ impl UiRealm {
     /// Current presentation incarnation.
     #[must_use]
     pub fn presentation_id(&self) -> PresentationId {
-        self.presentation.id()
+        self.presentations.primary().id()
+    }
+
+    /// This realm's shared cross-tree `GlobalKey` uniqueness domain
+    /// (ADR-0043 §1) — for the isolation test suite, which uses it to
+    /// assemble a second presentation sharing this realm's exact scope,
+    /// bypassing `PresentationForest`'s production ratchet deliberately.
+    #[cfg(test)]
+    pub(crate) fn global_key_scope(&self) -> &GlobalKeyScope {
+        &self.global_key_scope
+    }
+
+    /// Number of presentations this realm currently hosts — for the
+    /// isolation test suite (production topology is always exactly one until
+    /// `PresentationForest`'s ratchet lifts).
+    #[cfg(test)]
+    pub(crate) fn presentation_count(&self) -> usize {
+        self.presentations.len()
     }
 
     /// This realm's own scheduler — the strong root. `runner.rs`'s
@@ -802,7 +815,7 @@ impl UiRealm {
     /// checks at the physical owner ([`Self::handle_input_entered`]).
     #[must_use]
     pub(crate) fn presentation_lifecycle(&self) -> super::presentation::PresentationLifecycle {
-        self.presentation.lifecycle()
+        self.presentations.primary().lifecycle()
     }
 
     /// A new cross-thread sender into this runtime's inbox.
@@ -822,20 +835,29 @@ impl UiRealm {
 
     /// Enter this realm's owner scope.
     ///
-    /// The GlobalKey registry is active for the entire dynamic extent of `f`,
-    /// including lifecycle/build callbacks. Nested entry is stack-shaped and
-    /// panic unwinding restores the previously active realm.
+    /// A composite `GlobalKey` registry spanning every presentation this
+    /// realm hosts (ADR-0043 §1 RULING 1b) is active for the entire dynamic
+    /// extent of `f`, including lifecycle/build callbacks — whole-frame,
+    /// exactly as a single presentation's own registry always was: post-frame
+    /// callbacks, command drains, deferred arena resolutions, and hot-reload
+    /// reassemble all resolve keys realm-wide regardless of which
+    /// presentation's own segment is running. Nested entry is stack-shaped
+    /// and panic unwinding restores the previously active realm.
     pub(crate) fn enter<R>(&self, f: impl FnOnce(&Self) -> R) -> R {
         self.local_post_frame.enter(|| {
-            self.interaction_lane
-                .enter(|| self.widgets.with_global_key_registry(|| f(self)))
+            self.interaction_lane.enter(|| {
+                let composite = GlobalKeyRegistryComposite::assemble(
+                    self.presentations.iter().map(PresentationState::widgets),
+                );
+                composite.enter(|| f(self))
+            })
         })
     }
 
     /// Owner-local widgets binding. Crate-private so callers cannot bypass the
     /// guarded realm entry boundary.
     pub(crate) fn widgets(&self) -> &WidgetsBinding {
-        &self.widgets
+        self.presentations.primary().widgets()
     }
 
     /// Gesture state for the realm's current single presentation.
@@ -843,25 +865,25 @@ impl UiRealm {
     /// Crate-private so platform input can only reach it through the entered
     /// realm dispatch path rather than exposing a second public owner seam.
     pub(crate) fn gestures(&self) -> &GestureBinding {
-        self.presentation.gestures()
+        self.presentations.primary().gestures()
     }
 
     /// Focus state for the realm's current presentation.
     #[must_use]
     pub(crate) fn focus_manager(&self) -> Rc<FocusManager> {
-        self.presentation.focus_manager()
+        self.presentations.primary().focus_manager()
     }
 
     /// Text-input state for the realm's current single presentation.
     pub(crate) fn text_input(&self) -> &TextInputOwner {
-        self.presentation.text_input()
+        self.presentations.primary().text_input()
     }
 
     /// Weak text-input capability for this exact presentation.
     #[must_use]
     #[cfg(test)]
     pub(crate) fn text_input_handle(&self) -> flui_interaction::TextInputHandle {
-        self.presentation.text_input_handle()
+        self.presentations.primary().text_input_handle()
     }
 
     /// Keep presentation-owned resources aligned with the synthesized
@@ -869,22 +891,38 @@ impl UiRealm {
     pub(crate) fn handle_presentation_lifecycle(&self, state: AppLifecycleState) {
         match state {
             AppLifecycleState::Resumed | AppLifecycleState::Inactive => {
-                self.presentation.resume();
+                self.presentations.primary().resume();
             }
             AppLifecycleState::Hidden | AppLifecycleState::Paused => {
-                self.presentation.suspend();
+                self.presentations.primary().suspend();
             }
             AppLifecycleState::Detached => {
-                self.presentation.close();
+                self.presentations.primary().close();
             }
         }
     }
 
-    /// Reassemble this realm's element tree and exact presentation pipeline.
+    /// Reassemble EVERY presentation this realm hosts, in mount order —
+    /// under the whole-frame composite `enter()` already activates, so a
+    /// key resolved mid-fan-out still finds any presentation's tree, not
+    /// just the one currently reassembling.
+    ///
+    /// Deliberately does not short-circuit on the first presentation that
+    /// reports a change: every presentation must reassemble regardless of
+    /// what its predecessors reported, or a hot reload would silently skip
+    /// later-mounted presentations whenever an earlier one happened to
+    /// report no change. Returns whether ANY presentation requires a
+    /// redraw.
     #[cfg(feature = "hot-reload")]
     #[must_use]
     pub(crate) fn apply_hot_reload(&self, tier: flui_hot_reload::HotReloadTier) -> bool {
-        self.presentation.apply_hot_reload(&self.widgets, tier)
+        let mut needs_redraw = false;
+        for presentation in self.presentations.iter() {
+            if presentation.apply_hot_reload(tier) {
+                needs_redraw = true;
+            }
+        }
+        needs_redraw
     }
 
     /// Apply a hot reload at the given tier (Flutter parity entry point),
@@ -919,7 +957,7 @@ impl UiRealm {
         )
     )]
     pub(crate) fn renderer(&self) -> &RenderingFlutterBinding {
-        &self.renderer
+        self.presentations.primary().renderer()
     }
 
     /// Re-dirty this realm's root so the next frame actually produces
@@ -932,7 +970,12 @@ impl UiRealm {
     /// the same explicit re-dirty `allow_first_frame` needs after a
     /// deferral lifts.
     pub(crate) fn redirty_root_for_frames_reenable(&self) {
-        crate::bindings::redirty_pipeline_root(self.renderer.root_pipeline_owner());
+        crate::bindings::redirty_pipeline_root(
+            self.presentations
+                .primary()
+                .renderer()
+                .root_pipeline_owner(),
+        );
     }
 
     /// A clone of the shared controller registry for implicit animations.
@@ -1096,7 +1139,7 @@ impl UiRealm {
         )
     )]
     pub(crate) fn defer_first_frame(&self) {
-        self.renderer.defer_first_frame();
+        self.presentations.primary().renderer().defer_first_frame();
     }
 
     /// See [`RenderingFlutterBinding::allow_first_frame`].
@@ -1108,13 +1151,16 @@ impl UiRealm {
         )
     )]
     pub(crate) fn allow_first_frame(&self) {
-        self.renderer.allow_first_frame();
+        self.presentations.primary().renderer().allow_first_frame();
     }
 
     /// See [`RenderingFlutterBinding::send_frames_to_engine`] (via the
     /// `RendererBinding` trait).
     pub(crate) fn send_frames_to_engine(&self) -> bool {
-        self.renderer.send_frames_to_engine()
+        self.presentations
+            .primary()
+            .renderer()
+            .send_frames_to_engine()
     }
 
     /// Total frames rendered successfully by this presentation.
@@ -1122,13 +1168,13 @@ impl UiRealm {
         not(test),
         expect(
             dead_code,
-            reason = "draw_frame_entered reads self.presentation.frames_rendered() \
+            reason = "draw_frame_entered reads self.presentations.primary().frames_rendered() \
                       directly for the frame-number computation, not through \
                       this wrapper; kept for tests and future external callers"
         )
     )]
     pub(crate) fn frames_rendered(&self) -> u64 {
-        self.presentation.frames_rendered()
+        self.presentations.primary().frames_rendered()
     }
 
     /// Frames dropped due to surface errors on this presentation.
@@ -1138,13 +1184,15 @@ impl UiRealm {
                   forwards PresentationState::frames_dropped, also uncalled"
     )]
     pub(crate) fn frames_dropped(&self) -> u64 {
-        self.presentation.frames_dropped()
+        self.presentations.primary().frames_dropped()
     }
 
     /// Turn this presentation's performance overlay on or off. See the
     /// retired `AppBinding::set_performance_overlay`'s doc.
     pub(crate) fn set_performance_overlay(&self, enabled: bool) {
-        self.presentation.set_performance_overlay(enabled);
+        self.presentations
+            .primary()
+            .set_performance_overlay(enabled);
     }
 
     /// Perform haptic feedback on this presentation's window. See the
@@ -1156,13 +1204,17 @@ impl UiRealm {
                   PresentationState::perform_haptic_feedback directly)"
     )]
     pub(crate) fn perform_haptic_feedback(&self, feedback: HapticFeedback) {
-        self.presentation.perform_haptic_feedback(feedback);
+        self.presentations
+            .primary()
+            .perform_haptic_feedback(feedback);
     }
 
     /// Apply a new device pixel ratio to this realm's render pipeline (the
     /// resize path; construction applies the initial ratio directly).
     pub(crate) fn set_device_pixel_ratio(&self, device_pixel_ratio: f32) {
-        self.renderer
+        self.presentations
+            .primary()
+            .renderer()
             .root_pipeline_owner()
             .with_mut(|owner| owner.set_device_pixel_ratio(device_pixel_ratio));
     }
@@ -1171,11 +1223,13 @@ impl UiRealm {
     /// motion/deadlines, or a dirty render node. The runner's wake gate
     /// (`needs_redraw() || has_pending_work()`) reads this every frame.
     pub(crate) fn has_pending_work(&self) -> bool {
-        self.widgets.has_pending_builds()
+        self.presentations.primary().widgets().has_pending_builds()
             || self.gestures().has_pending_motion()
             || self.gestures().has_pending_deadlines()
             || self
-                .renderer
+                .presentations
+                .primary()
+                .renderer()
                 .root_pipeline_owner()
                 .with(PipelineOwner::has_dirty_nodes)
     }
@@ -1236,7 +1290,10 @@ impl UiRealm {
         let focused = FocusRoot::new(view.clone());
         let animated = VsyncScope::new(self.vsync(), focused);
         let wrapped = GestureArenaScope::new(self.gestures().arena().clone(), animated);
-        self.widgets.attach_root_widget(&wrapped)?;
+        self.presentations
+            .primary()
+            .widgets()
+            .attach_root_widget(&wrapped)?;
         self.request_redraw();
         tracing::debug!("Root widget attached");
         Ok(())
@@ -1278,7 +1335,9 @@ impl UiRealm {
         let focused = FocusRoot::new(view.clone());
         let animated = VsyncScope::new(self.vsync(), focused);
         let wrapped = GestureArenaScope::new(self.gestures().arena().clone(), animated);
-        self.widgets
+        self.presentations
+            .primary()
+            .widgets()
             .attach_root_widget_with_size(&wrapped, width, height)?;
         self.request_redraw();
         tracing::debug!(width, height, "Root widget attached (sized)");
@@ -1351,14 +1410,18 @@ impl UiRealm {
         // typestate-driven orchestrator.
         let mut pipeline_errored = false;
         let (layer_tree, link_registry) = {
-            self.renderer
+            self.presentations
+                .primary()
+                .renderer()
                 .root_pipeline_owner()
                 .with_mut(|owner| owner.set_root_constraints(Some(constraints)));
             let result = self
                 .widgets()
-                .run_frame_with_layout_builders(self.presentation.pipeline());
+                .run_frame_with_layout_builders(self.presentations.primary().pipeline());
             let link_registry = self
-                .renderer
+                .presentations
+                .primary()
+                .renderer()
                 .root_pipeline_owner()
                 .with_mut(PipelineOwner::take_link_registry);
             match result {
@@ -1375,15 +1438,16 @@ impl UiRealm {
         // requests accumulated by `run_frame`'s layout pass.
         {
             let w = self.widgets();
-            w.service_child_requests(self.presentation.pipeline());
+            w.service_child_requests(self.presentations.primary().pipeline());
         }
 
         // Phase 4: Create Scene from LayerTree
         let size = constraints.constrain(Size::ZERO);
-        let frame_number = self.presentation.frames_rendered() + 1;
+        let frame_number = self.presentations.primary().frames_rendered() + 1;
 
         if let Some(mut layer_tree) = layer_tree {
-            self.presentation
+            self.presentations
+                .primary()
                 .attach_performance_overlay(&mut layer_tree);
 
             let root = layer_tree.root();
@@ -1434,7 +1498,9 @@ impl UiRealm {
 
         let (width, height) = renderer.size();
         let dpr = self
-            .renderer
+            .presentations
+            .primary()
+            .renderer()
             .root_pipeline_owner()
             .with(PipelineOwner::device_pixel_ratio);
         let constraints =
@@ -1445,14 +1511,20 @@ impl UiRealm {
             .mouse_tracker()
             .update_all_devices(|position| {
                 let mut result = flui_interaction::routing::HitTestResult::new();
-                self.renderer.hit_test_in_view(&mut result, position, 0);
+                self.presentations
+                    .primary()
+                    .renderer()
+                    .hit_test_in_view(&mut result, position, 0);
                 result
             });
 
         let send_to_engine = self.send_frames_to_engine();
         let errored = matches!(outcome, FramePaintOutcome::Errored);
         if send_to_engine && !errored {
-            self.renderer.mark_first_frame_sent();
+            self.presentations
+                .primary()
+                .renderer()
+                .mark_first_frame_sent();
         }
 
         let mut presented = false;
@@ -1466,10 +1538,10 @@ impl UiRealm {
                 Ok(did_present) => {
                     presented = did_present;
                     if did_present {
-                        self.presentation.record_frame_rendered();
+                        self.presentations.primary().record_frame_rendered();
                         tracing::trace!(
                             frame = scene.frame_number(),
-                            total = self.presentation.frames_rendered(),
+                            total = self.presentations.primary().frames_rendered(),
                             "Frame rendered successfully"
                         );
                     } else {
@@ -1480,24 +1552,24 @@ impl UiRealm {
                     }
                 }
                 Err(EngineError::SurfaceLost) => {
-                    self.presentation.record_frame_dropped();
+                    self.presentations.primary().record_frame_dropped();
                     retry_needed = true;
                     tracing::debug!("Surface lost; frame dropped — retry armed via wake_frame()");
                 }
                 Err(EngineError::DeviceLost) => {
-                    self.presentation.record_frame_dropped();
+                    self.presentations.primary().record_frame_dropped();
                     tracing::warn!(
                         "GPU device lost — recovery will be attempted by the platform runner"
                     );
                 }
                 Err(EngineError::SurfaceValidation) => {
-                    self.presentation.record_frame_dropped();
+                    self.presentations.primary().record_frame_dropped();
                     tracing::error!(
                         "Surface validation error — surface misconfig; external reconfigure required"
                     );
                 }
                 Err(e) => {
-                    self.presentation.record_frame_dropped();
+                    self.presentations.primary().record_frame_dropped();
                     tracing::error!(error = ?e, "Render error (non-recoverable this frame)");
                 }
             }
@@ -1550,7 +1622,11 @@ impl UiRealm {
                         .handle_pointer_event(&pointer_event, |position| {
                             let mut result = flui_interaction::routing::HitTestResult::new();
                             let offset = flui_types::Offset::new(position.dx, position.dy);
-                            self.renderer.hit_test_in_view(&mut result, offset, 0);
+                            self.presentations.primary().renderer().hit_test_in_view(
+                                &mut result,
+                                offset,
+                                0,
+                            );
                             if !result.is_empty() {
                                 tracing::debug!(hits = result.len(), "Hit test found targets");
                             }
@@ -1627,7 +1703,7 @@ impl UiRealm {
             match command {
                 #[cfg(feature = "hot-reload")]
                 UiCommand::HotReload(tier) => {
-                    if self.presentation.apply_hot_reload(&self.widgets, tier) {
+                    if self.presentations.primary().apply_hot_reload(tier) {
                         self.redraw_pending.store(true, Ordering::Release);
                     }
                     report.invoked += 1;
@@ -1636,17 +1712,21 @@ impl UiRealm {
                     presentation_id,
                     request,
                 } => {
-                    if presentation_id != self.presentation.id() {
+                    if presentation_id != self.presentations.primary().id() {
                         tracing::trace!(
                             { flui_foundation::diagnostics::PRESENTATION_ID } =
-                                self.presentation.id().as_u64(),
+                                self.presentations.primary().id().as_u64(),
                             stamped_presentation_id = presentation_id.as_u64(),
                             "dropping semantics action stamped for a stale presentation incarnation"
                         );
                         report.dropped_stale += 1;
                         continue;
                     }
-                    match self.presentation.dispatch_semantics_action(request) {
+                    match self
+                        .presentations
+                        .primary()
+                        .dispatch_semantics_action(request)
+                    {
                         Ok(()) => {
                             report.invoked += 1;
                         }
@@ -1656,7 +1736,7 @@ impl UiRealm {
                             // the latest semantics update.
                             tracing::trace!(
                                 { flui_foundation::diagnostics::PRESENTATION_ID } =
-                                    self.presentation.id().as_u64(),
+                                    self.presentations.primary().id().as_u64(),
                                 ?error,
                                 "dropping semantics action against a stale snapshot"
                             );
@@ -1684,7 +1764,13 @@ impl UiRealm {
 
 impl Drop for UiRealm {
     fn drop(&mut self) {
-        self.presentation.close();
+        // Every presentation this realm hosts closes when the realm drops —
+        // production topology is exactly one until the forest's ratchet
+        // lifts, but this loop is already correct for N: nothing here
+        // assumes `len() == 1`.
+        for presentation in self.presentations.iter() {
+            presentation.close();
+        }
     }
 }
 
@@ -1740,6 +1826,35 @@ mod tests {
             1.0,
             Arc::new(AtomicBool::new(false)),
         )
+    }
+
+    /// Assemble and install a second presentation sharing `realm`'s exact
+    /// `GlobalKeyScope` and realm-level dispatch handles.
+    ///
+    /// Bypasses `PresentationForest`'s production ratchet
+    /// (`PresentationForest::push_for_test`) deliberately — this is the
+    /// isolation-suite seam #555 PR-3's plan names: a genuine
+    /// multi-presentation realm ahead of the addressed routing (#555
+    /// PR-4/5) that makes doing so safe in production.
+    fn install_second_presentation_for_test(realm: &mut UiRealm) -> PresentationId {
+        let (_, presentation_id) = crate::app::runtime::next_identity();
+        let pipeline = PipelineCell::new(PipelineOwner::new());
+        let window = crate::app::presentation::test_platform_window(None);
+        let presentation = PresentationState::new(
+            presentation_id,
+            pipeline,
+            window,
+            RealmCapabilities {
+                global_key_scope: realm.global_key_scope().clone(),
+                async_driver: realm.scheduler.async_driver().clone(),
+                post_frame_handle: realm.local_post_frame.post_frame_handle(),
+                interaction_dispatch_handle: realm.interaction_lane.dispatch_handle(),
+                scheduler: &realm.scheduler,
+                wake: Arc::clone(&realm.wake),
+            },
+        );
+        realm.presentations.push_for_test(presentation);
+        presentation_id
     }
 
     #[test]
@@ -4437,6 +4552,154 @@ mod tests {
                 )),
                 Err(flui_interaction::TextInputError::Unsupported)
             );
+        }
+    }
+
+    // ========================================================================
+    // Presentation forest — isolation suite (ADR-0043 §1, #555 PR-3)
+    //
+    // Production topology is exactly one presentation per realm
+    // (`PresentationForest`'s `install` ratchet); these tests bypass it via
+    // `push_for_test` to exercise the composite `GlobalKey` registry and
+    // hot-reload fan-out against a genuine N=2 forest.
+    // ========================================================================
+    mod presentation_forest_isolation {
+        use super::*;
+
+        #[test]
+        fn push_for_test_bypasses_the_production_ratchet() {
+            let mut realm = UiRealm::for_test();
+            assert_eq!(realm.presentation_count(), 1);
+
+            install_second_presentation_for_test(&mut realm);
+
+            assert_eq!(
+                realm.presentation_count(),
+                2,
+                "the isolation suite's push_for_test seam must bypass \
+                 PresentationForest::install's len()<=1 ratchet"
+            );
+        }
+
+        /// The realm composite `enter()` activates (ADR-0043 §1 RULING 1b)
+        /// must resolve a `GlobalKey` registered in EITHER presentation's own
+        /// tree, not just the primary one — the correctness property
+        /// `GlobalKeyRegistryComposite` exists for.
+        #[test]
+        fn composite_registry_resolves_keys_registered_in_either_presentation() {
+            let mut realm = UiRealm::for_test();
+            let second_id = install_second_presentation_for_test(&mut realm);
+
+            let key_in_primary = flui_view::GlobalKey::<()>::new();
+            let element_in_primary = flui_foundation::ElementId::new(1);
+            let key_in_second = flui_view::GlobalKey::<()>::new();
+            let element_in_second = flui_foundation::ElementId::new(1); // deliberately the SAME numeral
+
+            realm.enter(|realm| {
+                realm
+                    .presentations
+                    .primary()
+                    .widgets()
+                    .with_build_owner_mut(|owner| {
+                        owner.register_global_key(key_in_primary.id(), element_in_primary);
+                    });
+                let second = realm
+                    .presentations
+                    .get(second_id)
+                    .expect("second presentation installed");
+                second.widgets().with_build_owner_mut(|owner| {
+                    owner.register_global_key(key_in_second.id(), element_in_second);
+                });
+
+                assert_eq!(
+                    key_in_primary.current_element(),
+                    Some(element_in_primary),
+                    "composite must resolve a key registered in the primary presentation"
+                );
+                assert_eq!(
+                    key_in_second.current_element(),
+                    Some(element_in_second),
+                    "composite must resolve a key registered in the second \
+                     presentation, even though both trees use the same raw \
+                     ElementId numeral"
+                );
+            });
+        }
+
+        /// `UiRealm::apply_hot_reload` must reassemble EVERY presentation in
+        /// mount order, not just the primary one.
+        #[test]
+        #[cfg(feature = "hot-reload")]
+        fn reassemble_fans_out_to_all_presentations_in_mount_order() {
+            use flui_hot_reload::HotReloadTier;
+
+            let mut realm = UiRealm::for_test();
+            install_second_presentation_for_test(&mut realm);
+
+            // Both presentations start with no root attached; `apply_hot_reload`
+            // still calls `perform_reassemble`/`PipelineOwner::reassemble` on
+            // each regardless of whether a root is mounted, so this proves the
+            // fan-out reaches both without asserting on any particular return
+            // value from an unmounted reassemble.
+            let mounted_order: std::cell::RefCell<Vec<flui_foundation::PresentationId>> =
+                std::cell::RefCell::new(Vec::new());
+            for presentation in realm.presentations.iter() {
+                mounted_order.borrow_mut().push(presentation.id());
+            }
+            let expected_order = mounted_order.into_inner();
+            assert_eq!(
+                expected_order.len(),
+                2,
+                "the forest must hold both presentations before reassembling"
+            );
+
+            // `apply_hot_reload` itself does not report per-presentation
+            // identity, so the oracle here is structural: it must not panic
+            // or skip a presentation, and every presentation's own pipeline
+            // must have run `PipelineOwner::reassemble` — observable via each
+            // presentation's pipeline still being usable afterward (a panic
+            // or an unreachable presentation would fail this test outright).
+            let _ = realm.apply_hot_reload(HotReloadTier::HotReload);
+
+            for presentation in realm.presentations.iter() {
+                assert!(
+                    expected_order.contains(&presentation.id()),
+                    "reassemble must not have dropped or skipped a presentation"
+                );
+            }
+        }
+
+        /// Dropping the realm closes EVERY presentation it hosts, not just
+        /// the primary one.
+        #[test]
+        fn dropping_the_realm_closes_every_presentation() {
+            let mut realm = UiRealm::for_test();
+            install_second_presentation_for_test(&mut realm);
+
+            let lifecycles_before: Vec<_> = realm
+                .presentations
+                .iter()
+                .map(crate::app::presentation::PresentationState::lifecycle)
+                .collect();
+            assert!(
+                lifecycles_before.iter().all(|l| {
+                    *l == crate::app::presentation::PresentationLifecycle::SurfaceAttached
+                }),
+                "both presentations must start attached"
+            );
+
+            drop(realm);
+            // Both presentations' own Drop impls ran as part of the realm's
+            // Drop (each PresentationState transitions to Closed on its own
+            // drop -- see PresentationState::close/Drop); nothing left to
+            // assert on here beyond "this did not panic", since the values
+            // themselves are gone. The meaningful oracle is
+            // `closing_presentation_a_leaves_sibling_layer_tree_identical`-
+            // style structural isolation, which the single-presentation
+            // production path already covers via existing render-frame
+            // tests; a genuine N>1 close-one-keep-one-running scenario needs
+            // the addressed teardown path #555 PR-4/5 adds and is out of
+            // this slice's scope.
         }
     }
 }

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -207,6 +207,31 @@ impl WindowRegistry {
         removed
     }
 
+    /// Removes and returns every entry mapped to this EXACT
+    /// `(RealmId, PresentationId)` address — never a sibling presentation
+    /// within the same realm, and never every window the realm owns (see
+    /// [`Self::remove_realm`] for that whole-realm removal). This is step 1
+    /// of closing a single presentation out of a realm that keeps hosting
+    /// others: the closed presentation's own window mapping must stop
+    /// resolving to it before the presentation itself goes away, or a stale
+    /// platform event delivered to that exact window would still resolve to
+    /// a dead presentation id instead of being refused.
+    pub(crate) fn remove_presentation(
+        &mut self,
+        address: PresentationAddress,
+    ) -> Vec<(WindowId, PresentationAddress)> {
+        let mut removed = Vec::new();
+        self.entries.retain(|(id, entry_address)| {
+            if *entry_address == address {
+                removed.push((*id, *entry_address));
+                false
+            } else {
+                true
+            }
+        });
+        removed
+    }
+
     /// The number of window mappings currently held. Test/introspection
     /// only — production code never needs to enumerate the registry, only
     /// resolve or remove by identity.

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -222,6 +222,22 @@ impl RenderingFlutterBinding {
         binding
     }
 
+    /// Test/standalone construction sharing a CALLER-supplied
+    /// [`PipelineCell`] rather than building a fresh one.
+    ///
+    /// Same self-owned-scheduler shape as [`Self::new`] (see
+    /// `standalone_scheduler`'s field doc for the dead-weak-reference bug
+    /// this avoids) — for `PresentationState::new_for_test`, which must
+    /// share its exact caller-supplied pipeline with its renderer but has no
+    /// realm above it to supply a live `&Scheduler`.
+    #[cfg(test)]
+    pub(crate) fn new_for_test_with_pipeline(pipeline_owner: PipelineCell) -> Self {
+        let scheduler = Scheduler::new();
+        let mut binding = Self::new_with_pipeline(pipeline_owner, &scheduler);
+        binding.standalone_scheduler = Some(scheduler);
+        binding
+    }
+
     /// Creates a new rendering binding with a shared PipelineOwner, wired to
     /// `scheduler` for its (rare) device-metrics force-frame path.
     ///

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -870,18 +870,28 @@ impl WidgetsBinding {
 
     /// Detach the root widget.
     ///
-    /// This clears the element tree.
+    /// This clears the element tree — the WHOLE tree, not just the root
+    /// node: `ElementTree::remove_subtree` (not the single-node `remove`)
+    /// walks every descendant deepest-first, running each one's own
+    /// `unmount`/`State::dispose` hook, exactly as a real permanent removal
+    /// must. A plain `remove` would only unmount the root's own element
+    /// (in practice the internal `RootRenderView` wrapper every attached
+    /// view is mounted under — see [`Self::attach_root_widget`]'s doc) and
+    /// silently orphan everything beneath it: no descendant's `dispose`
+    /// would ever run, leaking subscriptions/listeners/timers for the life
+    /// of this binding.
     pub fn detach_root_widget(&self) {
         let mut inner = self.inner.write();
 
         if let Some(root_id) = inner.root_element.take() {
-            // Remove root element (this clears the tree since it's the root)
+            // Remove the whole subtree (this clears the tree since root_id
+            // is its root).
             let WidgetsBindingInner {
                 ref mut build_owner,
                 ref mut element_tree,
                 ..
             } = *inner;
-            let _ = element_tree.remove(root_id, &mut build_owner.element_owner_mut());
+            element_tree.remove_subtree(root_id, &mut build_owner.element_owner_mut());
             tracing::debug!(?root_id, "Root widget detached");
         }
     }
@@ -2003,6 +2013,95 @@ mod tests {
 
         binding.detach_root_widget();
         assert!(binding.root_element().is_none());
+    }
+
+    #[derive(Clone)]
+    struct DisposeMarkerView {
+        disposed: Arc<parking_lot::Mutex<bool>>,
+    }
+
+    struct DisposeMarkerState {
+        disposed: Arc<parking_lot::Mutex<bool>>,
+    }
+
+    impl crate::StatefulView for DisposeMarkerView {
+        type State = DisposeMarkerState;
+
+        fn create_state(&self) -> Self::State {
+            DisposeMarkerState {
+                disposed: Arc::clone(&self.disposed),
+            }
+        }
+    }
+
+    impl crate::ViewState<DisposeMarkerView> for DisposeMarkerState {
+        fn build(
+            &self,
+            _view: &DisposeMarkerView,
+            _ctx: &dyn crate::BuildContext,
+        ) -> impl IntoView {
+            LeafView
+        }
+
+        fn dispose(&mut self) {
+            *self.disposed.lock() = true;
+        }
+    }
+
+    impl View for DisposeMarkerView {
+        fn create_element(&self) -> crate::element::ElementKind {
+            crate::element::ElementKind::stateful(self)
+        }
+    }
+
+    /// `detach_root_widget` must cascade through the WHOLE tree, not just
+    /// unmount the root's own node: the attached root is always wrapped in
+    /// an internal `RootRenderView` (see this method's own doc), so even a
+    /// single-widget tree is already two elements deep, and a real tree is
+    /// deeper still (this one plants the dispose-observing element as a
+    /// stateful GRANDCHILD of the reconciled `ParentView`/`LeafView` shape
+    /// used elsewhere in this file). A single-node `remove` would only ever
+    /// unmount `RootRenderView`'s own element and silently leak every
+    /// descendant's `State::dispose` — this test is the regression guard for
+    /// that exact class of bug.
+    #[test]
+    fn detach_root_widget_disposes_every_descendant_not_just_the_root() {
+        #[derive(Clone)]
+        struct ParentOfDisposeMarker {
+            child: DisposeMarkerView,
+        }
+
+        impl crate::StatelessView for ParentOfDisposeMarker {
+            fn build(&self, _ctx: &dyn crate::BuildContext) -> impl IntoView {
+                self.child.clone()
+            }
+        }
+
+        impl View for ParentOfDisposeMarker {
+            fn create_element(&self) -> crate::element::ElementKind {
+                crate::element::ElementKind::stateless(self)
+            }
+        }
+
+        let binding = WidgetsBinding::new();
+        let disposed = Arc::new(parking_lot::Mutex::new(false));
+        let view = ParentOfDisposeMarker {
+            child: DisposeMarkerView {
+                disposed: Arc::clone(&disposed),
+            },
+        };
+
+        binding.attach_root_widget(&view).expect("attach succeeds");
+        binding.draw_frame();
+        assert!(!*disposed.lock(), "precondition: nothing has torn down yet");
+
+        binding.detach_root_widget();
+
+        assert!(
+            *disposed.lock(),
+            "detach_root_widget must run State::dispose for every descendant, \
+             not just unmount the (internal RootRenderView-wrapped) root node"
+        );
     }
 
     #[test]

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -496,8 +496,7 @@ pub enum AttachError {
 }
 
 /// A realm-level `GlobalKey` registry spanning several [`WidgetsBinding`]s —
-/// one per presentation sharing a realm's `GlobalKeyScope` (ADR-0043 §1
-/// RULING 1b).
+/// one per presentation sharing a realm's `GlobalKeyScope` (ADR-0043 §1).
 ///
 /// Assembled once over the presentations installed at the time
 /// [`Self::assemble`] runs, tried in the given order (a realm's mount

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -495,6 +495,48 @@ pub enum AttachError {
     AlreadyAttached,
 }
 
+/// A realm-level `GlobalKey` registry spanning several [`WidgetsBinding`]s —
+/// one per presentation sharing a realm's `GlobalKeyScope` (ADR-0043 §1
+/// RULING 1b).
+///
+/// Assembled once over the presentations installed at the time
+/// [`Self::assemble`] runs, tried in the given order (a realm's mount
+/// order). `GlobalKeyScope`'s uniqueness invariant guarantees at most one
+/// binding ever answers a given hash, so trying each in turn and returning
+/// the first hit is exact, not a heuristic — see
+/// `key::registry::build_composite`'s doc for why resolving the FOLLOW-UP
+/// `with_element` call correctly (rather than by the same blind scan) needs
+/// a small correlation cache.
+///
+/// Internal seam: this type is visible at the crate boundary only because
+/// the owning realm above `flui-view` needs to hold and activate it, not a
+/// stable downstream API — gated identically to
+/// [`WidgetsBinding::with_global_key_registry`].
+#[doc(hidden)]
+#[cfg(any(test, feature = "runtime-internals"))]
+#[derive(Debug)]
+pub struct GlobalKeyRegistryComposite(crate::key::registry::GlobalKeyRegistryHandle);
+
+#[cfg(any(test, feature = "runtime-internals"))]
+impl GlobalKeyRegistryComposite {
+    /// Assemble a composite spanning `bindings`' own registries, in order.
+    #[must_use]
+    pub fn assemble<'a>(bindings: impl IntoIterator<Item = &'a WidgetsBinding>) -> Self {
+        let handles = bindings
+            .into_iter()
+            .map(WidgetsBinding::global_key_registry_handle)
+            .collect();
+        Self(crate::key::registry::build_composite(handles))
+    }
+
+    /// Activate this composite for the dynamic extent of `f` — the
+    /// multi-presentation counterpart to
+    /// [`WidgetsBinding::with_global_key_registry`].
+    pub fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
+        crate::key::registry::with_active_registry(&self.0, f)
+    }
+}
+
 impl WidgetsBinding {
     /// Create a binding with a fresh, isolated focus manager.
     ///
@@ -590,6 +632,13 @@ impl WidgetsBinding {
                 }
             },
         )
+    }
+
+    /// This binding's own `GlobalKey` registry handle, for composing into a
+    /// [`GlobalKeyRegistryComposite`] spanning several bindings.
+    #[cfg(any(test, feature = "runtime-internals"))]
+    fn global_key_registry_handle(&self) -> crate::key::registry::GlobalKeyRegistryHandle {
+        self.global_key_registry.clone()
     }
 
     /// Set the [`PipelineCell`] for render tree management.

--- a/crates/flui-view/src/key/registry.rs
+++ b/crates/flui-view/src/key/registry.rs
@@ -31,10 +31,20 @@
 //! active handle and releases the TLS `RefCell` borrow before invoking either
 //! framework or user code.
 
-use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+use std::{cell::RefCell, sync::Arc};
 
 use crate::view::ElementBase;
 use flui_foundation::ElementId;
+
+// `build_composite` (below) is the sole user of `HashMap`/`Rc` — both go
+// unused (and therefore unused-import-warn, `-D warnings`-fail under CI's
+// feature-matrix `cargo-hack` sweep) in a build with neither `test` nor
+// `runtime-internals` active, e.g. `flui-widgets`'s own `--features images`
+// test build, which pulls in `flui-view` with its default feature set only.
+// Gated identically to the function that needs them, not a blanket
+// `#[allow(unused_imports)]`.
+#[cfg(any(test, feature = "runtime-internals"))]
+use std::{collections::HashMap, rc::Rc};
 
 /// Snapshot of the framework's global-key lookup surface that
 /// `GlobalKey::current_element` / `with_current_state` consult.

--- a/crates/flui-view/src/key/registry.rs
+++ b/crates/flui-view/src/key/registry.rs
@@ -331,8 +331,10 @@ mod tests {
     fn member(entries: Vec<(u64, ElementId, &'static str)>) -> GlobalKeyRegistryHandle {
         let by_hash: HashMap<u64, ElementId> =
             entries.iter().map(|(hash, id, _)| (*hash, *id)).collect();
-        let by_id: HashMap<ElementId, &'static str> =
-            entries.into_iter().map(|(_, id, label)| (id, label)).collect();
+        let by_id: HashMap<ElementId, &'static str> = entries
+            .into_iter()
+            .map(|(_, id, label)| (id, label))
+            .collect();
         GlobalKeyRegistryHandle::new(
             move |hash| by_hash.get(&hash).copied(),
             move |id, f| {
@@ -379,7 +381,11 @@ mod tests {
 
         fn deactivate(&mut self) {}
 
-        fn update(&mut self, _new_view: &dyn crate::view::View, _owner: &mut crate::ElementOwner<'_>) {
+        fn update(
+            &mut self,
+            _new_view: &dyn crate::view::View,
+            _owner: &mut crate::ElementOwner<'_>,
+        ) {
             unreachable!("test double: update is never exercised by this composite test")
         }
 

--- a/crates/flui-view/src/key/registry.rs
+++ b/crates/flui-view/src/key/registry.rs
@@ -116,7 +116,7 @@ impl GlobalKeyRegistryHandle {
 }
 
 /// Build one composite handle spanning `members`, consulted in the given
-/// order (ADR-0043 §1 RULING 1b's realm composite, over per-presentation
+/// order (ADR-0043 §1's realm composite, over per-presentation
 /// `WidgetsBinding` registries).
 ///
 /// `GlobalKeyScope`'s uniqueness invariant guarantees at most one member ever
@@ -321,7 +321,7 @@ mod tests {
     }
 
     // ========================================================================
-    // `build_composite` — the realm composite (ADR-0043 §1 RULING 1b)
+    // `build_composite` — the realm composite (ADR-0043 §1)
     // ========================================================================
 
     /// A member whose lookup/visit are driven by a plain `HashMap` the test

--- a/crates/flui-view/src/key/registry.rs
+++ b/crates/flui-view/src/key/registry.rs
@@ -31,7 +31,7 @@
 //! active handle and releases the TLS `RefCell` borrow before invoking either
 //! framework or user code.
 
-use std::{cell::RefCell, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
 
 use crate::view::ElementBase;
 use flui_foundation::ElementId;
@@ -113,6 +113,58 @@ impl GlobalKeyRegistryHandle {
         });
         result
     }
+}
+
+/// Build one composite handle spanning `members`, consulted in the given
+/// order (ADR-0043 §1 RULING 1b's realm composite, over per-presentation
+/// `WidgetsBinding` registries).
+///
+/// `GlobalKeyScope`'s uniqueness invariant guarantees at most one member ever
+/// answers a given hash, so `lookup` trying each member in turn and
+/// returning the first hit is exact, not a heuristic. `with_element` cannot
+/// re-derive that same answer from an `ElementId` alone — two members' trees
+/// may validly reuse the same raw id for unrelated elements — so `lookup`
+/// additionally remembers, per id, which member resolved it; `with_element`
+/// consults that memory first and only falls back to a try-in-order scan for
+/// an id nothing has looked up yet (no production caller does this today —
+/// `GlobalKey::with_current_state` always calls `current_element` first —
+/// but the fallback keeps the composite correct-by-construction rather than
+/// correct-by-caller-discipline). The memory is a plain cache: an entry for
+/// an id that has since unmounted is simply a miss on lookup (the owning
+/// member's own `with_element` already returns `None` for a gone id), never
+/// a dangling reference.
+#[cfg(any(test, feature = "runtime-internals"))]
+pub(crate) fn build_composite(members: Vec<GlobalKeyRegistryHandle>) -> GlobalKeyRegistryHandle {
+    let resolved_by: Rc<RefCell<HashMap<ElementId, usize>>> = Rc::new(RefCell::new(HashMap::new()));
+    let lookup_members = members.clone();
+    let lookup_cache = Rc::clone(&resolved_by);
+    let visit_members = members;
+
+    GlobalKeyRegistryHandle::new(
+        move |hash| {
+            for (index, member) in lookup_members.iter().enumerate() {
+                if let Some(id) = member.lookup_element(hash) {
+                    lookup_cache.borrow_mut().insert(id, index);
+                    return Some(id);
+                }
+            }
+            None
+        },
+        move |id, f| {
+            let cached_index = resolved_by.borrow().get(&id).copied();
+            if let Some(index) = cached_index
+                && let Some(member) = visit_members.get(index)
+                && member.with_element(id, |el| f(el)).is_some()
+            {
+                return;
+            }
+            for member in &visit_members {
+                if member.with_element(id, |el| f(el)).is_some() {
+                    return;
+                }
+            }
+        },
+    )
 }
 
 thread_local! {
@@ -266,5 +318,147 @@ mod tests {
         assert_eq!(current(), Some(ElementId::new(11)));
         let _ = take_registry();
         assert_eq!(current(), None);
+    }
+
+    // ========================================================================
+    // `build_composite` — the realm composite (ADR-0043 §1 RULING 1b)
+    // ========================================================================
+
+    /// A member whose lookup/visit are driven by a plain `HashMap` the test
+    /// controls directly, so a composite test can construct exact,
+    /// deliberately colliding scenarios (same `ElementId` numeral valid in
+    /// two different members) rather than depending on a real element tree.
+    fn member(entries: Vec<(u64, ElementId, &'static str)>) -> GlobalKeyRegistryHandle {
+        let by_hash: HashMap<u64, ElementId> =
+            entries.iter().map(|(hash, id, _)| (*hash, *id)).collect();
+        let by_id: HashMap<ElementId, &'static str> =
+            entries.into_iter().map(|(_, id, label)| (id, label)).collect();
+        GlobalKeyRegistryHandle::new(
+            move |hash| by_hash.get(&hash).copied(),
+            move |id, f| {
+                if let Some(label) = by_id.get(&id) {
+                    f(&LabeledElement(label));
+                }
+            },
+        )
+    }
+
+    /// Minimal `ElementBase` test double: every lifecycle/build method is
+    /// `unreachable!()` because this composite test never drives lifecycle —
+    /// it only exercises `with_element`'s visit path, which reads
+    /// `state_as_any` and nothing else.
+    struct LabeledElement(&'static str);
+
+    impl ElementBase for LabeledElement {
+        fn view_type_id(&self) -> std::any::TypeId {
+            std::any::TypeId::of::<Self>()
+        }
+
+        fn depth(&self) -> usize {
+            0
+        }
+
+        fn lifecycle(&self) -> crate::element::Lifecycle {
+            crate::element::Lifecycle::Active
+        }
+
+        fn mount(
+            &mut self,
+            _parent: Option<ElementId>,
+            _slot: usize,
+            _owner: &mut crate::ElementOwner<'_>,
+        ) {
+            unreachable!("test double: mount is never exercised by this composite test")
+        }
+
+        fn unmount(&mut self, _owner: &mut crate::ElementOwner<'_>) {
+            unreachable!("test double: unmount is never exercised by this composite test")
+        }
+
+        fn activate(&mut self) {}
+
+        fn deactivate(&mut self) {}
+
+        fn update(&mut self, _new_view: &dyn crate::view::View, _owner: &mut crate::ElementOwner<'_>) {
+            unreachable!("test double: update is never exercised by this composite test")
+        }
+
+        fn mark_needs_build(&mut self) {}
+
+        fn build_into_views(
+            &mut self,
+            _owner: &mut crate::ElementOwner<'_>,
+        ) -> Vec<Box<dyn crate::view::View>> {
+            Vec::new()
+        }
+
+        fn state_as_any(&self) -> Option<&dyn std::any::Any> {
+            Some(&self.0)
+        }
+    }
+
+    fn visited_label(registry: &GlobalKeyRegistryHandle, id: ElementId) -> Option<&'static str> {
+        registry.with_element(id, |el| {
+            *el.state_as_any()
+                .expect("LabeledElement always has state")
+                .downcast_ref::<&'static str>()
+                .expect("LabeledElement's state is always &str")
+        })
+    }
+
+    #[test]
+    fn composite_lookup_tries_members_in_order_and_returns_the_first_hit() {
+        let a = member(vec![(1, ElementId::new(5), "a")]);
+        let b = member(vec![(2, ElementId::new(5), "b")]);
+        let composite = build_composite(vec![a, b]);
+
+        assert_eq!(composite.lookup_element(1), Some(ElementId::new(5)));
+        assert_eq!(composite.lookup_element(2), Some(ElementId::new(5)));
+        assert_eq!(composite.lookup_element(3), None);
+    }
+
+    /// The correctness property `build_composite` exists for: two members
+    /// both validly using `ElementId::new(5)` for unrelated elements must not
+    /// cross-contaminate a `with_element` call once `lookup` has resolved
+    /// which member owns a given hash — even though `with_element` itself
+    /// only ever receives the bare id, never the hash.
+    #[test]
+    fn composite_routes_with_element_to_the_member_that_resolved_the_lookup() {
+        let a = member(vec![(1, ElementId::new(5), "a")]);
+        let b = member(vec![(2, ElementId::new(5), "b")]);
+        let composite = build_composite(vec![a, b]);
+
+        assert_eq!(composite.lookup_element(1), Some(ElementId::new(5)));
+        assert_eq!(
+            visited_label(&composite, ElementId::new(5)),
+            Some("a"),
+            "the id lookup(1) just resolved must route to member a, not b's \
+             colliding id 5"
+        );
+
+        assert_eq!(composite.lookup_element(2), Some(ElementId::new(5)));
+        assert_eq!(
+            visited_label(&composite, ElementId::new(5)),
+            Some("b"),
+            "re-resolving the same numeral through member b must now route \
+             to b"
+        );
+    }
+
+    /// No preceding `lookup` for this id: falls back to a try-in-order scan
+    /// rather than returning nothing.
+    #[test]
+    fn composite_with_element_without_a_preceding_lookup_falls_back_to_scanning_members() {
+        let a = member(vec![(1, ElementId::new(9), "a")]);
+        let composite = build_composite(vec![a]);
+
+        assert_eq!(visited_label(&composite, ElementId::new(9)), Some("a"));
+    }
+
+    #[test]
+    fn composite_over_zero_members_resolves_nothing() {
+        let composite = build_composite(vec![]);
+        assert_eq!(composite.lookup_element(1), None);
+        assert_eq!(visited_label(&composite, ElementId::new(1)), None);
     }
 }

--- a/crates/flui-view/src/lib.rs
+++ b/crates/flui-view/src/lib.rs
@@ -153,6 +153,11 @@ pub use binding::{
     AppExitResponse, AppLifecycleState, AttachError, PredictiveBackEvent, RouteInformation,
     ViewFocusDirection, ViewFocusEvent, ViewFocusState, WidgetsBinding, WidgetsBindingObserver,
 };
+// Internal seam (see `GlobalKeyRegistryComposite`'s own doc): re-exported only
+// under the same `runtime-internals`/test gate the type itself is defined
+// behind, so an ordinary downstream build never sees it.
+#[cfg(any(test, feature = "runtime-internals"))]
+pub use binding::GlobalKeyRegistryComposite;
 // Child helpers
 pub use child::{Child, Children};
 // Context

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -966,7 +966,18 @@ installs the realm's `GlobalKeyScope` before any realm-shared dispatch handle \
 and before attach/mount. Addressed routing across a genuine N>1 forest \
 (`PresentationForest::get`/`remove` by id) is wired but has no production \
 entry point yet -- a later addressed-routing slice adds one; lifting the \
-ratchet is deferred to it, not to this contract's ownership shape.\
+ratchet is deferred to it, not to this contract's ownership shape. \
+`UiRealm::draw_frame_entered`'s pump processes every presentation once each, \
+in mount order: each presentation's own wake bit (`PresentationState::
+redraw_pending`) is cleared at the START of its segment, before its dirty \
+predicate (`has_pending_work`: pending build, a live `LayoutBuilder` seam \
+entry, or a dirty render node -- draining the cross-thread dirty-request \
+channel first, since that channel is what `run_frame` itself always drains \
+before deciding) is sampled, so a mark landing anywhere between that clear \
+and the next pump's sample is never lost. At the production ratchet (N=1) \
+this degenerates to exactly one always-run segment, proven identical by the \
+full pre-existing frame-pipeline test suite; the isolation suite proves the \
+skip/wake-bit machinery is real for N>1.\
 """
 state = "partial"
 domain = "realm"
@@ -977,12 +988,15 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "presentations: PresentationForest" },
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "widgets: WidgetsBinding" },
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "renderer: RenderingFlutterBinding" },
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "redraw_pending: Cell<bool>" },
     { kind = "symbol", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "BUG: PresentationForest::install called while the ratchet is" },
     { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn install_panics_once_the_forest_already_holds_a_presentation" },
     { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn push_for_test_bypasses_the_ratchet" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn push_for_test_bypasses_the_production_ratchet" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn reassemble_fans_out_to_all_presentations_in_mount_order" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropping_the_realm_closes_every_presentation" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn sibling_presentations_flush_independently" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn cross_presentation_dirty_during_a_segment_sets_wake_bit_and_lands_next_pump" },
 ]
 
 [[contract]]

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -592,18 +592,36 @@ evidence = [
 [[contract]]
 key = "globalkey-realm-scoped"
 statement = """
-GlobalKey identity is realm-scoped through a realm-entry activation stack, \
-not a process-global active registry. Deliberate divergence from Flutter's \
-process-global registry, sanctioned by the leapfrog-zone governance.\
+GlobalKey identity is realm-scoped, split across two authorities (ADR-0043 \
+§1): `BuildOwner.global_keys` is the intra-tree RETAKE authority (key hash \
+-> ElementId in that owner's own tree; `element_tree.rs`'s reparent/retake \
+machinery reads and writes only this map and is scope-blind by design). \
+`GlobalKeyScope` is the cross-tree UNIQUENESS authority shared by every \
+presentation in a realm (key hash -> which owner currently holds it) -- a \
+cross-owner duplicate mount fails eagerly, traced before the panic, naming \
+both owners. RESOLUTION for `GlobalKey::current_element`/`with_current_state` \
+goes through neither authority directly: `UiRealm::enter()` activates one \
+`GlobalKeyRegistryComposite` (flui-view) assembled over every presentation's \
+own `WidgetsBinding` registry, whole-frame, exactly as a single \
+presentation's own registry always was -- so post-frame callbacks, command \
+drains, deferred arena resolutions, and hot-reload reassemble all resolve \
+keys realm-wide regardless of which presentation's own segment is running. \
+Deliberate divergence from Flutter's process-global registry, sanctioned by \
+the leapfrog-zone governance.\
 """
 state = "implemented"
 domain = "realm"
 mechanical = true
 mechanism = "test existence pinned here"
 evidence = [
+    { kind = "symbol", file = "crates/flui-view/src/owner/global_key_scope.rs", contains = "pub struct GlobalKeyScope" },
+    { kind = "symbol", file = "crates/flui-view/src/binding.rs", contains = "pub struct GlobalKeyRegistryComposite" },
+    { kind = "symbol", file = "crates/flui-view/src/key/registry.rs", contains = "pub(crate) fn build_composite" },
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn realm_id" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn realm_entry_activates_its_global_key_registry" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn whole_frame_event_keeps_realm_global_key_scope_active" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn composite_registry_resolves_keys_registered_in_either_presentation" },
+    { kind = "test", file = "crates/flui-view/src/key/registry.rs", contains = "fn composite_routes_with_element_to_the_member_that_resolved_the_lookup" },
 ]
 
 [[contract]]
@@ -934,19 +952,37 @@ evidence = [
 [[contract]]
 key = "multi-presentation-forest-gate"
 statement = """
-One-realm/multi-presentation support is gated on a verified element forest; \
-until then a realm holds at most one live `PresentationState`. The gate \
-holds structurally today — `UiRealm` stores exactly one `PresentationState` \
-by value, so a second attachment is unrepresentable. The forest itself is \
-future work.\
+`UiRealm` hosts an insertion-ordered `PresentationForest` (ADR-0043 §1), not \
+a single `PresentationState` field — but production topology stays gated at \
+exactly one presentation per realm through the forest's own mechanical \
+ratchet: `PresentationForest::install` panics with `BUG:` if the forest \
+already holds a presentation, and has no production caller (opening a second \
+independent window installs a second REALM instead, through the multi-realm \
+`AppRuntime`). `push_for_test` is the isolation suite's only bypass, \
+`cfg(test)`-gated. Every presentation is its own bundle (own \
+`WidgetsBinding`, `RenderingFlutterBinding`, focus/IME/gestures/semantics) \
+assembled via `PresentationState::new`'s `RealmCapabilities` parameter, which \
+installs the realm's `GlobalKeyScope` before any realm-shared dispatch handle \
+and before attach/mount. Addressed routing across a genuine N>1 forest \
+(`PresentationForest::get`/`remove` by id) is wired but has no production \
+entry point yet -- a later addressed-routing slice adds one; lifting the \
+ratchet is deferred to it, not to this contract's ownership shape.\
 """
 state = "partial"
 domain = "realm"
 owner_issue = 555
 mechanical = true
-mechanism = "single-field storage pinned by symbol check; a second slot or Vec would change the string"
+mechanism = "PresentationForest symbol + its install-ratchet panic message pinned; a lifted ratchet or renamed panic would change these strings"
 evidence = [
-    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "presentation: PresentationState" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "presentations: PresentationForest" },
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "widgets: WidgetsBinding" },
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "renderer: RenderingFlutterBinding" },
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "BUG: PresentationForest::install called while the ratchet is" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn install_panics_once_the_forest_already_holds_a_presentation" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn push_for_test_bypasses_the_ratchet" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn push_for_test_bypasses_the_production_ratchet" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn reassemble_fans_out_to_all_presentations_in_mount_order" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropping_the_realm_closes_every_presentation" },
 ]
 
 [[contract]]

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -977,7 +977,20 @@ before deciding) is sampled, so a mark landing anywhere between that clear \
 and the next pump's sample is never lost. At the production ratchet (N=1) \
 this degenerates to exactly one always-run segment, proven identical by the \
 full pre-existing frame-pipeline test suite; the isolation suite proves the \
-skip/wake-bit machinery is real for N>1.\
+skip/wake-bit machinery is real for N>1. \
+`UiRealm::close_presentation` is the consolidated six-step teardown contract \
+(WindowRegistry unregister is the caller's job -- `UiRealm` has no access to \
+that registry; IME/focus deactivate; `detach_root_widget` with capabilities \
+still installed; the realm-level `AsyncDriver` is not told about the \
+closure, so an in-flight task is not cancelled and its eventual completion \
+must fail closed; `GlobalKeyScope` reclaim via `BuildOwner::Drop`; the final \
+drop). `WidgetsBinding::detach_root_widget` itself was fixed in the same \
+change to call `ElementTree::remove_subtree` instead of the single-node \
+`remove` it used before -- the single-node call only ever unmounted the \
+internal `RootRenderView` wrapper every attached view is mounted under and \
+silently orphaned every descendant's `State::dispose`, which would have \
+made "teardown is total for that bundle" false for any tree deeper than one \
+node.\
 """
 state = "partial"
 domain = "realm"
@@ -997,6 +1010,11 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropping_the_realm_closes_every_presentation" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn sibling_presentations_flush_independently" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn cross_presentation_dirty_during_a_segment_sets_wake_bit_and_lands_next_pump" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "pub(crate) fn close_presentation" },
+    { kind = "symbol", file = "crates/flui-view/src/binding.rs", contains = "element_tree.remove_subtree(root_id, &mut build_owner.element_owner_mut());" },
+    { kind = "test", file = "crates/flui-view/src/binding.rs", contains = "fn detach_root_widget_disposes_every_descendant_not_just_the_root" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn async_completion_after_presentation_teardown_fails_closed_no_sibling_reach" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dispose_during_teardown_cannot_reach_sibling_or_dead_services" },
 ]
 
 [[contract]]

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -978,19 +978,45 @@ and the next pump's sample is never lost. At the production ratchet (N=1) \
 this degenerates to exactly one always-run segment, proven identical by the \
 full pre-existing frame-pipeline test suite; the isolation suite proves the \
 skip/wake-bit machinery is real for N>1. \
-`UiRealm::close_presentation` is the consolidated six-step teardown contract \
-(WindowRegistry unregister is the caller's job -- `UiRealm` has no access to \
-that registry; IME/focus deactivate; `detach_root_widget` with capabilities \
-still installed; the realm-level `AsyncDriver` is not told about the \
-closure, so an in-flight task is not cancelled and its eventual completion \
-must fail closed; `GlobalKeyScope` reclaim via `BuildOwner::Drop`; the final \
-drop). `WidgetsBinding::detach_root_widget` itself was fixed in the same \
-change to call `ElementTree::remove_subtree` instead of the single-node \
-`remove` it used before -- the single-node call only ever unmounted the \
-internal `RootRenderView` wrapper every attached view is mounted under and \
-silently orphaned every descendant's `State::dispose`, which would have \
-made "teardown is total for that bundle" false for any tree deeper than one \
-node.\
+`UiRealm::close_presentation_entered` is the consolidated six-step teardown \
+contract (WindowRegistry unregister is the caller's job -- `UiRealm` has no \
+access to that registry; IME/focus deactivate; `detach_root_widget` with \
+capabilities still installed; the realm-level `AsyncDriver` is not told \
+about the closure, so an in-flight task is not cancelled and its eventual \
+completion must fail closed; `GlobalKeyScope` reclaim via `BuildOwner::\
+Drop`; the final drop). `WidgetsBinding::detach_root_widget` itself was \
+fixed in the same change to call `ElementTree::remove_subtree` instead of \
+the single-node `remove` it used before -- the single-node call only ever \
+unmounted the internal `RootRenderView` wrapper every attached view is \
+mounted under and silently orphaned every descendant's `State::dispose`, \
+which would have made "teardown is total for that bundle" false for any \
+tree deeper than one node. \
+`close_presentation_entered` takes `&mut self` (it removes the closed \
+presentation from the forest), so it is reached only from `runner.rs`'s \
+`dispatch_platform_realm`, which special-cases a dedicated `RealmTask::\
+ClosePresentation` variant in its own drain loop (the one place the realm \
+sits checked out of `AppRuntime` as an owned local, so `&mut` is naturally \
+available) rather than routing it through `RealmTask::run`'s shared-`&self` \
+receiver every other task variant uses. `runner.rs::close_presentation` is \
+the request-shaped public entry (enqueue via the existing dispatch seam, \
+never a direct call) -- teardown-at-Idle is enforced by the dispatch \
+drain point itself, the same discipline `install_realm_alongside`/\
+`uninstall_platform_realm` already established for every other realm-map \
+mutation, not a second, independently-maintained convention. \
+Step 2-3 runs inside `UiRealm::enter_for_close`, which assembles the \
+whole-frame `GlobalKeyRegistryComposite` from every presentation EXCEPT \
+the one being closed: composing the closing presentation in would let a \
+dispose hook's `GlobalKey::current_element()` call -- for ANY key, even one \
+belonging to a different presentation, since the composite tries every \
+member in insertion order regardless of which one is being looked up -- \
+re-acquire a read lock on the exact non-reentrant `WidgetsBindingInner` \
+`RwLock` that same call already holds for writing across the whole \
+recursive `detach_root_widget` removal; that is an unconditional \
+self-deadlock, not a race, and was caught (the test hung) by this \
+contract's own red-exploit test before the exclusion existed. Excluding it \
+costs nothing real: every OTHER presentation still resolves normally, and \
+a presentation cannot meaningfully resolve one of its OWN keys through a \
+registry that is mid-teardown anyway.\
 """
 state = "partial"
 domain = "realm"
@@ -1010,13 +1036,17 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropping_the_realm_closes_every_presentation" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn sibling_presentations_flush_independently" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn cross_presentation_dirty_during_a_segment_sets_wake_bit_and_lands_next_pump" },
-    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "pub(crate) fn close_presentation" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "pub(crate) fn close_presentation_entered" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn enter_for_close" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "ClosePresentation(flui_foundation::PresentationId)" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn close_presentation(" },
     { kind = "symbol", file = "crates/flui-view/src/binding.rs", contains = "element_tree.remove_subtree(root_id, &mut build_owner.element_owner_mut());" },
     { kind = "test", file = "crates/flui-view/src/binding.rs", contains = "fn detach_root_widget_disposes_every_descendant_not_just_the_root" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn async_completion_after_presentation_teardown_fails_closed_no_sibling_reach" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dispose_during_teardown_cannot_reach_sibling_or_dead_services" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn closing_presentation_a_leaves_sibling_layer_tree_identical" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropped_presentations_surviving_pipeline_handles_fail_closed" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn dispose_opening_a_window_mid_teardown_defers_and_does_not_reenter" },
 ]
 
 [[contract]]

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1015,6 +1015,8 @@ evidence = [
     { kind = "test", file = "crates/flui-view/src/binding.rs", contains = "fn detach_root_widget_disposes_every_descendant_not_just_the_root" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn async_completion_after_presentation_teardown_fails_closed_no_sibling_reach" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dispose_during_teardown_cannot_reach_sibling_or_dead_services" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn closing_presentation_a_leaves_sibling_layer_tree_identical" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropped_presentations_surviving_pipeline_handles_fail_closed" },
 ]
 
 [[contract]]


### PR DESCRIPTION
Slice 3 of #555 — the forest itself, on top of the GlobalKeyScope slice (#604) and the multi-realm host (#606).

## What

- **`PresentationForest`** replaces `UiRealm`'s singular `presentation` field: an insertion-ordered newtype whose production `install` path mechanically enforces at most one presentation (`BUG:` panic, registry-pinned) — the ratchet lifts in the routing slice, in the same commit that lands presentation-addressed entry points. The isolation suite bypasses it in `cfg(test)` scope only.
- **Per-presentation UI bundles**: `PresentationState` now owns its `WidgetsBinding` and renderer binding; assembly wires the realm `GlobalKeyScope` first (the merged setter panics `BUG:` on late calls), then realm-shared handles, then the presentation's own focus/IME — all before attach/mount, pinned by a duplicate-key-across-presentations test that fails eagerly naming both owner tags.
- **Composite key registry**: `UiRealm::enter()` assembles one whole-frame composite over every presentation's registry, routing each `GlobalKey` lookup to the owning tree (correlation cache rebuilt per entry — no stale mapping can survive teardown or reassemble; member handles are `Weak`, so a dead binding is inert, never a retake candidate). The long-standing pinned whole-frame activation test survives unedited.
- **Per-presentation pump segments**: dirty = owner heap or external inbox, sampled at segment start; `needs_redraw` bits are wake-only and cleared at segment start; the realm aggregate is retained for platform wake. The single-presentation path degenerates to exactly the old flush sequence — no existing frame test changed outcome.
- **Task-routed teardown**: presentation close is a realm task executing at Idle on the dispatched path, where the realm is an owned value (no interior mutability added) and the TLS deferral guard is naturally active — a dispose callback's open-window request defers by the already-merged rule, proven by an exploit that fails when the guard is bypassed. Six-step order: window-mapping unregister (exact-address `remove_presentation` + address re-stamp so stale dispatchers hit `StalePresentation`), IME/focus detach, root detach through the presentation's own binding (capabilities + realm-wide key lookup active for dispose callbacks), async-task disposition (completions fail closed against the dropped tree — audited, no raw-id sibling reach), scope-claim reclamation, state drop. Closing the sole presentation routes into full realm uninstall via the deferral tail — an empty forest is unreachable.
- **Hot-reload reassemble fans out** to all presentations in mount order (oracle: per-presentation pending builds, mutant-verified against a primary-only revert).
- Registry contracts rewritten: `multi-presentation-forest-gate` (forest symbols + ratchet + isolation tests), `globalkey-realm-scoped` (split-authority model), new `widgets`-in-`PresentationState` pin.

## Evidence

- 8 planned red-exploits + 3 review-driven tests; five mutants run and killed during review (fan-out revert, scope-setter deletion, close-seam trio) — several by the reviewer independently.
- `cargo nextest run -p flui-app -p flui-view` 820/820 (825 with hot-reload); full `just ci` exit 0 (8625 workspace tests); workspace clippy `-D warnings`, conformance (47 contracts), port-check, wasm-check, rustdoc `-D warnings`, taplo, typos all clean.
- Two-stage review + narrow re-verification, final verdict CLEAN at 901b04bd. Honest residual documented: non-primary presentations carry no window mapping until the routing slice — production-unreachable behind the ratchet, detected by teardown's existing debug self-check rather than papered over.

Part of #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du3J3bDcsRaSU3tKgYKvni