### PR TITLE
feat(app): exact-presentation routing, focus arbitration, and the multi-presentation ratchet lift (#555)

### DIFF
--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -304,8 +304,29 @@ impl PresentationState {
         // pipeline cell checked out, and `wake` only touches `Send + Sync`
         // runtime-level state — never this presentation's own `widgets` /
         // `renderer` / gesture state.
+        //
+        // Pokes THIS presentation's own window directly (`Weak`, exactly
+        // like `Self::window` below — never a strong ref kept past the
+        // platform's own teardown), in addition to the realm-wide
+        // `capabilities.wake` call: `capabilities.wake` sets the shared
+        // `needs_redraw` bit (still required — it is what wakes an idle
+        // event loop at all) but only pokes whichever ONE window
+        // `AppRuntime`'s own `redraw_window` slot happens to hold (issue
+        // #555's still-single-window wake contract). Once a realm hosts
+        // more than one presentation, each needs its OWN window poked when
+        // IT dirties — never a sibling's — or a redraw request stamped for
+        // this presentation would silently wake (or fail to wake) the wrong
+        // native window. See `redraw_request_from_a_does_not_wake_bs_window`.
         let visual_wake = capabilities.wake;
-        pipeline.with_mut(|owner| owner.set_on_need_visual_update(move || visual_wake()));
+        let redraw_window = Arc::downgrade(&window);
+        pipeline.with_mut(|owner| {
+            owner.set_on_need_visual_update(move || {
+                visual_wake();
+                if let Some(window) = redraw_window.upgrade() {
+                    window.request_redraw();
+                }
+            });
+        });
 
         let semantics = SemanticsHost::new();
         // Semantics-enabled fan-out -> this presentation's own SemanticsHost.

--- a/crates/flui-app/src/app/presentation_forest.rs
+++ b/crates/flui-app/src/app/presentation_forest.rs
@@ -1,15 +1,15 @@
 //! `PresentationForest` — the insertion-ordered collection of
 //! [`PresentationState`]s one `UiRealm` owns (ADR-0043 §1).
 //!
-//! Production topology is exactly one presentation per realm today: opening
-//! a second independent window installs a second REALM (`AppRuntime`'s
-//! `RealmId`-keyed map), not a second presentation inside an existing one.
-//! This type exists so that shape — the realm-level composite `GlobalKey`
-//! registry, the per-presentation pump/teardown/reassemble machinery — is
-//! written once, generally, over `Vec<PresentationState>` rather than
-//! hand-specialized to "exactly one", so a later addressed-routing slice
-//! (window grouping / `WindowPolicy`) can lift the ratchet below without
-//! re-deriving this plumbing.
+//! Production topology now allows any number of presentations per realm
+//! (issue #555's addressed-routing slice lifts the mechanical 1×N ratchet this type used to
+//! enforce): `UiRealm::install_presentation` is the production entry point
+//! that assembles and installs a second (third, ...) presentation sharing
+//! this realm's `GlobalKeyScope` and dispatch handles, with its own real
+//! `WindowRegistry` mapping (`runner.rs::install_presentation_alongside`).
+//! Opening a genuinely independent, unrelated window still installs a second
+//! REALM (`AppRuntime`'s `RealmId`-keyed map) — this forest is for windows
+//! that share one realm's GlobalKey scope, focus arbitration, and scheduler.
 //!
 //! Iteration order is insertion (mount) order: a plain `Vec`, never
 //! reordered. Pump, reassemble fan-out, and the composite registry all rely
@@ -21,24 +21,13 @@ use flui_foundation::PresentationId;
 use super::presentation::PresentationState;
 
 /// The insertion-ordered set of presentations one `UiRealm` owns.
-///
-/// # Ratchet
-///
-/// [`Self::install`] is the production entry point and panics if the forest
-/// already holds a presentation — registry-pinned
-/// (`multi-presentation-forest-gate`, `docs/runtime-contract.toml`) as the
-/// mechanical 1×N ratchet: production topology stays exactly one
-/// presentation per realm until a later slice's addressed routing lifts it.
-/// `push_for_test` is the only bypass, and only compiles under `cfg(test)`
-/// (not linked from this doc: a plain `cfg(test)` item has no stable link
-/// target in a non-test doc build).
 pub(crate) struct PresentationForest {
     presentations: Vec<PresentationState>,
 }
 
 impl PresentationForest {
-    /// Construct a forest holding exactly one presentation — the only
-    /// production shape until the ratchet in [`Self::install`] lifts.
+    /// Construct a forest holding exactly one presentation — every realm's
+    /// starting shape; [`Self::install`] grows it from there.
     pub(crate) fn single(presentation: PresentationState) -> Self {
         Self {
             presentations: vec![presentation],
@@ -47,36 +36,14 @@ impl PresentationForest {
 
     /// Install another presentation into this forest.
     ///
-    /// **Ratchet:** panics with `BUG:` if the forest is not currently empty
-    /// — there is no production call site for this today (opening a second
-    /// window installs a second realm, not a second presentation), so this
-    /// exists to fail loudly the moment one is added ahead of the addressed
-    /// routing that makes a true forest safe to drive.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "no production caller until the len()<=1 ratchet lifts \
-                      (a later addressed-routing slice); push_for_test is the \
-                      isolation-suite bypass"
-        )
-    )]
+    /// Production entry point (this slice lifted the former `len()<=1`
+    /// ratchet, registry-pinned as `multi-presentation-forest-gate` in
+    /// `docs/runtime-contract.toml`): `UiRealm::install_presentation` is the
+    /// realm-level caller, and `runner.rs::install_presentation_alongside`
+    /// is the caller that also mints this presentation's real
+    /// `WindowRegistry` mapping — the two steps a hosted presentation needs
+    /// to be genuinely dispatchable, not just forest-resident.
     pub(crate) fn install(&mut self, presentation: PresentationState) {
-        assert!(
-            self.presentations.is_empty(),
-            "BUG: PresentationForest::install called while the ratchet is \
-             still closed -- production topology is exactly one presentation \
-             per realm until a later addressed-routing slice lifts the \
-             len()<=1 gate; tests use push_for_test to bypass it deliberately"
-        );
-        self.presentations.push(presentation);
-    }
-
-    /// Isolation-suite-only bypass of [`Self::install`]'s ratchet, so a test
-    /// can drive a genuine multi-presentation realm ahead of the addressed
-    /// routing that makes doing so safe in production.
-    #[cfg(test)]
-    pub(crate) fn push_for_test(&mut self, presentation: PresentationState) {
         self.presentations.push(presentation);
     }
 
@@ -159,26 +126,26 @@ mod tests {
         assert_eq!(forest.primary().id(), id);
     }
 
+    /// The former mechanical ratchet (`len() <= 1`) is lifted: `install`
+    /// now accepts any number of presentations through the SAME production
+    /// entry point every isolation test uses, not a `cfg(test)`-only
+    /// bypass. If reverted (the old `assert!(self.presentations.is_empty())`
+    /// restored), this fails on the second `install` call instead of
+    /// observing `len() == 2`.
     #[test]
-    #[should_panic(expected = "BUG: PresentationForest::install called")]
-    fn install_panics_once_the_forest_already_holds_a_presentation() {
+    fn install_accepts_any_number_of_presentations() {
         let mut forest = PresentationForest::single(presentation(1));
         forest.install(presentation(2));
-    }
+        forest.install(presentation(3));
 
-    #[test]
-    fn push_for_test_bypasses_the_ratchet() {
-        let mut forest = PresentationForest::single(presentation(1));
-        forest.push_for_test(presentation(2));
-
-        assert_eq!(forest.len(), 2);
+        assert_eq!(forest.len(), 3);
     }
 
     #[test]
     fn iter_yields_presentations_in_mount_order() {
         let mut forest = PresentationForest::single(presentation(1));
-        forest.push_for_test(presentation(2));
-        forest.push_for_test(presentation(3));
+        forest.install(presentation(2));
+        forest.install(presentation(3));
 
         let ids: Vec<_> = forest.iter().map(PresentationState::id).collect();
         assert_eq!(
@@ -197,7 +164,7 @@ mod tests {
         let mut forest = PresentationForest::single(presentation(1));
         let second = presentation(2);
         let second_id = second.id();
-        forest.push_for_test(second);
+        forest.install(second);
 
         assert!(forest.get(second_id).is_some());
         let removed = forest.remove(second_id).expect("present");

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -581,6 +581,28 @@ impl PlatformToUi {
                 tracing::trace!(?size, scale_factor, "realm resize committed");
             }
             Self::WindowFocus(focused) => {
+                // A `false` signal from a presentation that is NOT this
+                // realm's currently ACTIVE one (`FocusCoordinator`) is a
+                // stale, non-authoritative consequence of focus having
+                // already moved to a DIFFERENT presentation of this SAME
+                // realm (the exact scenario a realm hosting more than one
+                // presentation creates) -- applying it to the `focused`
+                // aggregate (still loop-scoped, not yet per-realm; see
+                // `app-runtime-composition-host`'s own documented
+                // limitation) would incorrectly suspend the WHOLE realm
+                // while a sibling window still holds OS focus. Only the
+                // ACTIVE presentation's own focus-loss is authoritative;
+                // every focus GAIN always is, so this check only ever
+                // applies to `focused == false`.
+                if !focused && !realm.is_active_presentation(presentation_id) {
+                    tracing::trace!(
+                        { flui_foundation::diagnostics::PRESENTATION_ID } =
+                            presentation_id.as_u64(),
+                        "dropping a stale WindowFocus(false) from a presentation that is not \
+                         this realm's currently active one"
+                    );
+                    return;
+                }
                 let (old, new) = APP_RUNTIME.with(|slot| {
                     let mut state = slot.borrow_mut();
                     let old = derive_lifecycle_state(state.visible, state.focused);
@@ -1465,6 +1487,16 @@ enum InstallPresentationError {
     /// stated gap rather than a defer-to-idle path.
     #[error("a dispatch or hot-restart visit is in flight on this thread")]
     DispatchInFlight,
+    /// `dispatcher`'s realm is live, but `dispatcher.address` itself is no
+    /// longer registered in `WindowRegistry` — the presentation it was
+    /// minted for closed since, even though a DIFFERENT presentation kept
+    /// the realm alive. The same authorization check
+    /// `dispatch_platform_realm` runs (`registry.contains_address`), applied
+    /// here too: a caller must hold a dispatcher whose exact address is
+    /// CURRENTLY live to authorize installing another presentation
+    /// alongside it, not merely one whose realm happens to still exist.
+    #[error("the presentation this dispatcher was minted for is no longer registered")]
+    StalePresentation,
     /// `window`'s id was already registered to a (possibly different)
     /// address — practically unreachable for a freshly opened window, but
     /// a real, distinct failure mode from `RealmUnavailable`: the realm
@@ -1498,7 +1530,12 @@ enum InstallPresentationError {
 /// # Errors
 ///
 /// [`InstallPresentationError::RealmUnavailable`] if `dispatcher`'s realm no
-/// longer exists. [`InstallPresentationError::WindowAlreadyMapped`] if
+/// longer exists. [`InstallPresentationError::StalePresentation`] if the
+/// realm survives but `dispatcher.address` itself is no longer a live
+/// registered address (its own presentation closed, even though a sibling
+/// kept the realm alive) — the same authorization
+/// `dispatch_platform_realm` requires of every dispatched task, applied to
+/// this mutation too. [`InstallPresentationError::WindowAlreadyMapped`] if
 /// `window`'s id is somehow already registered (practically unreachable: a
 /// freshly opened window has a fresh id by construction) — nothing is
 /// installed into the forest in this case.
@@ -1543,9 +1580,30 @@ fn install_presentation_alongside(
             );
             return Err(InstallPresentationError::DispatchInFlight);
         }
-        let Some(realm_slot) = state.realms.get_mut(&realm_id) else {
+        if !state.realms.contains_key(&realm_id) {
             return Err(InstallPresentationError::RealmUnavailable);
-        };
+        }
+        // Authorization check (mirrors `dispatch_platform_realm`'s own):
+        // the realm existing is not enough -- `dispatcher.address` itself
+        // must still be a LIVE registered address. A realm survives its
+        // sole non-primary presentation closing (a sibling keeps it
+        // alive), so a caller could otherwise still hold a dispatcher for
+        // that now-closed presentation and use it to authorize installing
+        // yet another one alongside -- checked BEFORE borrowing
+        // `state.realms` mutably below, exactly like `dispatch_platform_
+        // realm` checks `state.registry` before `state.realms.get_mut`.
+        if !state.registry.contains_address(dispatcher.address) {
+            tracing::debug!(
+                ?dispatcher,
+                "rejecting install_presentation_alongside: the dispatcher's own presentation is \
+                 no longer registered, even though its realm survives"
+            );
+            return Err(InstallPresentationError::StalePresentation);
+        }
+        let realm_slot = state
+            .realms
+            .get_mut(&realm_id)
+            .expect("BUG: presence just checked above via contains_key");
         let Some(realm) = realm_slot.realm.as_mut() else {
             return Err(InstallPresentationError::RealmUnavailable);
         };
@@ -4337,6 +4395,21 @@ mod realm_dispatch_tests {
                     "WindowFocus(false) must never move the active presentation, regardless \
                      of which presentation it was addressed to"
                 );
+                // The realm-wide lifecycle aggregate must ALSO stay
+                // Resumed: A's focus loss is a normal consequence of focus
+                // having already moved to B (a sibling presentation of
+                // this SAME realm), not a sign that the realm itself lost
+                // focus -- B still holds it. Before the fix, this
+                // non-active-presentation `WindowFocus(false)` flipped the
+                // still loop-scoped `focused` aggregate unconditionally,
+                // incorrectly suspending the whole realm while B was
+                // still focused.
+                assert_eq!(
+                    realm.scheduler().lifecycle_state(),
+                    AppLifecycleState::Resumed,
+                    "a WindowFocus(false) from a non-active presentation must never suspend \
+                     the realm while a sibling presentation still holds focus"
+                );
             })),
         )
         .expect("frame task dispatches");
@@ -4384,6 +4457,73 @@ mod realm_dispatch_tests {
             Some(1),
             "a registration failure must leave the forest exactly as it was -- the \
              assembled-but-unregistered presentation must never have been installed"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// A `RealmDispatcher` for a presentation that has since CLOSED must be
+    /// refused, even though its realm survives (a sibling presentation kept
+    /// it alive) -- the same authorization `dispatch_platform_realm`
+    /// requires of every dispatched task. Before this fix,
+    /// `install_presentation_alongside` checked only realm existence, so a
+    /// caller still holding A's dispatcher after A closed could use it to
+    /// install a THIRD presentation alongside the survivor.
+    ///
+    /// If reverted (the `registry.contains_address` check removed): this
+    /// fails -- the install succeeds instead of returning
+    /// `StalePresentation`, and `presentation_count()` observes `2` instead
+    /// of `1`.
+    #[test]
+    fn install_presentation_alongside_refuses_a_stale_dispatcher_even_though_its_realm_survives() {
+        // One shared platform instance for every window -- see
+        // `install_two_test_realms`'s doc for why two independent
+        // `headless_platform()` calls would risk an aliased window id.
+        let platform = flui_platform::headless_platform();
+        let window_p = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window p");
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let window_c = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window c");
+
+        let realm = super::super::ui_realm::UiRealm::for_test();
+        let dispatcher_p = install_platform_realm(realm, &window_p);
+        let dispatcher_a = install_presentation_alongside(dispatcher_p, &window_a)
+            .expect("A installs alongside P with a real window mapping");
+        let a_id = dispatcher_a.address.presentation_id;
+
+        // Close A (non-primary) -- P survives, so the realm itself is
+        // still perfectly live.
+        close_presentation(dispatcher_p, a_id).expect("A closes through the real dispatch seam");
+
+        // `dispatcher_a` is now stale: its own address is no longer
+        // registered, even though `dispatcher_a.address.realm_id` still
+        // names a live realm.
+        let result = install_presentation_alongside(dispatcher_a, &window_c);
+        assert!(
+            matches!(result, Err(InstallPresentationError::StalePresentation)),
+            "a dispatcher for a closed presentation must be refused as StalePresentation, even \
+             though its realm survives, got {result:?}"
+        );
+
+        let count = Rc::new(Cell::new(None));
+        let count_in_task = Rc::clone(&count);
+        dispatch_platform_realm(
+            dispatcher_p,
+            RealmTask::Frame(Box::new(move |realm| {
+                count_in_task.set(Some(realm.presentation_count()));
+            })),
+        )
+        .expect("frame task dispatches");
+        assert_eq!(
+            count.get(),
+            Some(1),
+            "the rejected install must never have installed a third presentation -- only P \
+             survives"
         );
 
         teardown_platform_realm();

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -4320,13 +4320,27 @@ mod realm_dispatch_tests {
     /// dispatched for a presentation moves the active presentation to it;
     /// `WindowFocus(false)` dispatched for a DIFFERENT, non-active
     /// presentation never moves it away from whichever presentation is
-    /// currently active.
+    /// currently active, and must NOT suspend the realm-wide lifecycle
+    /// either (a sibling presentation still holds focus). The FINAL step
+    /// pins the other half of that same guard: `WindowFocus(false)`
+    /// dispatched for the presentation that IS currently active must still
+    /// suspend the realm normally -- the guard drops only NON-active
+    /// focus-loss, never focus-loss in general.
     ///
-    /// Mutant: `PlatformToUi::run`'s `WindowFocus` arm calls
-    /// `notify_presentation_focus_gained` inside `if focused { .. }` --
-    /// removing that guard (calling it unconditionally, so `WindowFocus(false)`
-    /// also moves active) makes this fail: the final assertion would observe
-    /// A active instead of B.
+    /// Mutants, both confirmed to make this fail:
+    /// - `PlatformToUi::run`'s `WindowFocus` arm calling
+    ///   `notify_presentation_focus_gained` inside `if focused { .. }`
+    ///   unconditionally (removing that guard, so `WindowFocus(false)` also
+    ///   moves active) -- the active-presentation assertion after B gains
+    ///   focus would observe A instead of B.
+    /// - The polarity mutant `if !focused { return; }` in place of
+    ///   `if !focused && !realm.is_active_presentation(presentation_id) { return; }`
+    ///   -- dropping EVERY focus loss unconditionally, so the realm can
+    ///   never suspend at all. This one is invisible to the middle
+    ///   assertions (A's focus loss is already supposed to be dropped) and
+    ///   is caught ONLY by the final step below, where B -- the ACTUALLY
+    ///   active presentation -- loses focus and the realm must still
+    ///   suspend.
     #[test]
     fn window_focus_true_moves_active_presentation_end_to_end_and_false_does_not() {
         // One shared platform instance for both windows -- see
@@ -4409,6 +4423,29 @@ mod realm_dispatch_tests {
                     AppLifecycleState::Resumed,
                     "a WindowFocus(false) from a non-active presentation must never suspend \
                      the realm while a sibling presentation still holds focus"
+                );
+            })),
+        )
+        .expect("frame task dispatches");
+
+        // WindowFocus(false) dispatched for B -- the presentation that IS
+        // currently active -- pins the OTHER half of the guard: dropping
+        // non-active focus-loss must never widen into dropping ALL
+        // focus-loss. The realm must actually suspend here.
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Event(PlatformToUi::WindowFocus(false)),
+        )
+        .expect("WindowFocus(false) for B dispatches");
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(move |realm| {
+                assert_ne!(
+                    realm.scheduler().lifecycle_state(),
+                    AppLifecycleState::Resumed,
+                    "WindowFocus(false) from the presentation that IS currently active must \
+                     still suspend the realm -- the guard drops only NON-active focus-loss, \
+                     never focus-loss unconditionally"
                 );
             })),
         )

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -1448,39 +1448,69 @@ fn install_realm_alongside(
     }
 }
 
+/// Errors from [`install_presentation_alongside`]. A dedicated type rather
+/// than folding into [`RealmDispatchError`]: none of that enum's variants
+/// mean "the realm is fine, but this specific window id collided" —
+/// mislabeling that as `RealmUnavailable` (the pre-fix shape) told a caller
+/// the wrong thing about what actually went wrong.
+#[cfg(not(target_os = "ios"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+enum InstallPresentationError {
+    /// `dispatcher`'s realm no longer exists (a newer realm replaced it, or
+    /// it was already torn down).
+    #[error("the realm this dispatcher was minted for no longer exists")]
+    RealmUnavailable,
+    /// A dispatch or hot-restart visit is currently in flight on this
+    /// thread; see this function's own doc for why that is a named,
+    /// stated gap rather than a defer-to-idle path.
+    #[error("a dispatch or hot-restart visit is in flight on this thread")]
+    DispatchInFlight,
+    /// `window`'s id was already registered to a (possibly different)
+    /// address — practically unreachable for a freshly opened window, but
+    /// a real, distinct failure mode from `RealmUnavailable`: the realm
+    /// itself is perfectly fine.
+    #[error("window is already registered: {0}")]
+    WindowAlreadyMapped(#[from] super::window_registry::RegistryError),
+}
+
 /// Installs another presentation into `dispatcher`'s realm, alongside
 /// whatever it already hosts — the addressed-routing counterpart to
 /// [`install_realm_alongside`] (which installs a second REALM instead of a
 /// second presentation of the SAME realm). This is the production entry
 /// point [`super::presentation_forest::PresentationForest`]'s doc and
 /// `docs/runtime-contract.toml`'s `multi-presentation-forest-gate` entry
-/// both point to: the forest's former `len()<=1` ratchet lifted (issue #555
-///) specifically so this function has somewhere real to install into.
+/// both point to: the forest's former `len()<=1` ratchet lifted (issue #555)
+/// specifically so this function has somewhere real to install into.
 ///
-/// `window` becomes the fresh presentation's own native window; its
-/// `WindowRegistry` mapping is minted in the SAME call, at the fresh
-/// presentation's real address, so the returned [`RealmDispatcher`] is
-/// dispatchable the moment this returns — no window is ever left resident
-/// in the forest without a registry entry of its own (the still-open gap
-/// this function closes; see `docs/pr-notes-555-3.md`'s "recommended next
-/// steps" for the exact residual).
+/// `window` becomes the fresh presentation's own native window. Ordering is
+/// load-bearing: the presentation is
+/// [`assembled`](super::ui_realm::UiRealm::assemble_presentation) but NOT
+/// yet installed into the forest, then its `WindowRegistry` mapping is
+/// minted, and ONLY on success is it
+/// [`installed`](super::ui_realm::UiRealm::install_presentation) — so a
+/// registration failure leaves nothing forest-resident to roll back (the
+/// assembled-but-uninstalled `PresentationState` is simply dropped), never
+/// a presentation the forest holds with no registry entry of its own. This
+/// is the single-native-window-map-authority invariant this function
+/// exists to uphold: no hosted presentation is ever forest-resident
+/// without a mapping.
 ///
 /// # Errors
 ///
-/// [`RealmDispatchError::RealmUnavailable`] if `dispatcher`'s realm no
-/// longer exists, OR — folded into the same variant rather than growing a
-/// new one for a path no test exercises yet — if `window`'s id is somehow
-/// already registered (practically unreachable: a freshly opened window has
-/// a fresh id by construction). [`RealmDispatchError::
-/// NestedCrossRealmDispatchRejected`] if a dispatch or hot-restart visit is
-/// currently in flight on this thread: **named gap, not a silent one** —
-/// unlike [`install_realm_alongside`]/[`uninstall_platform_realm`], this
-/// path does not yet defer to loop idle through
-/// `AppRuntime::pending_realm_mutations`; no production embedder call site
-/// opens a second presentation from inside a running callback yet, so
-/// there is nothing forcing that generalization today. Extending the
-/// deferral queue to presentation-install requests is follow-up work, not
-/// silently skipped: this refuses loudly (a `debug_assert!` in debug
+/// [`InstallPresentationError::RealmUnavailable`] if `dispatcher`'s realm no
+/// longer exists. [`InstallPresentationError::WindowAlreadyMapped`] if
+/// `window`'s id is somehow already registered (practically unreachable: a
+/// freshly opened window has a fresh id by construction) — nothing is
+/// installed into the forest in this case.
+/// [`InstallPresentationError::DispatchInFlight`] if a dispatch or
+/// hot-restart visit is currently in flight on this thread: **named gap,
+/// not a silent one** — unlike [`install_realm_alongside`]/
+/// [`uninstall_platform_realm`], this path does not yet defer to loop idle
+/// through `AppRuntime::pending_realm_mutations`; no production embedder
+/// call site opens a second presentation from inside a running callback
+/// yet, so there is nothing forcing that generalization today. Extending
+/// the deferral queue to presentation-install requests is follow-up work,
+/// not silently skipped: this refuses loudly (a `debug_assert!` in debug
 /// builds) rather than corrupting `AppRuntime` state.
 #[cfg(not(target_os = "ios"))]
 #[cfg_attr(
@@ -1495,7 +1525,7 @@ fn install_realm_alongside(
 fn install_presentation_alongside(
     dispatcher: RealmDispatcher,
     window: &std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
-) -> Result<RealmDispatcher, RealmDispatchError> {
+) -> Result<RealmDispatcher, InstallPresentationError> {
     let realm_id = dispatcher.address.realm_id;
     let owner_thread = dispatcher.owner_thread;
     APP_RUNTIME.with(|slot| {
@@ -1511,29 +1541,33 @@ fn install_presentation_alongside(
                 ?realm_id,
                 "rejecting install_presentation_alongside while a dispatch is in flight"
             );
-            return Err(RealmDispatchError::NestedCrossRealmDispatchRejected);
+            return Err(InstallPresentationError::DispatchInFlight);
         }
         let Some(realm_slot) = state.realms.get_mut(&realm_id) else {
-            return Err(RealmDispatchError::RealmUnavailable);
+            return Err(InstallPresentationError::RealmUnavailable);
         };
         let Some(realm) = realm_slot.realm.as_mut() else {
-            return Err(RealmDispatchError::RealmUnavailable);
+            return Err(InstallPresentationError::RealmUnavailable);
         };
-        let presentation_id = realm.install_presentation(std::sync::Arc::clone(window));
+        // Assemble WITHOUT installing yet -- see this function's own doc
+        // for why the ordering matters. `presentation` is dropped (no
+        // forest membership, so nothing to roll back) if registration
+        // below fails.
+        let presentation = realm.assemble_presentation(std::sync::Arc::clone(window));
         let address = flui_foundation::PresentationAddress {
             realm_id,
-            presentation_id,
+            presentation_id: presentation.id(),
         };
-        if let Err(error) = state.registry.try_register_window(window, address) {
-            tracing::error!(
-                ?error,
-                ?address,
-                "install_presentation_alongside: the fresh presentation's window id was \
-                 already registered -- folding this into RealmUnavailable, since no test \
-                 exercises a real collision here"
-            );
-            return Err(RealmDispatchError::RealmUnavailable);
-        }
+        state.registry.try_register_window(window, address)?;
+        let realm_slot = state
+            .realms
+            .get_mut(&realm_id)
+            .expect("BUG: presence checked above, and nothing between here and there removed it");
+        let realm = realm_slot
+            .realm
+            .as_mut()
+            .expect("BUG: presence checked above, and nothing between here and there took it");
+        realm.install_presentation(presentation);
         Ok(RealmDispatcher {
             owner_thread,
             address,
@@ -3895,11 +3929,11 @@ mod realm_dispatch_tests {
 
         let dispatcher = install_platform_realm(realm, &window_a);
         // B installs alongside A through the REAL production entry point
-        // (issue #555's addressed-routing slice), with its own genuine `WindowRegistry` mapping
-        // -- not the `cfg(test)`-only `install_second_presentation_for_test`
-        // bypass this test used before, which left B with no mapping of its
-        // own and is why `teardown_platform_realm()` used to have to be
-        // skipped here (see this test's `git blame` / `pr-notes-555-3.md`).
+        // (issue #555's addressed-routing slice), with its own genuine
+        // `WindowRegistry` mapping -- not the `cfg(test)`-only
+        // `install_second_presentation_for_test` bypass this test used
+        // before, which left B with no mapping of its own and is why
+        // `teardown_platform_realm()` used to have to be skipped here.
         let b_dispatcher = install_presentation_alongside(dispatcher, &window_b)
             .expect("B installs alongside A with a real window mapping");
         let b_id = b_dispatcher.address.presentation_id;
@@ -4218,6 +4252,140 @@ mod realm_dispatch_tests {
 
         // Harmless no-op cleanup (the realm is already gone) -- matches
         // every other test in this module for the same TLS-state hygiene.
+        teardown_platform_realm();
+    }
+
+    /// `FocusCoordinator`'s two write-side behaviors, end to end through the
+    /// REAL production path (`dispatch_platform_realm` running a genuine
+    /// `RealmTask::Event(PlatformToUi::WindowFocus(_))` task, not a direct
+    /// `notify_presentation_focus_gained` call): `WindowFocus(true)`
+    /// dispatched for a presentation moves the active presentation to it;
+    /// `WindowFocus(false)` dispatched for a DIFFERENT, non-active
+    /// presentation never moves it away from whichever presentation is
+    /// currently active.
+    ///
+    /// Mutant: `PlatformToUi::run`'s `WindowFocus` arm calls
+    /// `notify_presentation_focus_gained` inside `if focused { .. }` --
+    /// removing that guard (calling it unconditionally, so `WindowFocus(false)`
+    /// also moves active) makes this fail: the final assertion would observe
+    /// A active instead of B.
+    #[test]
+    fn window_focus_true_moves_active_presentation_end_to_end_and_false_does_not() {
+        // One shared platform instance for both windows -- see
+        // `install_two_test_realms`'s doc for why two independent
+        // `headless_platform()` calls would risk an aliased window id.
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
+
+        let realm = super::super::ui_realm::UiRealm::for_test();
+        let dispatcher_a = install_platform_realm(realm, &window_a);
+        let a_id = dispatcher_a.address.presentation_id;
+        let dispatcher_b = install_presentation_alongside(dispatcher_a, &window_b)
+            .expect("B installs alongside A with a real window mapping");
+        let b_id = dispatcher_b.address.presentation_id;
+
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(move |realm| {
+                assert_eq!(
+                    realm.active_presentation_for_test(),
+                    a_id,
+                    "precondition: a freshly installed realm starts with its primary active"
+                );
+            })),
+        )
+        .expect("precondition frame task dispatches");
+
+        // WindowFocus(true) dispatched for B, through the REAL dispatch
+        // seam -- not a direct notify_presentation_focus_gained call.
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Event(PlatformToUi::WindowFocus(true)),
+        )
+        .expect("WindowFocus(true) for B dispatches");
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(move |realm| {
+                assert_eq!(
+                    realm.active_presentation_for_test(),
+                    b_id,
+                    "WindowFocus(true) dispatched through the real production path must move \
+                     the active presentation to the presentation it was addressed to"
+                );
+            })),
+        )
+        .expect("frame task dispatches");
+
+        // WindowFocus(false) dispatched for A -- NOT the currently active
+        // presentation (B is) -- must never move active away from B.
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Event(PlatformToUi::WindowFocus(false)),
+        )
+        .expect("WindowFocus(false) for A dispatches");
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(move |realm| {
+                assert_eq!(
+                    realm.active_presentation_for_test(),
+                    b_id,
+                    "WindowFocus(false) must never move the active presentation, regardless \
+                     of which presentation it was addressed to"
+                );
+            })),
+        )
+        .expect("frame task dispatches");
+
+        teardown_platform_realm();
+    }
+
+    /// If `window`'s id is already registered (forced here by reusing A's
+    /// OWN window as the "second" presentation's window), the forest must
+    /// be left EXACTLY as it was -- no presentation resident without a
+    /// registry mapping of its own (`single-native-window-map-authority`).
+    ///
+    /// If reverted (installing into the forest BEFORE registering, with no
+    /// rollback on failure -- the pre-fix ordering): this fails --
+    /// `presentation_count()` observes `2` instead of `1`, a forest-resident
+    /// presentation this test's own colliding window never actually mapped.
+    #[test]
+    fn install_presentation_alongside_leaves_the_forest_unchanged_on_registration_failure() {
+        let window_a = test_window();
+        let realm = super::super::ui_realm::UiRealm::for_test();
+        let dispatcher = install_platform_realm(realm, &window_a);
+
+        // Reusing A's own window forces `try_register_window` to fail --
+        // its id is already mapped to A's own address.
+        let result = install_presentation_alongside(dispatcher, &window_a);
+        assert!(
+            matches!(
+                result,
+                Err(InstallPresentationError::WindowAlreadyMapped(_))
+            ),
+            "a colliding window id must be refused as WindowAlreadyMapped, got {result:?}"
+        );
+
+        let count = Rc::new(Cell::new(None));
+        let count_in_task = Rc::clone(&count);
+        dispatch_platform_realm(
+            dispatcher,
+            RealmTask::Frame(Box::new(move |realm| {
+                count_in_task.set(Some(realm.presentation_count()));
+            })),
+        )
+        .expect("frame task dispatches");
+        assert_eq!(
+            count.get(),
+            Some(1),
+            "a registration failure must leave the forest exactly as it was -- the \
+             assembled-but-unregistered presentation must never have been installed"
+        );
+
         teardown_platform_realm();
     }
 }

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -487,15 +487,27 @@ pub(super) enum RealmTask {
 impl RealmTask {
     /// Runs an `Event`/`Frame` task against the realm's shared capabilities.
     ///
+    /// `presentation_id` is the [`flui_foundation::PresentationId`] the
+    /// enqueueing [`RealmDispatcher`] was addressed to — stamped onto this
+    /// task's queue entry at enqueue time (`dispatch_platform_realm`), since
+    /// a realm's queue is shared across every presentation it hosts (issue
+    /// #555 the addressed-routing slice). `Self::Frame`'s closure ignores it (the
+    /// frame pump is realm-wide, not presentation-addressed); only
+    /// `Self::Event` threads it through to [`PlatformToUi::run`].
+    ///
     /// # Panics
     /// Panics if called with `Self::ClosePresentation` — that variant never
     /// reaches this method: [`dispatch_platform_realm`]'s drain loop matches
     /// it out before calling `run`, since it needs `&mut UiRealm` instead of
     /// this method's `&UiRealm` receiver. Not reachable from any other
     /// caller — `run` has exactly one call site.
-    fn run(self, realm: &super::ui_realm::UiRealm) {
+    fn run(
+        self,
+        realm: &super::ui_realm::UiRealm,
+        presentation_id: flui_foundation::PresentationId,
+    ) {
         match self {
-            Self::Event(event) => event.run(realm),
+            Self::Event(event) => event.run(realm, presentation_id),
             Self::Frame(run) => run(realm),
             Self::ClosePresentation(id) => unreachable!(
                 "BUG: RealmTask::ClosePresentation({id:?}) reached RealmTask::run -- \
@@ -509,9 +521,24 @@ impl RealmTask {
 
 #[cfg(not(target_os = "ios"))]
 impl PlatformToUi {
-    fn run(self, realm: &super::ui_realm::UiRealm) {
+    /// `presentation_id` is the exact presentation this event was stamped
+    /// for at enqueue time (see [`RealmTask::run`]'s doc). `Input` delivers
+    /// to it through [`super::ui_realm::UiRealm::handle_input_addressed`];
+    /// every other variant (`Resized`/`WindowFocus`/`WindowVisibility`/
+    /// `Lifecycle`) is still realm-wide, not yet per-presentation-addressed
+    /// — a stated, named gap (not silent): resize/lifecycle addressing
+    /// across a genuine N>1 forest is future work, out of this hop-2 slice's
+    /// bounded scope (input/IME/semantics/keyboard/redraw), except
+    /// `WindowFocus(true)`, which DOES use `presentation_id` to update
+    /// [`super::ui_realm::UiRealm::notify_presentation_focus_gained`] — see
+    /// that arm below.
+    fn run(
+        self,
+        realm: &super::ui_realm::UiRealm,
+        presentation_id: flui_foundation::PresentationId,
+    ) {
         match self {
-            Self::Input(input) => realm.handle_input_entered(input),
+            Self::Input(input) => realm.handle_input_addressed(presentation_id, input),
             Self::Resized { size, scale_factor } => {
                 // Take the applier out of THIS realm's slot, release the
                 // borrow, call it, then restore it — never call through a
@@ -560,6 +587,13 @@ impl PlatformToUi {
                     state.focused = focused;
                     (old, derive_lifecycle_state(state.visible, state.focused))
                 });
+                if focused {
+                    // FocusCoordinator (issue #555's addressed-routing slice): this event's own
+                    // stamped presentation is the one whose window just
+                    // gained OS focus -- keyboard input routes there until
+                    // a DIFFERENT presentation's window reports focus next.
+                    realm.notify_presentation_focus_gained(presentation_id);
+                }
                 emit_lifecycle_transition(realm, old, new);
             }
             Self::WindowVisibility(visible) => {
@@ -1414,6 +1448,99 @@ fn install_realm_alongside(
     }
 }
 
+/// Installs another presentation into `dispatcher`'s realm, alongside
+/// whatever it already hosts — the addressed-routing counterpart to
+/// [`install_realm_alongside`] (which installs a second REALM instead of a
+/// second presentation of the SAME realm). This is the production entry
+/// point [`super::presentation_forest::PresentationForest`]'s doc and
+/// `docs/runtime-contract.toml`'s `multi-presentation-forest-gate` entry
+/// both point to: the forest's former `len()<=1` ratchet lifted (issue #555
+///) specifically so this function has somewhere real to install into.
+///
+/// `window` becomes the fresh presentation's own native window; its
+/// `WindowRegistry` mapping is minted in the SAME call, at the fresh
+/// presentation's real address, so the returned [`RealmDispatcher`] is
+/// dispatchable the moment this returns — no window is ever left resident
+/// in the forest without a registry entry of its own (the still-open gap
+/// this function closes; see `docs/pr-notes-555-3.md`'s "recommended next
+/// steps" for the exact residual).
+///
+/// # Errors
+///
+/// [`RealmDispatchError::RealmUnavailable`] if `dispatcher`'s realm no
+/// longer exists, OR — folded into the same variant rather than growing a
+/// new one for a path no test exercises yet — if `window`'s id is somehow
+/// already registered (practically unreachable: a freshly opened window has
+/// a fresh id by construction). [`RealmDispatchError::
+/// NestedCrossRealmDispatchRejected`] if a dispatch or hot-restart visit is
+/// currently in flight on this thread: **named gap, not a silent one** —
+/// unlike [`install_realm_alongside`]/[`uninstall_platform_realm`], this
+/// path does not yet defer to loop idle through
+/// `AppRuntime::pending_realm_mutations`; no production embedder call site
+/// opens a second presentation from inside a running callback yet, so
+/// there is nothing forcing that generalization today. Extending the
+/// deferral queue to presentation-install requests is follow-up work, not
+/// silently skipped: this refuses loudly (a `debug_assert!` in debug
+/// builds) rather than corrupting `AppRuntime` state.
+#[cfg(not(target_os = "ios"))]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "design-for-N presentation-install path; no production embedder call site \
+                  opens a second presentation of an existing realm yet -- exercised by this \
+                  module's own tests"
+    )
+)]
+fn install_presentation_alongside(
+    dispatcher: RealmDispatcher,
+    window: &std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
+) -> Result<RealmDispatcher, RealmDispatchError> {
+    let realm_id = dispatcher.address.realm_id;
+    let owner_thread = dispatcher.owner_thread;
+    APP_RUNTIME.with(|slot| {
+        let mut state = slot.borrow_mut();
+        if state.dispatched_realm_id.is_some() || state.iterating_all_realms {
+            debug_assert!(
+                false,
+                "BUG: install_presentation_alongside called while a dispatch/hot-restart visit \
+                 is in flight -- this path has no defer-to-idle queue yet (a named, stated gap, \
+                 not a silent one); call only from outside any dispatched callback"
+            );
+            tracing::error!(
+                ?realm_id,
+                "rejecting install_presentation_alongside while a dispatch is in flight"
+            );
+            return Err(RealmDispatchError::NestedCrossRealmDispatchRejected);
+        }
+        let Some(realm_slot) = state.realms.get_mut(&realm_id) else {
+            return Err(RealmDispatchError::RealmUnavailable);
+        };
+        let Some(realm) = realm_slot.realm.as_mut() else {
+            return Err(RealmDispatchError::RealmUnavailable);
+        };
+        let presentation_id = realm.install_presentation(std::sync::Arc::clone(window));
+        let address = flui_foundation::PresentationAddress {
+            realm_id,
+            presentation_id,
+        };
+        if let Err(error) = state.registry.try_register_window(window, address) {
+            tracing::error!(
+                ?error,
+                ?address,
+                "install_presentation_alongside: the fresh presentation's window id was \
+                 already registered -- folding this into RealmUnavailable, since no test \
+                 exercises a real collision here"
+            );
+            return Err(RealmDispatchError::RealmUnavailable);
+        }
+        Ok(RealmDispatcher {
+            owner_thread,
+            address,
+        })
+    })
+}
+
 /// Uninstalls exactly one realm — a single window closing while siblings
 /// stay open — without disturbing any other hosted realm. Requests the
 /// removal through
@@ -1499,10 +1626,7 @@ fn dispatch_platform_realm(
         // Normative compare order (ADR-0037): realm first, then
         // presentation. `realm_id`/`presentation_id` mint from one shared
         // counter, so teardown+reinstall always changes both and the realm
-        // check fires first on the common path; `StalePresentation` is
-        // reachable only when the realm half matches but the presentation
-        // half does not (a forged/mixed address today; real presentation
-        // replacement within a live realm once a forest exists).
+        // check fires first on the common path.
         if state.realms.is_empty() {
             tracing::debug!(
                 ?dispatcher,
@@ -1510,28 +1634,45 @@ fn dispatch_platform_realm(
             );
             return Err(RealmDispatchError::RealmUnavailable);
         }
-        let Some(realm_slot) = state.realms.get_mut(&realm_id) else {
+        if !state.realms.contains_key(&realm_id) {
             tracing::debug!(
                 ?dispatcher,
                 "dropping realm callback: a newer realm replaced the one it was dispatched for"
             );
             return Err(RealmDispatchError::StaleRealm);
-        };
-        if realm_slot.address.presentation_id != dispatcher.address.presentation_id {
+        }
+        // Presentation check (issue #555's addressed-routing slice): membership in the SAME
+        // `WindowRegistry` authority `dispatch_platform_realm`'s own
+        // production window callbacks are resolved through, not equality
+        // against `realm_slot.address` (which tracks only ONE presentation —
+        // this realm's primary). A realm hosting N presentations has N live
+        // addresses at once; a dispatcher naming any one of them, as long as
+        // its exact address is still registered, is live -- one closed
+        // (unregistered) since the dispatcher was minted, or a forged/mixed
+        // address, is `StalePresentation` either way. Checked BEFORE
+        // borrowing `realm_slot` mutably below (the registry is a sibling
+        // field on the same `state`, so an immutable read here and a mutable
+        // `realms` borrow next cannot overlap).
+        if !state.registry.contains_address(dispatcher.address) {
             tracing::debug!(
                 ?dispatcher,
-                current_address = ?realm_slot.address,
                 "dropping realm callback: presentation incarnation mismatch within the live realm"
             );
             return Err(RealmDispatchError::StalePresentation);
         }
+        let realm_slot = state
+            .realms
+            .get_mut(&realm_id)
+            .expect("BUG: presence just checked above via contains_key");
         // Same-realm reentrancy: this realm is already draining (mid its
         // own drain loop below) or checked out (by its own dispatch, or by
         // a `for_each_installed_realm` visit) -- always safe to enqueue and
         // return early; the ongoing drain loop, or the next legitimate
         // dispatch once the realm is restored, picks the event up.
         if realm_slot.draining || realm_slot.realm.is_none() {
-            realm_slot.queue.push_back(event);
+            realm_slot
+                .queue
+                .push_back((dispatcher.address.presentation_id, event));
             return Ok(None);
         }
         // Nested cross-realm dispatch guard (issue #555), checked BEFORE
@@ -1567,7 +1708,9 @@ fn dispatch_platform_realm(
             .realms
             .get_mut(&realm_id)
             .expect("BUG: presence checked above");
-        realm_slot.queue.push_back(event);
+        realm_slot
+            .queue
+            .push_back((dispatcher.address.presentation_id, event));
         let first = realm_slot
             .queue
             .pop_front()
@@ -1596,7 +1739,7 @@ fn dispatch_platform_realm(
     // only to restore the host invariants; the original panic is resumed.
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut next = Some(first);
-        while let Some(event) = next {
+        while let Some((task_presentation_id, event)) = next {
             // `ClosePresentation` is matched out here, before it would
             // otherwise reach `RealmTask::run`'s `&UiRealm` receiver: closing
             // a presentation removes it from the forest (`&mut UiRealm`),
@@ -1685,7 +1828,7 @@ fn dispatch_platform_realm(
                         realm.close_presentation_entered(id);
                     }
                 }
-                other => realm.enter(|realm| other.run(realm)),
+                other => realm.enter(|realm| other.run(realm, task_presentation_id)),
             }
             next = APP_RUNTIME.with(|slot| {
                 slot.borrow_mut()
@@ -2057,14 +2200,16 @@ mod realm_dispatch_tests {
                 .realms
                 .get_mut(&dispatcher_a.address.realm_id)
                 .expect("dispatcher_a's realm is installed above");
-            realm_slot
-                .queue
-                .push_back(RealmTask::Frame(Box::new(move |_| {
+            let stamp = dispatcher_a.address.presentation_id;
+            realm_slot.queue.push_back((
+                stamp,
+                RealmTask::Frame(Box::new(move |_| {
                     *delivered_in_event.borrow_mut() = true;
-                })));
+                })),
+            ));
             realm_slot
                 .queue
-                .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
+                .push_back((stamp, RealmTask::Frame(Box::new(move |_| drop(probe)))));
             realm_slot.draining = true;
         });
 
@@ -2381,20 +2526,23 @@ mod realm_dispatch_tests {
                 .realms
                 .get_mut(&dispatcher.address.realm_id)
                 .expect("just installed above");
-            realm_slot
-                .queue
-                .push_back(RealmTask::Frame(Box::new(move |_| {
+            let stamp = dispatcher.address.presentation_id;
+            realm_slot.queue.push_back((
+                stamp,
+                RealmTask::Frame(Box::new(move |_| {
                     *delivered_in_event.borrow_mut() = true;
-                })));
-            realm_slot
-                .queue
-                .push_back(RealmTask::Event(PlatformToUi::Resized {
+                })),
+            ));
+            realm_slot.queue.push_back((
+                stamp,
+                RealmTask::Event(PlatformToUi::Resized {
                     size: flui_types::Size::new(
                         flui_types::geometry::px(100.0),
                         flui_types::geometry::px(100.0),
                     ),
                     scale_factor: 1.0,
-                }));
+                }),
+            ));
         });
 
         teardown_platform_realm();
@@ -2609,7 +2757,10 @@ mod realm_dispatch_tests {
                 .get_mut(&dispatcher.address.realm_id)
                 .expect("just installed above")
                 .queue
-                .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
+                .push_back((
+                    dispatcher.address.presentation_id,
+                    RealmTask::Frame(Box::new(move |_| drop(probe))),
+                ));
         });
         teardown_platform_realm();
         assert!(*dropped.borrow());
@@ -3696,34 +3847,31 @@ mod realm_dispatch_tests {
             }
         }
 
-        // One shared platform instance for BOTH windows -- see
+        // One shared platform instance for every window -- see
         // `install_two_test_realms`'s doc for why two independent
         // `headless_platform()` calls would risk an aliased window id.
         let platform = flui_platform::headless_platform();
         let window_a = platform
             .open_window(flui_platform::WindowOptions::default())
             .expect("headless platform should create window a");
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
         let window_for_new_realm = platform
             .open_window(flui_platform::WindowOptions::default())
             .expect("headless platform should create the second window");
 
-        let mut realm = super::super::ui_realm::UiRealm::for_test();
+        let realm = super::super::ui_realm::UiRealm::for_test();
         let a_id = realm.presentation_id();
-        let b_id = realm.install_second_presentation_for_test();
 
         let key_in_sibling = flui_view::GlobalKey::<()>::new();
         let element_in_sibling = flui_foundation::ElementId::new(1);
-        realm
-            .presentation_widgets_for_test(b_id)
-            .with_build_owner_mut(|owner| {
-                owner.register_global_key(key_in_sibling.id(), element_in_sibling);
-            });
 
         let resolved_sibling_element = Rc::new(Cell::new(None));
         let install_deferred = Rc::new(Cell::new(None));
         let opened_realm_id = Rc::new(Cell::new(None));
         let probe = OpenWindowOnDisposeView {
-            key_in_sibling,
+            key_in_sibling: key_in_sibling.clone(),
             new_window: window_for_new_realm,
             resolved_sibling_element: Rc::clone(&resolved_sibling_element),
             install_deferred: Rc::clone(&install_deferred),
@@ -3746,6 +3894,33 @@ mod realm_dispatch_tests {
         ));
 
         let dispatcher = install_platform_realm(realm, &window_a);
+        // B installs alongside A through the REAL production entry point
+        // (issue #555's addressed-routing slice), with its own genuine `WindowRegistry` mapping
+        // -- not the `cfg(test)`-only `install_second_presentation_for_test`
+        // bypass this test used before, which left B with no mapping of its
+        // own and is why `teardown_platform_realm()` used to have to be
+        // skipped here (see this test's `git blame` / `pr-notes-555-3.md`).
+        let b_dispatcher = install_presentation_alongside(dispatcher, &window_b)
+            .expect("B installs alongside A with a real window mapping");
+        let b_id = b_dispatcher.address.presentation_id;
+
+        // Register the sibling key into B directly: no dispatch is in
+        // flight yet (registration itself needs no active composite; only
+        // resolution via `GlobalKey::current_element` does, which is what
+        // A's dispose hook below exercises).
+        APP_RUNTIME.with(|slot| {
+            let state = slot.borrow();
+            let realm_slot = state
+                .realms
+                .get(&dispatcher.address.realm_id)
+                .expect("installed above");
+            let realm = realm_slot.realm.as_ref().expect("not checked out yet");
+            realm
+                .presentation_widgets_for_test(b_id)
+                .with_build_owner_mut(|owner| {
+                    owner.register_global_key(key_in_sibling.id(), element_in_sibling);
+                });
+        });
 
         close_presentation(dispatcher, a_id).expect("A closes through the real dispatch seam");
 
@@ -3770,17 +3945,13 @@ mod realm_dispatch_tests {
             "the deferred install must land once A's close dispatch restores"
         );
 
-        // No `teardown_platform_realm()` here, deliberately -- same reason
-        // as `closing_a_presentation_unregisters_its_window_mapping`: this
-        // test's own `install_second_presentation_for_test` fixture bypasses
-        // the production ratchet to give B no window mapping of its own, so
-        // after A closes and the surviving realm's tracked address re-stamps
-        // to B, teardown's own self-check (every live realm's tracked
-        // address must resolve to at least one registered window) no
-        // longer holds -- a still-open design-for-N gap, not something this
-        // test can paper over. Each nextest test runs in its own process,
-        // so skipping teardown here leaks nothing another test could
-        // observe.
+        // B now has a real `WindowRegistry` mapping of its own (minted by
+        // `install_presentation_alongside` above), so after A closes and the
+        // surviving realm's tracked address re-stamps to B, teardown's own
+        // self-check ("every live realm's tracked address resolves to a
+        // registered window") holds again -- the still-open design-for-N gap
+        // this test used to skip teardown for is closed.
+        teardown_platform_realm();
     }
 
     /// Closing presentation A (a sibling, B, stays open) must unregister
@@ -3800,13 +3971,20 @@ mod realm_dispatch_tests {
         let window_a = platform
             .open_window(flui_platform::WindowOptions::default())
             .expect("headless platform should create window a");
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
 
-        let mut realm = super::super::ui_realm::UiRealm::for_test();
+        let realm = super::super::ui_realm::UiRealm::for_test();
         let a_id = realm.presentation_id();
-        let _b_id = realm.install_second_presentation_for_test();
 
         let dispatcher = install_platform_realm(realm, &window_a);
         let realm_id = dispatcher.address.realm_id;
+        // B installs alongside A through the real production entry point
+        // (issue #555's addressed-routing slice), with its own genuine `WindowRegistry` mapping.
+        let b_dispatcher = install_presentation_alongside(dispatcher, &window_b)
+            .expect("B installs alongside A with a real window mapping");
+        let b_id = b_dispatcher.address.presentation_id;
 
         assert_eq!(
             APP_RUNTIME.with(|slot| slot.borrow().registry.resolve(window_a.id())),
@@ -3815,6 +3993,11 @@ mod realm_dispatch_tests {
                 presentation_id: a_id,
             }),
             "precondition: A's window starts mapped to A's own address"
+        );
+        assert_eq!(
+            APP_RUNTIME.with(|slot| slot.borrow().registry.resolve(window_b.id())),
+            Some(b_dispatcher.address),
+            "precondition: B's window starts mapped to B's own address"
         );
 
         close_presentation(dispatcher, a_id).expect("A closes through the real dispatch seam");
@@ -3825,6 +4008,12 @@ mod realm_dispatch_tests {
             "closing A must unregister its own window mapping -- leaving it mapped would let \
              a stale platform event for that exact window keep resolving to A's now-dead \
              PresentationId"
+        );
+        assert_eq!(
+            APP_RUNTIME.with(|slot| slot.borrow().registry.resolve(window_b.id())),
+            Some(b_dispatcher.address),
+            "closing A must never touch B's own window mapping -- hop-1 demux is per-window, \
+             not per-realm"
         );
 
         let delivered = Rc::new(Cell::new(false));
@@ -3846,19 +4035,14 @@ mod realm_dispatch_tests {
              primary), exactly the sibling-reach bug this test guards"
         );
 
-        // No `teardown_platform_realm()` here, deliberately: this test's own
-        // fixture (`install_second_presentation_for_test`) bypasses the
-        // production ratchet to give B no window mapping of its own -- the
-        // real, still-open design-for-N gap this whole test exists to probe
-        // one corner of, not something this test can paper over. Calling
-        // teardown would trip ITS OWN debug-only self-check (every live
-        // realm's tracked address must resolve to at least one registered
-        // window), which no longer holds once B, unregistered, becomes the
-        // realm's tracked primary. Each nextest test runs in its own
-        // process (see this crate's own `AGENTS.md`), so skipping teardown
-        // here leaks nothing another test could observe -- the process
-        // exit itself drops `APP_RUNTIME`, running `UiRealm::Drop`'s
-        // best-effort close loop for B as the natural fallback.
+        // B has a real `WindowRegistry` mapping of its own (minted by
+        // `install_presentation_alongside` above), so teardown's own
+        // self-check ("every live realm's tracked address resolves to a
+        // registered window") holds even after A closes and the surviving
+        // realm's tracked address re-stamps to B -- the still-open
+        // design-for-N gap this test used to skip teardown for is closed.
+        teardown_platform_realm();
+        let _ = b_id;
     }
 
     /// A dispose hook that re-enters `dispatch_platform_realm` DURING the
@@ -3936,9 +4120,19 @@ mod realm_dispatch_tests {
             }
         }
 
-        let mut realm = super::super::ui_realm::UiRealm::for_test();
+        // One shared platform instance for both windows -- see
+        // `install_two_test_realms`'s doc for why two independent
+        // `headless_platform()` calls would risk an aliased window id.
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
+
+        let realm = super::super::ui_realm::UiRealm::for_test();
         let a_id = realm.presentation_id();
-        let _b_id = realm.install_second_presentation_for_test();
 
         let dispatcher_slot = Rc::new(Cell::new(None));
         let reentrant_result = Rc::new(Cell::new(None));
@@ -3962,7 +4156,11 @@ mod realm_dispatch_tests {
             ),
         ));
 
-        let dispatcher = install_platform_realm(realm, &test_window());
+        let dispatcher = install_platform_realm(realm, &window_a);
+        // B installs alongside A through the real production entry point
+        // (issue #555's addressed-routing slice), with its own genuine `WindowRegistry` mapping.
+        let _b_dispatcher = install_presentation_alongside(dispatcher, &window_b)
+            .expect("B installs alongside A with a real window mapping");
         dispatcher_slot.set(Some(dispatcher));
 
         close_presentation(dispatcher, a_id).expect("A closes through the real dispatch seam");
@@ -3983,9 +4181,13 @@ mod realm_dispatch_tests {
              rather than refused"
         );
 
-        // No `teardown_platform_realm()` here either, for the identical
-        // reason `closing_a_presentation_unregisters_its_window_mapping`
-        // skips it -- see that test's own closing comment.
+        // B has a real `WindowRegistry` mapping of its own (minted by
+        // `install_presentation_alongside` above), so teardown's own
+        // self-check holds even after A closes and the surviving realm's
+        // tracked address re-stamps to B -- see
+        // `closing_a_presentation_unregisters_its_window_mapping`'s closing
+        // comment for the full explanation of the gap this closes.
+        teardown_platform_realm();
     }
 
     /// Closing a realm's SOLE presentation must not leave a live realm with

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -256,8 +256,18 @@ pub(super) struct RealmSlot {
     pub(super) realm: Option<UiRealm>,
     /// This realm's own owner-thread work queue — never shared with a
     /// sibling realm's queue, so draining one realm's events can never pop a
-    /// task meant for another.
-    pub(super) queue: VecDeque<RealmTask>,
+    /// task meant for another. Each entry is stamped with the
+    /// [`PresentationId`] of the `RealmDispatcher` (`runner.rs`, private to
+    /// that module) that enqueued it (issue #555's addressed-routing slice): a
+    /// realm's queue is shared across every presentation it hosts, so which
+    /// window produced a given `RealmTask::Event` cannot be recovered from
+    /// the queue's OWN dispatch call alone once more than one presentation's
+    /// window can enqueue into it — the stamp travels with the task itself
+    /// instead. `RealmTask::Frame`/`ClosePresentation` ignore their stamp
+    /// (frame pump is realm-wide; `ClosePresentation` already carries its
+    /// own target id as its payload) — only `RealmTask::Event` reads it, in
+    /// `PlatformToUi::run` (`runner.rs`).
+    pub(super) queue: VecDeque<(PresentationId, RealmTask)>,
     /// Set while a queued task for THIS realm is running, so a reentrant
     /// same-realm dispatch enqueues instead of recursing into `realm.take()`.
     pub(super) draining: bool,

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -537,10 +537,22 @@ pub(crate) struct AppRuntime {
     ///
     /// **Known limitation, stated rather than silently overclaimed:** this
     /// pair is still loop-scoped, not per-realm — with more than one
-    /// hosted realm, a focus/visibility change on any one window's OS
-    /// signal drives the SAME derivation for the whole loop. Per-realm
-    /// lifecycle derivation is `FocusCoordinator` territory (a later, exact-routing
-    /// slice of issue #555), out of this change's scope.
+    /// hosted REALM, a focus/visibility change on any one window's OS
+    /// signal drives the SAME derivation for every realm on this loop.
+    /// Issue #555's addressed-routing slice narrowed this for the
+    /// WITHIN-one-realm case (more than one PRESENTATION of the same
+    /// realm): `runner.rs`'s `PlatformToUi::WindowFocus` handling now
+    /// checks `UiRealm::is_active_presentation` before applying a `false`
+    /// signal to this field, so a non-active presentation's own window
+    /// losing OS focus (a normal consequence of focus having already moved
+    /// to a sibling presentation of that SAME realm) no longer suspends it
+    /// — only the realm's currently active presentation's own focus-loss
+    /// is authoritative. The remaining, unaddressed gap is strictly
+    /// cross-REALM: this field has no realm identity at all, so a focus
+    /// change on realm A's window still drives realm B's own lifecycle
+    /// derivation too. A genuinely per-realm `(visible, focused)` pair
+    /// (moving these fields onto `RealmSlot`) is the fix for that
+    /// remainder, out of this slice's scope.
     pub(super) visible: bool,
     pub(super) focused: bool,
     /// The loop-scoped owner-thread platform capability (ADR-0039 §6).

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -95,9 +95,13 @@ impl FocusCoordinator {
         self.active.get()
     }
 
-    /// Record that `id`'s native window just gained OS focus — the sole
-    /// production write side (`PlatformToUi::WindowFocus(true)` handling,
-    /// `runner.rs`).
+    /// Record that `id` is now the active presentation. Two write sides:
+    /// `PlatformToUi::WindowFocus(true)` handling (`runner.rs`) calls this
+    /// with the event's own addressed presentation when its native window
+    /// gains OS focus; [`UiRealm::close_presentation_entered`] calls this
+    /// with the surviving primary when `id` is the presentation being
+    /// closed and it was the active one (never leave this pointing at a
+    /// presentation the forest is about to drop).
     ///
     /// A `WindowFocus(false)` (focus LOST) never calls this: losing focus
     /// names no new owner, so the coordinator keeps pointing at whichever
@@ -433,10 +437,10 @@ pub(crate) struct UiRealm {
     /// installed into every presentation's `BuildOwner` at assembly time
     /// (`PresentationState::new`). Retained here (not just handed off once)
     /// so a later-installed presentation can share the same scope: both
-    /// [`Self::install_presentation`] (production, issue #555's addressed-routing slice) and the
-    /// `cfg(test)`-only `global_key_scope` accessor below (the isolation
-    /// test suite) read it back to assemble a second presentation sharing
-    /// this exact scope.
+    /// [`Self::assemble_presentation`] (production, issue #555's
+    /// addressed-routing slice) and its `install_second_presentation_for_test`
+    /// counterpart (the isolation test suite) read it back to assemble a
+    /// second presentation sharing this exact scope.
     global_key_scope: GlobalKeyScope,
     /// The insertion-ordered set of UI-owner presentation domains this realm
     /// hosts (ADR-0043 §1 — `PresentationForest`). Production topology
@@ -903,7 +907,7 @@ impl UiRealm {
     /// addressed counterpart to [`Self::text_input_handle`] (primary-only),
     /// for the isolation suite proving IME sessions stay exclusive to the
     /// exact presentation they were attached on
-    /// (`ime_attach_on_a_does_not_detach_bs_session`).
+    /// (`ime_event_addressed_to_b_does_not_reach_as_session`).
     #[must_use]
     #[cfg(test)]
     pub(crate) fn presentation_text_input_handle_for_test(
@@ -916,28 +920,27 @@ impl UiRealm {
             .text_input_handle()
     }
 
-    /// Assemble and install another presentation into this realm, sharing
-    /// its exact `GlobalKeyScope` and realm-level dispatch handles — the
-    /// production entry point (this slice lifted
-    /// `PresentationForest::install`'s former `len()<=1` ratchet).
+    /// Assemble another presentation for this realm, sharing its exact
+    /// `GlobalKeyScope` and realm-level dispatch handles — WITHOUT
+    /// installing it into the forest yet. Deliberately split from
+    /// [`Self::install_presentation`] below: a caller that must register a
+    /// `WindowRegistry` mapping before this presentation is safely
+    /// dispatchable (`runner.rs::install_presentation_alongside`) can do so
+    /// BETWEEN assembly and installation — if registration fails, the
+    /// assembled-but-never-installed `PresentationState` is simply dropped
+    /// (no forest membership to roll back; its construction has no
+    /// observable side effect on anything this realm shares, since nothing
+    /// has attached/mounted into it yet).
     ///
     /// `window` becomes this presentation's own native window (cursor,
-    /// haptics, redraw-poke — see `PresentationState::new`'s wiring); the
-    /// caller is responsible for minting its `WindowRegistry` mapping —
-    /// `UiRealm` has no access to that registry (ADR-0037 §2), exactly the
-    /// same split [`Self::close_presentation_entered`]'s own doc states for
-    /// teardown. `runner.rs::install_presentation_alongside` is that
-    /// caller in production; `Self::install_second_presentation_for_test`
-    /// (`cfg(test)`-only, no stable link target in a non-test doc build) is
-    /// the test-only counterpart for `UiRealm`-only tests that never touch
-    /// `AppRuntime`/`WindowRegistry` at all.
-    pub(crate) fn install_presentation(
-        &mut self,
+    /// haptics, redraw-poke — see `PresentationState::new`'s wiring).
+    pub(crate) fn assemble_presentation(
+        &self,
         window: Arc<dyn PlatformWindow>,
-    ) -> PresentationId {
+    ) -> PresentationState {
         let (_, presentation_id) = super::runtime::next_identity();
         let pipeline = PipelineCell::new(PipelineOwner::new());
-        let presentation = PresentationState::new(
+        PresentationState::new(
             presentation_id,
             pipeline,
             window,
@@ -949,7 +952,29 @@ impl UiRealm {
                 scheduler: &self.scheduler,
                 wake: Arc::clone(&self.wake),
             },
-        );
+        )
+    }
+
+    /// Install an already-[`assembled`](Self::assemble_presentation)
+    /// presentation into this realm's forest — the production entry point
+    /// (this slice lifted `PresentationForest::install`'s former
+    /// `len()<=1` ratchet).
+    ///
+    /// The caller is responsible for minting this presentation's
+    /// `WindowRegistry` mapping BEFORE calling this (typically between
+    /// `assemble_presentation` and this call) — `UiRealm` has no access to
+    /// that registry (ADR-0037 §2), exactly the same split
+    /// [`Self::close_presentation_entered`]'s own doc states for teardown.
+    /// `runner.rs::install_presentation_alongside` is that caller in
+    /// production; `Self::install_second_presentation_for_test`
+    /// (`cfg(test)`-only, no stable link target in a non-test doc build) is
+    /// the test-only counterpart for `UiRealm`-only tests that never touch
+    /// `AppRuntime`/`WindowRegistry` at all.
+    pub(crate) fn install_presentation(
+        &mut self,
+        presentation: PresentationState,
+    ) -> PresentationId {
+        let presentation_id = presentation.id();
         self.presentations.install(presentation);
         presentation_id
     }
@@ -966,7 +991,8 @@ impl UiRealm {
     #[cfg(test)]
     pub(crate) fn install_second_presentation_for_test(&mut self) -> PresentationId {
         let window = super::presentation::test_platform_window(None);
-        self.install_presentation(window)
+        let presentation = self.assemble_presentation(window);
+        self.install_presentation(presentation)
     }
 
     /// The presentation keyboard input currently routes to
@@ -1910,13 +1936,15 @@ impl UiRealm {
     /// primary`](super::presentation_forest::PresentationForest::primary).
     ///
     /// Pointer/IME/drag-drop events go to the ADDRESSED presentation's own
-    /// gesture/text-input state — never a sibling's
-    /// (`input_stamped_for_a_never_reaches_bs_arena`,
-    /// `ime_attach_on_a_does_not_detach_bs_session`). Keyboard is the one
-    /// exception: it always goes to [`Self::focus_coordinator`]'s currently
-    /// ACTIVE presentation instead of the stamped one — see
-    /// [`FocusCoordinator`]'s own doc for why
-    /// (`keyboard_routes_to_active_presentation_only`).
+    /// gesture/text-input state — never a sibling's, and never falling
+    /// through to the primary when the addressed id is missing
+    /// (`input_stamped_for_b_never_reaches_as_arena`,
+    /// `ime_event_addressed_to_b_does_not_reach_as_session`,
+    /// `input_addressed_to_a_closed_or_unknown_presentation_drops_traced_
+    /// never_falls_through`). Keyboard is the one exception: it always
+    /// goes to [`Self::focus_coordinator`]'s currently ACTIVE presentation
+    /// instead of the stamped one — see [`FocusCoordinator`]'s own doc for
+    /// why (`keyboard_routes_to_active_presentation_only`).
     ///
     /// [`input_dropped_by_lifecycle`] gates every kind next, against the
     /// RESOLVED target's own lifecycle (not necessarily `presentation_id`'s,
@@ -2225,6 +2253,26 @@ impl UiRealm {
             let Some(presentation) = realm.presentations.get(id) else {
                 return false;
             };
+            // Re-stamp the active presentation to the survivor BEFORE
+            // dispose hooks run, if `id` is the realm's currently ACTIVE
+            // one (`FocusCoordinator`) -- mirrors `runner.rs`'s
+            // `RealmSlot::address` re-stamp ordering (dispose-time
+            // reentrancy safety: re-stamp before disposal, never after) and
+            // closes the keyboard-blackhole gap a naive close would leave:
+            // without this, `FocusCoordinator` keeps pointing at `id` after
+            // steps 4-6 remove it from the forest, so `handle_input_
+            // addressed`'s `Keyboard` arm resolves a presentation the
+            // forest no longer has and every keyboard event drops traced
+            // until a fresh `WindowFocus(true)` names a live presentation --
+            // `primary_id_excluding` always returns `Some` here since
+            // `close_presentation_entered` is never called for a realm's
+            // sole presentation (that case routes through a full realm
+            // uninstall instead, in `runner.rs`).
+            if realm.focus_coordinator.active() == id
+                && let Some(surviving) = realm.primary_id_excluding(id)
+            {
+                realm.focus_coordinator.note_focus_gained(surviving);
+            }
             // Steps 2 + 3, composite (minus `id` itself) + capabilities active.
             presentation.close();
             true
@@ -5565,26 +5613,41 @@ mod tests {
             (fake, capability)
         }
 
-        /// A pointer event addressed to A must reach ONLY A's own gesture
-        /// arena — never B's, even though both presentations share one
-        /// realm's `enter()` scope and dispatch machinery.
+        /// A pointer event addressed to B (the NON-primary presentation)
+        /// must reach ONLY B's own gesture arena — never A's (the primary),
+        /// even though both presentations share one realm's `enter()` scope
+        /// and dispatch machinery.
         ///
-        /// If reverted (`handle_input_addressed`'s `Pointer` arm reads
-        /// `self.presentations.primary()` instead of the resolved addressed
-        /// target): this fails whenever `presentation_id` names the
-        /// non-primary presentation, since the event would land on the
-        /// wrong arena entirely.
+        /// Deliberately stamps for B, not A: A is this realm's primary, so a
+        /// mutant that reroutes `handle_input_addressed` to
+        /// `self.presentations.primary()` regardless of the addressed id
+        /// would still (accidentally) satisfy an A-stamped version of this
+        /// test — addressed-vs-primary is unobservable when the stamped
+        /// target IS the primary. Stamping for B is the only fixture that
+        /// actually exercises the addressed lookup: reverting the `Pointer`
+        /// arm to `self.presentations.primary()` makes this fail (B's count
+        /// stays `0`, A's becomes `1`).
         #[test]
-        fn input_stamped_for_a_never_reaches_bs_arena() {
+        fn input_stamped_for_b_never_reaches_as_arena() {
             let mut realm = UiRealm::for_test();
             let a_id = realm.presentation_id();
             let b_id = realm.install_second_presentation_for_test();
 
             let down = make_down_event(Offset::new(Pixels(4.0), Pixels(6.0)), PointerType::Mouse);
             realm.enter(|realm| {
-                realm.handle_input_addressed(a_id, PlatformInput::Pointer(down));
+                realm.handle_input_addressed(b_id, PlatformInput::Pointer(down));
             });
 
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B installed")
+                    .gestures()
+                    .active_pointer_count(),
+                1,
+                "the addressed (non-primary) presentation must receive the pointer event"
+            );
             assert_eq!(
                 realm
                     .presentations
@@ -5592,8 +5655,50 @@ mod tests {
                     .expect("A installed")
                     .gestures()
                     .active_pointer_count(),
-                1,
-                "the addressed presentation must receive the pointer event"
+                0,
+                "a pointer event stamped for B must never reach A's own gesture arena, even \
+                 though A is this realm's primary"
+            );
+        }
+
+        /// Input addressed to a presentation this realm does not (or no
+        /// longer) host must drop traced -- never silently fall through to
+        /// the primary, and never reach ANY live presentation's own arena.
+        /// Covers both shapes of "not a live presentation": an id that
+        /// never existed in this realm, and a real id that existed, was
+        /// closed, and is now gone from the forest.
+        ///
+        /// If reverted (`handle_input_addressed` falling back to
+        /// `self.presentations.primary()` when the addressed id is not
+        /// found, instead of tracing and returning): this fails in BOTH
+        /// cases -- A's (the primary's) pointer count would become
+        /// nonzero instead of staying `0`.
+        #[test]
+        fn input_addressed_to_a_closed_or_unknown_presentation_drops_traced_never_falls_through() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = realm.install_second_presentation_for_test();
+
+            // Case 1: an id that never existed in this realm at all.
+            let bogus = flui_foundation::PresentationId::new_gen(
+                999,
+                std::num::NonZeroU32::new(999).expect("nonzero"),
+            );
+            let down_for_bogus =
+                make_down_event(Offset::new(Pixels(4.0), Pixels(6.0)), PointerType::Mouse);
+            realm.enter(|realm| {
+                realm.handle_input_addressed(bogus, PlatformInput::Pointer(down_for_bogus));
+            });
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(a_id)
+                    .expect("A installed")
+                    .gestures()
+                    .active_pointer_count(),
+                0,
+                "input addressed to a never-existed presentation id must never fall through \
+                 to the primary"
             );
             assert_eq!(
                 realm
@@ -5603,25 +5708,56 @@ mod tests {
                     .gestures()
                     .active_pointer_count(),
                 0,
-                "a pointer event stamped for A must never reach B's own gesture arena"
+                "input addressed to a never-existed presentation id must never reach ANY \
+                 live presentation"
+            );
+
+            // Case 2: a real id that existed, was closed, and is now gone
+            // from the forest.
+            realm.close_presentation_entered(b_id);
+            assert!(
+                realm.presentations.get(b_id).is_none(),
+                "precondition: B must actually be gone from the forest after closing"
+            );
+            let down_for_closed =
+                make_down_event(Offset::new(Pixels(8.0), Pixels(10.0)), PointerType::Mouse);
+            realm.enter(|realm| {
+                realm.handle_input_addressed(b_id, PlatformInput::Pointer(down_for_closed));
+            });
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(a_id)
+                    .expect("A installed")
+                    .gestures()
+                    .active_pointer_count(),
+                0,
+                "input addressed to a CLOSED presentation id must never fall through to the \
+                 surviving primary either"
             );
         }
 
         /// Two independently attached IME sessions, one per presentation:
-        /// delivering an event addressed to A must reach only A's attached
-        /// client and must not disturb B's own platform IME session.
+        /// delivering an event addressed to B (the NON-primary presentation)
+        /// must reach only B's attached client and must not disturb A's
+        /// (the primary's) own platform IME session.
         ///
-        /// If reverted the same way as the pointer exploit above: this
-        /// fails by observing B's sink non-empty, or A's sink empty.
+        /// Deliberately addresses B, not A — see `input_stamped_for_b_never_
+        /// reaches_as_arena`'s doc for why an A-addressed fixture cannot
+        /// distinguish "delivered to the addressed presentation" from
+        /// "delivered to the primary": reverting the `Ime` arm to
+        /// `self.presentations.primary()` makes this fail (B's sink stays
+        /// empty, A's receives the event instead).
         #[test]
-        fn ime_attach_on_a_does_not_detach_bs_session() {
+        fn ime_event_addressed_to_b_does_not_reach_as_session() {
             let (fake_a, capability_a) = headless_text_input();
             let (fake_b, capability_b) = headless_text_input();
 
             let mut realm = UiRealm::for_test_with_text_input(Some(capability_a));
             let a_id = realm.presentation_id();
             let window_b = crate::app::presentation::test_platform_window(Some(capability_b));
-            let b_id = realm.install_presentation(window_b);
+            let presentation_b = realm.assemble_presentation(window_b);
+            let b_id = realm.install_presentation(presentation_b);
 
             let received_a = Rc::new(RefCell::new(Vec::new()));
             let sink_a = Rc::clone(&received_a);
@@ -5646,24 +5782,25 @@ mod tests {
 
             realm.enter(|realm| {
                 realm.handle_input_addressed(
-                    a_id,
+                    b_id,
                     PlatformInput::Ime(ImeEvent::Commit("hello".to_string())),
                 );
             });
 
             assert_eq!(
-                received_a.borrow().as_slice(),
+                received_b.borrow().as_slice(),
                 [ImeEvent::Commit("hello".to_string())],
-                "A's attached client must receive the event addressed to A"
+                "B's attached client must receive the event addressed to B, even though A is \
+                 this realm's primary"
             );
             assert!(
-                received_b.borrow().is_empty(),
-                "an IME event addressed to A must never reach B's attached client"
+                received_a.borrow().is_empty(),
+                "an IME event addressed to B must never reach A's attached client"
             );
             assert_eq!(
-                fake_b.last_ime_allowed(),
+                fake_a.last_ime_allowed(),
                 Some(true),
-                "delivering an event to A must not touch B's own platform IME session"
+                "delivering an event to B must not touch A's own platform IME session"
             );
         }
 
@@ -5716,31 +5853,19 @@ mod tests {
             );
         }
 
-        /// `WindowFocus(false)` (focus LOST) never moves the active
-        /// presentation — see [`FocusCoordinator::note_focus_gained`]'s doc
-        /// for why: losing focus names no new owner.
-        #[test]
-        fn focus_lost_does_not_move_the_active_presentation() {
-            let mut realm = UiRealm::for_test();
-            let a_id = realm.presentation_id();
-            let b_id = realm.install_second_presentation_for_test();
-
-            realm.notify_presentation_focus_gained(b_id);
-            assert_eq!(realm.active_presentation_for_test(), b_id);
-
-            // `notify_presentation_focus_gained` only exists for the
-            // gained-focus direction; there is no "focus lost" write side to
-            // call, by design (see FocusCoordinator's doc) -- this test pins
-            // that b_id, once active, stays active absent a DIFFERENT
-            // presentation's own focus-gained notification.
-            assert_eq!(
-                realm.active_presentation_for_test(),
-                b_id,
-                "the active presentation must not drift without an explicit focus-gained \
-                 notification naming someone else"
-            );
-            let _ = a_id;
-        }
+        // This module can only exercise `UiRealm`'s own write side
+        // (`notify_presentation_focus_gained`) directly -- the production
+        // `WindowFocus(false)`-never-moves-active guard actually lives in
+        // `runner.rs`'s `PlatformToUi::run` (the `if focused` check around
+        // the call to `notify_presentation_focus_gained`), which a direct
+        // `UiRealm`-level test cannot reach or mutate. See
+        // `realm_dispatch_tests::window_focus_true_moves_active_
+        // presentation_end_to_end_and_false_does_not` (`runner.rs`) for the
+        // real end-to-end proof, driven through `dispatch_platform_realm`
+        // with genuine `RealmTask::Event(PlatformToUi::WindowFocus(_))`
+        // tasks -- a vacuous direct-call version of this test (set B active,
+        // assert B active, assert B active again with no operation between)
+        // used to live here and was replaced for exactly that reason.
 
         /// A focus-gained notification naming a presentation this realm no
         /// longer hosts (already closed, or a forged id) is a traced no-op —
@@ -5760,6 +5885,53 @@ mod tests {
                 realm.active_presentation_for_test(),
                 a_id,
                 "an unknown presentation id must never become the active one"
+            );
+        }
+
+        /// Closing the realm's currently ACTIVE presentation must re-stamp
+        /// `FocusCoordinator` to the surviving primary before returning --
+        /// never leave it pointing at a now-dead id, which would
+        /// black-hole every keyboard event until a fresh `WindowFocus(true)`
+        /// happened to name a live presentation. Closes B (the non-primary)
+        /// while B is active, so this also exercises "the active
+        /// presentation being closed is not the primary" -- not just "close
+        /// the primary while it's active".
+        ///
+        /// If reverted (the re-stamp removed from
+        /// `close_presentation_entered`): this fails -- the post-close
+        /// keyboard event resolves `self.presentations.get(dead_b_id)` to
+        /// `None` and drops traced, so A's `redraw_pending` bit is never
+        /// set.
+        #[test]
+        fn keyboard_after_closing_the_active_presentation_routes_to_the_survivor() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = realm.install_second_presentation_for_test();
+
+            realm.notify_presentation_focus_gained(b_id);
+            assert_eq!(realm.active_presentation_for_test(), b_id);
+
+            realm.close_presentation_entered(b_id);
+
+            assert_eq!(
+                realm.active_presentation_for_test(),
+                a_id,
+                "closing the active presentation must re-stamp active to the surviving primary"
+            );
+
+            let key_event = KeyEventBuilder::new(flui_interaction::events::Code::KeyA).build();
+            realm.enter(|realm| {
+                realm.handle_input_addressed(a_id, PlatformInput::Keyboard(key_event));
+            });
+
+            assert!(
+                realm
+                    .presentations
+                    .get(a_id)
+                    .expect("A installed")
+                    .take_redraw_pending(),
+                "keyboard input must reach the surviving primary after the active presentation \
+                 closes, never drop as if no presentation were active"
             );
         }
     }
@@ -5858,7 +6030,8 @@ mod tests {
             )
             .expect("realm constructs");
             let a_id = realm.presentation_id();
-            let b_id = realm.install_presentation(Arc::clone(&window_b));
+            let presentation_b = realm.assemble_presentation(Arc::clone(&window_b));
+            let b_id = realm.install_presentation(presentation_b);
 
             assert_eq!(calls_a.load(AtomicOrdering::Relaxed), 0);
             assert_eq!(calls_b.load(AtomicOrdering::Relaxed), 0);

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -709,11 +709,16 @@ impl UiRealm {
     /// (`PipelineOwner::new`'s own default applies) — preserved exactly,
     /// not silently changed to an explicit `1.0`.
     ///
-    /// Assembles this realm's SOLE (production ratchet: `PresentationForest`
-    /// enforces `len() <= 1`) presentation via [`PresentationState::new`],
-    /// which installs the scope, the realm's shared dispatch handles, and
-    /// this presentation's own focus/IME before anything attaches or mounts
-    /// (ADR-0043 §1).
+    /// Assembles this realm's INITIAL presentation via
+    /// [`PresentationState::new`], which installs the scope, the realm's
+    /// shared dispatch handles, and this presentation's own focus/IME
+    /// before anything attaches or mounts (ADR-0043 §1). Production
+    /// topology is no longer limited to this one presentation:
+    /// `PresentationForest`'s former `len()<=1` ratchet is lifted (issue
+    /// #555's addressed-routing slice) — [`Self::install_presentation`]
+    /// (paired with [`Self::assemble_presentation`]) is how a realm grows
+    /// PAST this initial presentation, once the realm itself already
+    /// exists.
     fn construct(
         capacity: usize,
         wake: Arc<dyn Fn() + Send + Sync>,

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -934,12 +934,23 @@ impl UiRealm {
     ///
     /// `window` becomes this presentation's own native window (cursor,
     /// haptics, redraw-poke — see `PresentationState::new`'s wiring).
+    /// Its pipeline is seeded with `window.scale_factor()` before
+    /// construction — the same DPR-before-first-frame ordering
+    /// [`Self::construct`] uses for this realm's own primary presentation
+    /// (there, the caller reads the window's scale factor and passes it in
+    /// as `device_pixel_ratio`; here, `window` is already in hand, so this
+    /// method reads it directly instead of requiring every caller to
+    /// remember to). Without this, a non-primary presentation's
+    /// `RenderView` and first frame would disagree with its OWN window's
+    /// actual scale — silently defaulting to `1.0` regardless of what
+    /// `window.scale_factor()` actually reports.
     pub(crate) fn assemble_presentation(
         &self,
         window: Arc<dyn PlatformWindow>,
     ) -> PresentationState {
         let (_, presentation_id) = super::runtime::next_identity();
         let pipeline = PipelineCell::new(PipelineOwner::new());
+        pipeline.with_mut(|owner| owner.set_device_pixel_ratio(window.scale_factor() as f32));
         PresentationState::new(
             presentation_id,
             pipeline,
@@ -1001,6 +1012,20 @@ impl UiRealm {
     #[cfg(test)]
     pub(crate) fn active_presentation_for_test(&self) -> PresentationId {
         self.focus_coordinator.active()
+    }
+
+    /// Whether `id` is this realm's currently ACTIVE presentation
+    /// ([`FocusCoordinator`]). Production reader:
+    /// `runner.rs`'s `PlatformToUi::WindowFocus` handling uses this to tell
+    /// an authoritative focus-loss (the active presentation's own window
+    /// losing OS focus) apart from a stale one (a DIFFERENT, non-active
+    /// presentation of this same realm reporting focus loss, a normal
+    /// consequence of focus having already moved elsewhere within this
+    /// realm) — see that call site's own doc for why the distinction
+    /// matters for the realm-wide lifecycle aggregate.
+    #[must_use]
+    pub(crate) fn is_active_presentation(&self, id: PresentationId) -> bool {
+        self.focus_coordinator.active() == id
     }
 
     /// This realm's own scheduler — the strong root. `runner.rs`'s
@@ -6071,6 +6096,96 @@ mod tests {
                 calls_b.load(AtomicOrdering::Relaxed),
                 1,
                 "dirtying B's own pipeline must poke B's own window"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Presentation DPR seeding — a non-primary presentation's pipeline must
+    // be seeded with ITS OWN window's scale factor before construction, the
+    // same DPR-before-first-frame ordering the primary path already gets.
+    // ========================================================================
+    mod presentation_dpr_seeding {
+        use flui_platform::CursorIcon;
+        use flui_platform::traits::{CursorError, WindowId};
+        use flui_types::geometry::{DevicePixels, Pixels};
+
+        use super::*;
+
+        struct ScaledTestWindow {
+            id: WindowId,
+            scale_factor: f64,
+        }
+
+        impl PlatformWindow for ScaledTestWindow {
+            fn id(&self) -> WindowId {
+                self.id
+            }
+
+            fn physical_size(&self) -> Size<DevicePixels> {
+                Size::default()
+            }
+
+            fn logical_size(&self) -> Size<Pixels> {
+                Size::default()
+            }
+
+            fn scale_factor(&self) -> f64 {
+                self.scale_factor
+            }
+
+            fn request_redraw(&self) {}
+
+            fn is_focused(&self) -> bool {
+                false
+            }
+
+            fn is_visible(&self) -> bool {
+                true
+            }
+
+            fn set_cursor(&self, _cursor: CursorIcon) -> Result<(), CursorError> {
+                Ok(())
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        /// A non-primary presentation's pipeline must be seeded with ITS
+        /// OWN window's `scale_factor()` before construction — the same
+        /// DPR-before-first-frame ordering `UiRealm::construct` already
+        /// gives this realm's primary presentation (there, the caller reads
+        /// the window's scale factor and passes it in explicitly; here,
+        /// `assemble_presentation` already holds the window, so it reads
+        /// the value directly instead).
+        ///
+        /// If reverted (the `set_device_pixel_ratio` seeding call removed
+        /// from `assemble_presentation`): this fails — the readback
+        /// observes the `PipelineOwner::new()` default (`1.0`) instead of
+        /// the window's real `2.5`.
+        #[test]
+        fn non_primary_presentation_pipeline_is_seeded_with_its_own_windows_scale_factor() {
+            let mut realm = UiRealm::for_test();
+            let window_b: Arc<dyn PlatformWindow> = Arc::new(ScaledTestWindow {
+                id: WindowId(42),
+                scale_factor: 2.5,
+            });
+            let presentation_b = realm.assemble_presentation(window_b);
+            let b_id = realm.install_presentation(presentation_b);
+
+            let dpr = realm
+                .presentations
+                .get(b_id)
+                .expect("B installed")
+                .pipeline()
+                .with(flui_rendering::pipeline::PipelineOwner::device_pixel_ratio);
+
+            assert_eq!(
+                dpr, 2.5,
+                "B's pipeline must be seeded with its own window's scale factor before \
+                 construction, not the PipelineOwner default"
             );
         }
     }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -22,6 +22,7 @@
 //! gets a fresh generational [`RealmId`], so results stamped for a dead
 //! runtime are droppable by identity, not by convention.
 
+use std::cell::Cell;
 use std::marker::PhantomData;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::rc::Rc;
@@ -34,7 +35,7 @@ use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use flui_animation::Vsync;
 use flui_engine::{EngineError, RasterBackend};
 use flui_foundation::{PresentationId, RealmId};
-use flui_interaction::{FocusManager, GestureBinding, InteractionLane, TextInputOwner};
+use flui_interaction::{FocusManager, GestureBinding, InteractionLane};
 use flui_layer::Scene;
 #[cfg(test)]
 use flui_platform::traits::PlatformTextInput;
@@ -60,6 +61,53 @@ use crate::bindings::RenderingFlutterBinding;
 /// precedent (`DEFAULT_DIRTY_CHANNEL_CAPACITY`)). Observable at
 /// runtime via `UiCommandSender::capacity`; not part of the public API.
 const DEFAULT_COMMAND_CAPACITY: usize = 256;
+
+/// Realm-level arbitration of which presentation currently owns OS keyboard
+/// focus (issue #555's addressed-routing slice). One [`FocusManager`] exists per presentation
+/// (`PresentationState::focus_manager`), but only ONE presentation's tree
+/// should ever receive a keyboard event at a time — the one whose native
+/// window the platform most recently reported as focused.
+/// [`UiRealm::handle_input_addressed`]'s `Keyboard` arm routes there,
+/// deliberately never to whichever presentation an individual event happens
+/// to be stamped for: a stray or racing keyboard event addressed to a
+/// presentation that is not (or no longer) the OS-focused one must still
+/// land on the active one, matching a real OS's single-keyboard-focus model
+/// rather than trusting the per-event address.
+///
+/// Defaults to the realm's initial presentation, so single-presentation
+/// production topology (today's only shipped shape) observes no behavior
+/// change: focus starts exactly where it always did, and only moves once a
+/// genuine `WindowFocus(true)` event names a different, currently-hosted
+/// presentation.
+struct FocusCoordinator {
+    active: Cell<PresentationId>,
+}
+
+impl FocusCoordinator {
+    fn new(initial: PresentationId) -> Self {
+        Self {
+            active: Cell::new(initial),
+        }
+    }
+
+    /// The presentation keyboard input currently routes to.
+    fn active(&self) -> PresentationId {
+        self.active.get()
+    }
+
+    /// Record that `id`'s native window just gained OS focus — the sole
+    /// production write side (`PlatformToUi::WindowFocus(true)` handling,
+    /// `runner.rs`).
+    ///
+    /// A `WindowFocus(false)` (focus LOST) never calls this: losing focus
+    /// names no new owner, so the coordinator keeps pointing at whichever
+    /// presentation held it most recently — the same retention Flutter's
+    /// own single-view focus model has (losing OS focus does not un-focus
+    /// the last-focused element; a *different* window gaining focus does).
+    fn note_focus_gained(&self, id: PresentationId) {
+        self.active.set(id);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -384,30 +432,25 @@ pub(crate) struct UiRealm {
     /// This realm's cross-tree `GlobalKey` uniqueness domain (ADR-0043 §1),
     /// installed into every presentation's `BuildOwner` at assembly time
     /// (`PresentationState::new`). Retained here (not just handed off once)
-    /// so a later-installed presentation can share the same scope; read back
-    /// by the `cfg(test)`-only `global_key_scope` accessor below for the
-    /// isolation test suite, which bypasses `PresentationForest`'s production
-    /// ratchet to assemble a second presentation sharing this exact scope.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "no production reader until a later addressed-routing \
-                      slice's presentation-install path needs to hand this \
-                      same scope to a newly assembled presentation; the \
-                      isolation test suite reads it back today via \
-                      Self::global_key_scope"
-        )
-    )]
+    /// so a later-installed presentation can share the same scope: both
+    /// [`Self::install_presentation`] (production, issue #555's addressed-routing slice) and the
+    /// `cfg(test)`-only `global_key_scope` accessor below (the isolation
+    /// test suite) read it back to assemble a second presentation sharing
+    /// this exact scope.
     global_key_scope: GlobalKeyScope,
     /// The insertion-ordered set of UI-owner presentation domains this realm
-    /// hosts (ADR-0043 §1 — `PresentationForest`). Production topology stays
-    /// exactly one presentation per realm until the forest's own ratchet
-    /// lifts; see [`PresentationForest`]'s doc. Everything that builds, lays
-    /// out, focuses, or presents for one surface lives in and dies with its
-    /// own `PresentationState` inside this forest — the realm owns only
-    /// what is genuinely cross-tree (this struct's other fields).
+    /// hosts (ADR-0043 §1 — `PresentationForest`). Production topology
+    /// allows any number of presentations per realm since issue #555's addressed-routing slice
+    /// lifted the forest's former `len()<=1` ratchet; see
+    /// [`PresentationForest`]'s doc. Everything that builds, lays out,
+    /// focuses, or presents for one surface lives in and dies with its own
+    /// `PresentationState` inside this forest — the realm owns only what is
+    /// genuinely cross-tree (this struct's other fields).
     presentations: PresentationForest,
+    /// Realm-level arbitration of which presentation currently owns OS
+    /// keyboard focus (ADR-0043 §4, issue #555's addressed-routing slice). See
+    /// [`FocusCoordinator`]'s own doc.
+    focus_coordinator: FocusCoordinator,
     /// Controller registry for implicit animations (`VsyncScope`-driven).
     /// Moved here from the retired `AppBinding` — an interim home: a later
     /// scheduler-owning change re-homes controllers to `UpdateScheduler`,
@@ -711,6 +754,7 @@ impl UiRealm {
             interaction_lane,
             global_key_scope,
             presentations: PresentationForest::single(presentation),
+            focus_coordinator: FocusCoordinator::new(presentation_id),
             vsync_slot: Mutex::new(Vsync::new()),
             start: web_time::Instant::now(),
             needs_redraw,
@@ -832,18 +876,9 @@ impl UiRealm {
             .map(PresentationState::id)
     }
 
-    /// This realm's shared cross-tree `GlobalKey` uniqueness domain
-    /// (ADR-0043 §1) — for the isolation test suite, which uses it to
-    /// assemble a second presentation sharing this realm's exact scope,
-    /// bypassing `PresentationForest`'s production ratchet deliberately.
-    #[cfg(test)]
-    pub(crate) fn global_key_scope(&self) -> &GlobalKeyScope {
-        &self.global_key_scope
-    }
-
     /// Number of presentations this realm currently hosts — for the
-    /// isolation test suite (production topology is always exactly one until
-    /// `PresentationForest`'s ratchet lifts).
+    /// isolation test suite (production topology allows any number since
+    /// this slice lifted `PresentationForest`'s former ratchet).
     #[cfg(test)]
     pub(crate) fn presentation_count(&self) -> usize {
         self.presentations.len()
@@ -864,27 +899,50 @@ impl UiRealm {
             .widgets()
     }
 
-    /// Assemble and install a second presentation sharing this realm's exact
-    /// `GlobalKeyScope` and realm-level dispatch handles.
-    ///
-    /// Bypasses `PresentationForest`'s production ratchet
-    /// (`PresentationForest::push_for_test`) deliberately — the
-    /// isolation-suite seam for exercising a genuine multi-presentation
-    /// realm ahead of the addressed routing that makes doing so safe in
-    /// production. `pub(crate)` (rather than confined to this module's own
-    /// `mod tests`) so `runner.rs`'s dispatch-seam tests can build the same
-    /// two-presentation fixture their real dispatch machinery drives.
+    /// This realm's `TextInputHandle` for the presentation named `id` — the
+    /// addressed counterpart to [`Self::text_input_handle`] (primary-only),
+    /// for the isolation suite proving IME sessions stay exclusive to the
+    /// exact presentation they were attached on
+    /// (`ime_attach_on_a_does_not_detach_bs_session`).
+    #[must_use]
     #[cfg(test)]
-    pub(crate) fn install_second_presentation_for_test(&mut self) -> PresentationId {
+    pub(crate) fn presentation_text_input_handle_for_test(
+        &self,
+        id: PresentationId,
+    ) -> flui_interaction::TextInputHandle {
+        self.presentations
+            .get(id)
+            .expect("BUG: presentation_text_input_handle_for_test called with an unknown id")
+            .text_input_handle()
+    }
+
+    /// Assemble and install another presentation into this realm, sharing
+    /// its exact `GlobalKeyScope` and realm-level dispatch handles — the
+    /// production entry point (this slice lifted
+    /// `PresentationForest::install`'s former `len()<=1` ratchet).
+    ///
+    /// `window` becomes this presentation's own native window (cursor,
+    /// haptics, redraw-poke — see `PresentationState::new`'s wiring); the
+    /// caller is responsible for minting its `WindowRegistry` mapping —
+    /// `UiRealm` has no access to that registry (ADR-0037 §2), exactly the
+    /// same split [`Self::close_presentation_entered`]'s own doc states for
+    /// teardown. `runner.rs::install_presentation_alongside` is that
+    /// caller in production; `Self::install_second_presentation_for_test`
+    /// (`cfg(test)`-only, no stable link target in a non-test doc build) is
+    /// the test-only counterpart for `UiRealm`-only tests that never touch
+    /// `AppRuntime`/`WindowRegistry` at all.
+    pub(crate) fn install_presentation(
+        &mut self,
+        window: Arc<dyn PlatformWindow>,
+    ) -> PresentationId {
         let (_, presentation_id) = super::runtime::next_identity();
         let pipeline = PipelineCell::new(PipelineOwner::new());
-        let window = super::presentation::test_platform_window(None);
         let presentation = PresentationState::new(
             presentation_id,
             pipeline,
             window,
             RealmCapabilities {
-                global_key_scope: self.global_key_scope().clone(),
+                global_key_scope: self.global_key_scope.clone(),
                 async_driver: self.scheduler.async_driver().clone(),
                 post_frame_handle: self.local_post_frame.post_frame_handle(),
                 interaction_dispatch_handle: self.interaction_lane.dispatch_handle(),
@@ -892,8 +950,31 @@ impl UiRealm {
                 wake: Arc::clone(&self.wake),
             },
         );
-        self.presentations.push_for_test(presentation);
+        self.presentations.install(presentation);
         presentation_id
+    }
+
+    /// [`Self::install_presentation`], with a throwaway test window — for
+    /// `UiRealm`-only tests (this module's own `mod tests`, plus
+    /// `runner.rs`'s dispatch-seam tests) that exercise a genuine
+    /// multi-presentation realm WITHOUT ever touching `AppRuntime`'s
+    /// `WindowRegistry` — that layer is a different module's own test
+    /// concern (`runner.rs`'s `install_presentation_alongside`, exercised by
+    /// the three tests that need a REAL window mapping for the second
+    /// presentation). `pub(crate)` so `runner.rs`'s own tests that only need
+    /// forest membership, never registry routing, can still use it.
+    #[cfg(test)]
+    pub(crate) fn install_second_presentation_for_test(&mut self) -> PresentationId {
+        let window = super::presentation::test_platform_window(None);
+        self.install_presentation(window)
+    }
+
+    /// The presentation keyboard input currently routes to
+    /// ([`FocusCoordinator`]) — for the isolation suite proving
+    /// `WindowFocus` events move it.
+    #[cfg(test)]
+    pub(crate) fn active_presentation_for_test(&self) -> PresentationId {
+        self.focus_coordinator.active()
     }
 
     /// This realm's own scheduler — the strong root. `runner.rs`'s
@@ -904,13 +985,6 @@ impl UiRealm {
     #[must_use]
     pub(crate) fn scheduler(&self) -> &flui_scheduler::Scheduler {
         &self.scheduler
-    }
-
-    /// The current presentation's lifecycle state, for the input-gate
-    /// checks at the physical owner ([`Self::handle_input_entered`]).
-    #[must_use]
-    pub(crate) fn presentation_lifecycle(&self) -> super::presentation::PresentationLifecycle {
-        self.presentations.primary().lifecycle()
     }
 
     /// A new cross-thread sender into this runtime's inbox.
@@ -1002,15 +1076,23 @@ impl UiRealm {
         self.presentations.primary().gestures()
     }
 
-    /// Focus state for the realm's current presentation.
+    /// Focus state for the realm's current primary presentation. Since
+    /// issue #555's addressed-routing slice, [`Self::handle_input_addressed`] reads the ADDRESSED
+    /// presentation's own `focus_manager()` directly instead of through this
+    /// primary-only wrapper; kept for the tests that still exercise a
+    /// single-presentation realm's focus tree without addressing.
     #[must_use]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "production input dispatch reads the addressed presentation's own \
+                      focus_manager() directly (handle_input_addressed); this primary-only \
+                      wrapper is exercised only by tests"
+        )
+    )]
     pub(crate) fn focus_manager(&self) -> Rc<FocusManager> {
         self.presentations.primary().focus_manager()
-    }
-
-    /// Text-input state for the realm's current single presentation.
-    pub(crate) fn text_input(&self) -> &TextInputOwner {
-        self.presentations.primary().text_input()
     }
 
     /// Weak text-input capability for this exact presentation.
@@ -1212,16 +1294,28 @@ impl UiRealm {
     /// See [`Self::needs_redraw`]'s field doc for why this and
     /// [`Self::wake_frame`] share one underlying atomic with `AppRuntime`.
     ///
-    /// Every current caller is a presentation-scoped operation
-    /// (`attach_root_widget*`, `handle_input_entered`) working on
-    /// `self.presentations.primary()` — no addressed routing exists yet
-    /// (a later slice's job) — so this also marks that presentation's own
-    /// pump wake bit (ADR-0043 §3), the signal
-    /// `UiRealm::draw_frame_entered`'s per-presentation loop reads at
-    /// segment start.
+    /// Every current caller (`attach_root_widget*`, and every
+    /// [`Self::handle_input_addressed`] arm not yet ported to it) is still a
+    /// primary-only operation, so this marks `self.presentations.primary()`'s
+    /// own pump wake bit (ADR-0043 §3) specifically — see
+    /// [`Self::request_redraw_for`] for the addressed counterpart
+    /// [`Self::handle_input_addressed`] actually uses.
     pub(crate) fn request_redraw(&self) {
+        self.request_redraw_for(self.presentations.primary());
+    }
+
+    /// [`Self::request_redraw`], addressed to exactly `presentation` rather
+    /// than always the primary (issue #555's addressed-routing slice): still
+    /// sets the realm-wide coalesced flag (needed either way — it is what
+    /// wakes an idle event loop at all) but marks the ADDRESSED
+    /// presentation's own pump wake bit, never a sibling's, so an
+    /// idle-and-quiet sibling presentation is not woken by a redraw request
+    /// that was never its own (`redraw_request_from_a_does_not_wake_bs_window`
+    /// covers the platform-window half of this same requirement via each
+    /// presentation's own `on_need_visual_update` wiring, `presentation.rs`).
+    fn request_redraw_for(&self, presentation: &PresentationState) {
         self.needs_redraw.store(true, Ordering::Relaxed);
-        self.presentations.primary().mark_redraw_pending();
+        presentation.mark_redraw_pending();
     }
 
     /// Whether a redraw is needed.
@@ -1785,24 +1879,78 @@ impl UiRealm {
     // Input dispatch (moved from the retired `AppBinding`)
     // ========================================================================
 
-    /// Handle a platform input event while this realm is already entered.
-    ///
-    /// This is the single runner entry point for platform input. Pointer
-    /// events go to this presentation's gesture state; IME and keyboard
-    /// events go to the same presentation's text-input and focus owners.
-    /// [`input_dropped_by_lifecycle`] gates every kind first:
-    /// `Closing`/`Closed` refuses all input; `Suspended` drops pointer/
-    /// drag-drop only (keyboard/IME keep flowing, so a flaky or absent
-    /// occlusion signal never becomes a keystroke blackout).
-    ///
-    /// Pointer events are coalesced by this presentation's `GestureBinding`
-    /// — high-frequency move events are stored and flushed once per frame
-    /// via [`Self::render_frame_entered`].
+    /// [`Self::handle_input_addressed`], addressed to this realm's primary —
+    /// the pre-addressed-routing shape, kept for every existing single-presentation
+    /// test (production dispatch, `runner.rs`'s `PlatformToUi::run`, calls
+    /// `handle_input_addressed` directly with the real stamped id).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "production input dispatch calls handle_input_addressed directly with the \
+                      real stamped presentation id (PlatformToUi::run); this primary-only \
+                      convenience is exercised only by tests that never address a specific \
+                      presentation"
+        )
+    )]
     pub(crate) fn handle_input_entered(&self, input: PlatformInput) {
-        if input_dropped_by_lifecycle(self.presentation_lifecycle(), &input) {
+        self.handle_input_addressed(self.presentations.primary().id(), input);
+    }
+
+    /// Handle a platform input event while this realm is already entered,
+    /// addressed to exactly one presentation this realm hosts (issue #555
+    /// the addressed-routing slice).
+    ///
+    /// `presentation_id` is the exact presentation `dispatch_platform_realm`
+    /// (`runner.rs`) stamped this event with at enqueue time — the window
+    /// that produced it, resolved through `WindowRegistry` at hop-1 — never
+    /// assumed to be this realm's primary. A `presentation_id` this realm no
+    /// longer hosts (closed between enqueue and drain) is a traced drop,
+    /// never a panic or a silent fall-through to [`PresentationForest::
+    /// primary`](super::presentation_forest::PresentationForest::primary).
+    ///
+    /// Pointer/IME/drag-drop events go to the ADDRESSED presentation's own
+    /// gesture/text-input state — never a sibling's
+    /// (`input_stamped_for_a_never_reaches_bs_arena`,
+    /// `ime_attach_on_a_does_not_detach_bs_session`). Keyboard is the one
+    /// exception: it always goes to [`Self::focus_coordinator`]'s currently
+    /// ACTIVE presentation instead of the stamped one — see
+    /// [`FocusCoordinator`]'s own doc for why
+    /// (`keyboard_routes_to_active_presentation_only`).
+    ///
+    /// [`input_dropped_by_lifecycle`] gates every kind next, against the
+    /// RESOLVED target's own lifecycle (not necessarily `presentation_id`'s,
+    /// for `Keyboard`): `Closing`/`Closed` refuses all input; `Suspended`
+    /// drops pointer/drag-drop only (keyboard/IME keep flowing, so a flaky
+    /// or absent occlusion signal never becomes a keystroke blackout).
+    ///
+    /// Pointer events are coalesced by the target presentation's own
+    /// `GestureBinding` — high-frequency move events are stored and flushed
+    /// once per frame via [`Self::render_frame_entered`].
+    pub(crate) fn handle_input_addressed(
+        &self,
+        presentation_id: PresentationId,
+        input: PlatformInput,
+    ) {
+        let target_id = match &input {
+            PlatformInput::Keyboard(_) => self.focus_coordinator.active(),
+            PlatformInput::Pointer(_) | PlatformInput::Ime(_) | PlatformInput::DragDrop(_) => {
+                presentation_id
+            }
+        };
+        let Some(presentation) = self.presentations.get(target_id) else {
             tracing::debug!(
-                { flui_foundation::diagnostics::PRESENTATION_ID } = self.presentation_id().as_u64(),
-                lifecycle = ?self.presentation_lifecycle(),
+                { flui_foundation::diagnostics::PRESENTATION_ID } = target_id.as_u64(),
+                stamped_presentation_id = presentation_id.as_u64(),
+                input_kind = input_kind(&input),
+                "dropping input addressed to a presentation this realm no longer hosts"
+            );
+            return;
+        };
+        if input_dropped_by_lifecycle(presentation.lifecycle(), &input) {
+            tracing::debug!(
+                { flui_foundation::diagnostics::PRESENTATION_ID } = presentation.id().as_u64(),
+                lifecycle = ?presentation.lifecycle(),
                 input_kind = input_kind(&input),
                 "dropping input due to presentation lifecycle"
             );
@@ -1810,20 +1958,19 @@ impl UiRealm {
         }
         match input {
             PlatformInput::Ime(ime_event) => {
-                self.text_input().dispatch(&ime_event);
-                self.request_redraw();
+                presentation.text_input().dispatch(&ime_event);
+                self.request_redraw_for(presentation);
             }
             PlatformInput::Pointer(pointer_event) => {
                 let routing_panic = catch_unwind(AssertUnwindSafe(|| {
-                    self.gestures()
+                    presentation
+                        .gestures()
                         .handle_pointer_event(&pointer_event, |position| {
                             let mut result = flui_interaction::routing::HitTestResult::new();
                             let offset = flui_types::Offset::new(position.dx, position.dy);
-                            self.presentations.primary().renderer().hit_test_in_view(
-                                &mut result,
-                                offset,
-                                0,
-                            );
+                            presentation
+                                .renderer()
+                                .hit_test_in_view(&mut result, offset, 0);
                             if !result.is_empty() {
                                 tracing::debug!(hits = result.len(), "Hit test found targets");
                             }
@@ -1832,7 +1979,7 @@ impl UiRealm {
                 }))
                 .err();
                 let deferred_panic = catch_unwind(AssertUnwindSafe(|| {
-                    self.gestures().drain_deferred_arena_resolutions();
+                    presentation.gestures().drain_deferred_arena_resolutions();
                 }))
                 .err();
 
@@ -1843,14 +1990,16 @@ impl UiRealm {
                     deferred_panic,
                     "deferred arena resolution",
                 );
-                self.request_redraw();
+                self.request_redraw_for(presentation);
                 if let Some(payload) = first_panic {
                     resume_unwind(payload);
                 }
             }
             PlatformInput::Keyboard(keyboard_event) => {
-                self.focus_manager().dispatch_key_event(&keyboard_event);
-                self.request_redraw();
+                presentation
+                    .focus_manager()
+                    .dispatch_key_event(&keyboard_event);
+                self.request_redraw_for(presentation);
             }
             PlatformInput::DragDrop(drag_drop_event) => {
                 tracing::debug!(
@@ -1859,6 +2008,22 @@ impl UiRealm {
                 );
             }
         }
+    }
+
+    /// Record that `presentation_id`'s native window just gained OS focus —
+    /// [`FocusCoordinator::note_focus_gained`]'s sole write side. A stale or
+    /// unknown `presentation_id` (already closed, or a forged/mixed address)
+    /// is a traced no-op: focus arbitration never points at a presentation
+    /// this realm does not currently host.
+    pub(crate) fn notify_presentation_focus_gained(&self, presentation_id: PresentationId) {
+        if self.presentations.get(presentation_id).is_none() {
+            tracing::debug!(
+                { flui_foundation::diagnostics::PRESENTATION_ID } = presentation_id.as_u64(),
+                "dropping a focus-gained notification for a presentation this realm no longer hosts"
+            );
+            return;
+        }
+        self.focus_coordinator.note_focus_gained(presentation_id);
     }
 
     /// Consume the coalesced redraw request, if any.
@@ -1920,21 +2085,22 @@ impl UiRealm {
                     presentation_id,
                     request,
                 } => {
-                    if presentation_id != self.presentations.primary().id() {
+                    // Forest-membership check (issue #555's addressed-routing slice), not
+                    // primary-only equality: a presentation generation this
+                    // realm no longer hosts -- closed since the action was
+                    // stamped, or a genuinely different (non-primary)
+                    // presentation among several -- is a traced drop either
+                    // way, never delivered to a sibling.
+                    let Some(presentation) = self.presentations.get(presentation_id) else {
                         tracing::trace!(
-                            { flui_foundation::diagnostics::PRESENTATION_ID } =
-                                self.presentations.primary().id().as_u64(),
                             stamped_presentation_id = presentation_id.as_u64(),
-                            "dropping semantics action stamped for a stale presentation incarnation"
+                            "dropping semantics action stamped for a presentation this realm no \
+                             longer hosts"
                         );
                         report.dropped_stale += 1;
                         continue;
-                    }
-                    match self
-                        .presentations
-                        .primary()
-                        .dispatch_semantics_action(request)
-                    {
+                    };
+                    match presentation.dispatch_semantics_action(request) {
                         Ok(()) => {
                             report.invoked += 1;
                         }
@@ -1944,7 +2110,7 @@ impl UiRealm {
                             // the latest semantics update.
                             tracing::trace!(
                                 { flui_foundation::diagnostics::PRESENTATION_ID } =
-                                    self.presentations.primary().id().as_u64(),
+                                    presentation_id.as_u64(),
                                 ?error,
                                 "dropping semantics action against a stale snapshot"
                             );
@@ -2415,6 +2581,99 @@ mod tests {
             0,
             "a stale-stamped action must never reach the handler at all"
         );
+    }
+
+    /// Issue #555's addressed-routing slice: `drain_commands`'s `SemanticsAction` arm checks
+    /// FOREST MEMBERSHIP (`self.presentations.get(presentation_id)`), not
+    /// equality against `self.presentations.primary().id()` — a live
+    /// NON-primary presentation's own stamped action must actually invoke,
+    /// not be dropped as stale just because it is not the primary.
+    ///
+    /// If reverted (the pre-addressed-routing primary-equality check restored):
+    /// this fails — `report.invoked` would be `0` and `dropped_stale` would
+    /// be `1`, because B is never the primary in this fixture.
+    #[test]
+    fn semantics_action_addressed_to_a_live_non_primary_presentation_is_invoked() {
+        let mut realm = UiRealm::for_test();
+        let b_id = realm.install_second_presentation_for_test();
+
+        let render_id = RenderId::new(1);
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let invoked_in_handler = Arc::clone(&invoked);
+        let mut node = SemanticsNode::new().with_source_render_id(render_id);
+        node.config_mut().add_action(
+            SemanticsAction::Tap,
+            Arc::new(move |_action, _arguments| {
+                invoked_in_handler.fetch_add(1, Ordering::SeqCst);
+            }),
+        );
+        let mut semantics_owner = SemanticsOwner::new(Arc::new(|_| {}));
+        let root = semantics_owner.insert(node);
+        semantics_owner.set_root(Some(root));
+        realm
+            .presentations
+            .get(b_id)
+            .expect("B installed")
+            .pipeline()
+            .with_mut(|owner| owner.set_semantics_owner(Some(semantics_owner)));
+
+        realm
+            .command_sender()
+            .send(UiCommand::SemanticsAction {
+                presentation_id: b_id,
+                request: SemanticsActionRequest::new(
+                    AccessibilityNodeId::from(render_id),
+                    SemanticsAction::Tap,
+                ),
+            })
+            .expect("realm inbox has room");
+
+        let report = realm.drain_commands();
+        assert_eq!(
+            report.invoked, 1,
+            "B's own stamped action must be invoked, not dropped"
+        );
+        assert_eq!(report.dropped_stale, 0);
+        assert_eq!(invoked.load(Ordering::SeqCst), 1);
+    }
+
+    /// Issue #555's addressed-routing slice: an action stamped for a presentation that this
+    /// realm no longer hosts — closed since the request was enqueued —
+    /// drops traced, exactly like a forged/never-existed generation does.
+    ///
+    /// If reverted the same way as the test above (primary-equality
+    /// restored, or the forest-membership check deleted outright): this
+    /// still passes vacuously for the WRONG reason (A, the closed
+    /// presentation, was never the primary either) — the companion test
+    /// above is what actually pins the membership check; this one pins the
+    /// closed-presentation half of the same contract.
+    #[test]
+    fn semantics_action_with_stale_presentation_generation_drops_traced() {
+        let mut realm = UiRealm::for_test();
+        let a_id = realm.presentation_id();
+        let _b_id = realm.install_second_presentation_for_test();
+
+        realm
+            .command_sender()
+            .send(UiCommand::SemanticsAction {
+                presentation_id: a_id,
+                request: SemanticsActionRequest::new(
+                    AccessibilityNodeId::from(RenderId::new(1)),
+                    SemanticsAction::Tap,
+                ),
+            })
+            .expect("realm inbox has room");
+
+        // Close A (the sender's stamped target) while B survives -- A's
+        // generation is now gone from the forest entirely.
+        realm.close_presentation_entered(a_id);
+
+        let report = realm.drain_commands();
+        assert_eq!(
+            report.invoked, 0,
+            "a request stamped for a presentation this realm no longer hosts must never invoke"
+        );
+        assert_eq!(report.dropped_stale, 1);
     }
 
     #[test]
@@ -4870,8 +5129,13 @@ mod tests {
     mod presentation_forest_isolation {
         use super::*;
 
+        /// This slice lifted `PresentationForest::install`'s former
+        /// `len()<=1` ratchet: `install_second_presentation_for_test` (and
+        /// its production counterpart, `UiRealm::install_presentation`) now
+        /// go through the SAME production `install` call, not a
+        /// `cfg(test)`-only bypass.
         #[test]
-        fn push_for_test_bypasses_the_production_ratchet() {
+        fn install_presentation_grows_the_forest_past_one() {
             let mut realm = UiRealm::for_test();
             assert_eq!(realm.presentation_count(), 1);
 
@@ -4880,8 +5144,8 @@ mod tests {
             assert_eq!(
                 realm.presentation_count(),
                 2,
-                "the isolation suite's push_for_test seam must bypass \
-                 PresentationForest::install's len()<=1 ratchet"
+                "PresentationForest::install must accept a second presentation now that the \
+                 ratchet is lifted"
             );
         }
 
@@ -5272,6 +5536,368 @@ mod tests {
                  bit must not be lost -- it must cause a second flush on \
                  the next pump, even though nothing else about the \
                  presentation is dirty"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Addressed input/keyboard routing (issue #555's addressed-routing slice hop-2) — every
+    // input/IME delivery lands on exactly the stamped presentation, except
+    // keyboard, which routes through FocusCoordinator's active presentation
+    // instead (ADR-0043 §4).
+    // ========================================================================
+    mod addressed_input_routing {
+        use std::cell::RefCell;
+
+        use flui_interaction::events::{PointerType, make_down_event};
+        use flui_interaction::testing::input::KeyEventBuilder;
+        use flui_types::ImeEvent;
+        use flui_types::geometry::{Offset, Pixels};
+
+        use super::*;
+
+        fn headless_text_input() -> (
+            Arc<flui_platform::FakeTextInput>,
+            Arc<dyn flui_platform::traits::PlatformTextInput>,
+        ) {
+            let fake = Arc::new(flui_platform::FakeTextInput::new());
+            let capability: Arc<dyn flui_platform::traits::PlatformTextInput> = fake.clone();
+            (fake, capability)
+        }
+
+        /// A pointer event addressed to A must reach ONLY A's own gesture
+        /// arena — never B's, even though both presentations share one
+        /// realm's `enter()` scope and dispatch machinery.
+        ///
+        /// If reverted (`handle_input_addressed`'s `Pointer` arm reads
+        /// `self.presentations.primary()` instead of the resolved addressed
+        /// target): this fails whenever `presentation_id` names the
+        /// non-primary presentation, since the event would land on the
+        /// wrong arena entirely.
+        #[test]
+        fn input_stamped_for_a_never_reaches_bs_arena() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = realm.install_second_presentation_for_test();
+
+            let down = make_down_event(Offset::new(Pixels(4.0), Pixels(6.0)), PointerType::Mouse);
+            realm.enter(|realm| {
+                realm.handle_input_addressed(a_id, PlatformInput::Pointer(down));
+            });
+
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(a_id)
+                    .expect("A installed")
+                    .gestures()
+                    .active_pointer_count(),
+                1,
+                "the addressed presentation must receive the pointer event"
+            );
+            assert_eq!(
+                realm
+                    .presentations
+                    .get(b_id)
+                    .expect("B installed")
+                    .gestures()
+                    .active_pointer_count(),
+                0,
+                "a pointer event stamped for A must never reach B's own gesture arena"
+            );
+        }
+
+        /// Two independently attached IME sessions, one per presentation:
+        /// delivering an event addressed to A must reach only A's attached
+        /// client and must not disturb B's own platform IME session.
+        ///
+        /// If reverted the same way as the pointer exploit above: this
+        /// fails by observing B's sink non-empty, or A's sink empty.
+        #[test]
+        fn ime_attach_on_a_does_not_detach_bs_session() {
+            let (fake_a, capability_a) = headless_text_input();
+            let (fake_b, capability_b) = headless_text_input();
+
+            let mut realm = UiRealm::for_test_with_text_input(Some(capability_a));
+            let a_id = realm.presentation_id();
+            let window_b = crate::app::presentation::test_platform_window(Some(capability_b));
+            let b_id = realm.install_presentation(window_b);
+
+            let received_a = Rc::new(RefCell::new(Vec::new()));
+            let sink_a = Rc::clone(&received_a);
+            let handle_a = realm.presentation_text_input_handle_for_test(a_id);
+            let _token_a = handle_a
+                .attach(Rc::new(move |event: &ImeEvent| {
+                    sink_a.borrow_mut().push(event.clone());
+                }))
+                .expect("A's headless window supports text input");
+
+            let received_b = Rc::new(RefCell::new(Vec::new()));
+            let sink_b = Rc::clone(&received_b);
+            let handle_b = realm.presentation_text_input_handle_for_test(b_id);
+            let _token_b = handle_b
+                .attach(Rc::new(move |event: &ImeEvent| {
+                    sink_b.borrow_mut().push(event.clone());
+                }))
+                .expect("B's headless window supports text input");
+
+            assert_eq!(fake_a.last_ime_allowed(), Some(true));
+            assert_eq!(fake_b.last_ime_allowed(), Some(true));
+
+            realm.enter(|realm| {
+                realm.handle_input_addressed(
+                    a_id,
+                    PlatformInput::Ime(ImeEvent::Commit("hello".to_string())),
+                );
+            });
+
+            assert_eq!(
+                received_a.borrow().as_slice(),
+                [ImeEvent::Commit("hello".to_string())],
+                "A's attached client must receive the event addressed to A"
+            );
+            assert!(
+                received_b.borrow().is_empty(),
+                "an IME event addressed to A must never reach B's attached client"
+            );
+            assert_eq!(
+                fake_b.last_ime_allowed(),
+                Some(true),
+                "delivering an event to A must not touch B's own platform IME session"
+            );
+        }
+
+        /// Keyboard input always routes to the realm's ACTIVE presentation
+        /// (`FocusCoordinator`), never to whichever presentation an
+        /// individual event happens to be stamped for — the race/stray-event
+        /// case where the stamp and the OS-focused window disagree.
+        ///
+        /// Oracle: each presentation's own wake-only `redraw_pending` bit
+        /// (`take_redraw_pending`), set only by the presentation that
+        /// actually ran `dispatch_key_event`. If reverted (the `Keyboard`
+        /// arm dispatches to the STAMPED `presentation_id` instead of
+        /// `self.focus_coordinator.active()`): A's bit would be set and B's
+        /// would not, the opposite of what this test asserts.
+        #[test]
+        fn keyboard_routes_to_active_presentation_only() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = realm.install_second_presentation_for_test();
+            assert_eq!(
+                realm.active_presentation_for_test(),
+                a_id,
+                "a freshly constructed realm starts with its initial presentation active"
+            );
+
+            realm.notify_presentation_focus_gained(b_id);
+            assert_eq!(
+                realm.active_presentation_for_test(),
+                b_id,
+                "a WindowFocus(true) naming B must move the active presentation to B"
+            );
+
+            let key_event = KeyEventBuilder::new(flui_interaction::events::Code::KeyA).build();
+            // Stamped for A -- but B is the currently active presentation.
+            realm.enter(|realm| {
+                realm.handle_input_addressed(a_id, PlatformInput::Keyboard(key_event));
+            });
+
+            let a_presentation = realm.presentations.get(a_id).expect("A installed");
+            let b_presentation = realm.presentations.get(b_id).expect("B installed");
+            assert!(
+                !a_presentation.take_redraw_pending(),
+                "A is only the STAMPED presentation, never the active one here -- it must not \
+                 have received the keyboard event"
+            );
+            assert!(
+                b_presentation.take_redraw_pending(),
+                "keyboard input must route to B, the ACTIVE presentation, regardless of which \
+                 presentation the event was stamped for"
+            );
+        }
+
+        /// `WindowFocus(false)` (focus LOST) never moves the active
+        /// presentation — see [`FocusCoordinator::note_focus_gained`]'s doc
+        /// for why: losing focus names no new owner.
+        #[test]
+        fn focus_lost_does_not_move_the_active_presentation() {
+            let mut realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let b_id = realm.install_second_presentation_for_test();
+
+            realm.notify_presentation_focus_gained(b_id);
+            assert_eq!(realm.active_presentation_for_test(), b_id);
+
+            // `notify_presentation_focus_gained` only exists for the
+            // gained-focus direction; there is no "focus lost" write side to
+            // call, by design (see FocusCoordinator's doc) -- this test pins
+            // that b_id, once active, stays active absent a DIFFERENT
+            // presentation's own focus-gained notification.
+            assert_eq!(
+                realm.active_presentation_for_test(),
+                b_id,
+                "the active presentation must not drift without an explicit focus-gained \
+                 notification naming someone else"
+            );
+            let _ = a_id;
+        }
+
+        /// A focus-gained notification naming a presentation this realm no
+        /// longer hosts (already closed, or a forged id) is a traced no-op —
+        /// arbitration never points at a dead presentation.
+        #[test]
+        fn focus_gained_for_an_unknown_presentation_is_a_traced_no_op() {
+            let realm = UiRealm::for_test();
+            let a_id = realm.presentation_id();
+            let bogus = flui_foundation::PresentationId::new_gen(
+                999,
+                std::num::NonZeroU32::new(999).expect("nonzero"),
+            );
+
+            realm.notify_presentation_focus_gained(bogus);
+
+            assert_eq!(
+                realm.active_presentation_for_test(),
+                a_id,
+                "an unknown presentation id must never become the active one"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Per-presentation redraw wake (issue #555's addressed-routing slice) — a redraw request that
+    // dirties one presentation's own pipeline must poke ITS OWN native
+    // window only, never a sibling's.
+    // ========================================================================
+    mod redraw_wake_routing {
+        use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+        use flui_platform::CursorIcon;
+        use flui_platform::traits::{CursorError, WindowId};
+        use flui_types::geometry::{DevicePixels, Pixels};
+
+        use super::*;
+
+        struct RedrawCountingWindow {
+            id: WindowId,
+            redraw_calls: Arc<AtomicU32>,
+        }
+
+        impl PlatformWindow for RedrawCountingWindow {
+            fn id(&self) -> WindowId {
+                self.id
+            }
+
+            fn physical_size(&self) -> Size<DevicePixels> {
+                Size::default()
+            }
+
+            fn logical_size(&self) -> Size<Pixels> {
+                Size::default()
+            }
+
+            fn scale_factor(&self) -> f64 {
+                1.0
+            }
+
+            fn request_redraw(&self) {
+                self.redraw_calls.fetch_add(1, AtomicOrdering::Relaxed);
+            }
+
+            fn is_focused(&self) -> bool {
+                false
+            }
+
+            fn is_visible(&self) -> bool {
+                true
+            }
+
+            fn set_cursor(&self, _cursor: CursorIcon) -> Result<(), CursorError> {
+                Ok(())
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        fn counting_window(id: u64) -> (Arc<dyn PlatformWindow>, Arc<AtomicU32>) {
+            let redraw_calls = Arc::new(AtomicU32::new(0));
+            let window: Arc<dyn PlatformWindow> = Arc::new(RedrawCountingWindow {
+                id: WindowId(id),
+                redraw_calls: Arc::clone(&redraw_calls),
+            });
+            (window, redraw_calls)
+        }
+
+        /// A redraw request that dirties presentation A's own pipeline must
+        /// poke ONLY A's native window — never B's — even though both
+        /// presentations share this realm's platform wake capability.
+        ///
+        /// If reverted (`PresentationState::new`'s `on_need_visual_update`
+        /// wiring calling only `capabilities.wake` with no per-window poke,
+        /// the pre-addressed-routing shape): this fails by observing A's own
+        /// counter stay at zero — `capabilities.wake` in this test is a
+        /// no-op closure, so nothing would poke ANY window at all.
+        #[test]
+        fn redraw_request_from_a_does_not_wake_bs_window() {
+            let (window_a, calls_a) = counting_window(1);
+            let (window_b, calls_b) = counting_window(2);
+
+            // `PresentationState` keeps only a `Weak` ref to its window (the
+            // platform owns the strong `Arc` in production, e.g. via its own
+            // per-window callback closures) -- these two local bindings are
+            // what keep each window alive for this test, exactly like
+            // `presentation.rs`'s own `perform_haptic_feedback_*` tests do;
+            // pass clones into the realm, never the only strong reference.
+            let mut realm = UiRealm::new(
+                noop_wake(),
+                Arc::clone(&window_a),
+                1.0,
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect("realm constructs");
+            let a_id = realm.presentation_id();
+            let b_id = realm.install_presentation(Arc::clone(&window_b));
+
+            assert_eq!(calls_a.load(AtomicOrdering::Relaxed), 0);
+            assert_eq!(calls_b.load(AtomicOrdering::Relaxed), 0);
+
+            realm
+                .presentations
+                .get(a_id)
+                .expect("A installed")
+                .pipeline()
+                .with(flui_rendering::pipeline::PipelineOwner::request_visual_update);
+
+            assert_eq!(
+                calls_a.load(AtomicOrdering::Relaxed),
+                1,
+                "dirtying A's own pipeline must poke A's own window"
+            );
+            assert_eq!(
+                calls_b.load(AtomicOrdering::Relaxed),
+                0,
+                "dirtying A must never poke B's window"
+            );
+
+            // The reverse direction, for symmetry: dirtying B pokes B only.
+            realm
+                .presentations
+                .get(b_id)
+                .expect("B installed")
+                .pipeline()
+                .with(flui_rendering::pipeline::PipelineOwner::request_visual_update);
+
+            assert_eq!(
+                calls_a.load(AtomicOrdering::Relaxed),
+                1,
+                "dirtying B must never poke A's window"
+            );
+            assert_eq!(
+                calls_b.load(AtomicOrdering::Relaxed),
+                1,
+                "dirtying B's own pipeline must poke B's own window"
             );
         }
     }

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -176,6 +176,20 @@ impl WindowRegistry {
             .map(|(_, address)| *address)
     }
 
+    /// Whether `address` names a window mapping currently held by this
+    /// registry — the addressed-dispatch validity check `dispatch_platform_
+    /// realm` (`runner.rs`) uses in place of comparing against a single
+    /// cached "current" address (issue #555's per-presentation
+    /// generational `StalePresentation` extension): a realm hosting more
+    /// than one presentation has more than one live address at once, so
+    /// membership in this one authority — not equality against any single
+    /// value — is the only check general enough for N presentations.
+    pub(crate) fn contains_address(&self, address: PresentationAddress) -> bool {
+        self.entries
+            .iter()
+            .any(|(_, entry_address)| *entry_address == address)
+    }
+
     /// Removes and returns **every** entry addressed to `realm_id`.
     ///
     /// The target model is one realm owning any number of windows, so a

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -177,13 +177,14 @@ impl WindowRegistry {
     }
 
     /// Whether `address` names a window mapping currently held by this
-    /// registry — the addressed-dispatch validity check `dispatch_platform_
-    /// realm` (`runner.rs`) uses in place of comparing against a single
-    /// cached "current" address (issue #555's per-presentation
-    /// generational `StalePresentation` extension): a realm hosting more
-    /// than one presentation has more than one live address at once, so
-    /// membership in this one authority — not equality against any single
-    /// value — is the only check general enough for N presentations.
+    /// registry — the addressed-dispatch validity check
+    /// `dispatch_platform_realm` (`runner.rs`) uses in place of comparing
+    /// against a single cached "current" address (issue #555's
+    /// per-presentation generational `StalePresentation` extension): a
+    /// realm hosting more than one presentation has more than one live
+    /// address at once, so membership in this one authority — not equality
+    /// against any single value — is the only check general enough for N
+    /// presentations.
     pub(crate) fn contains_address(&self, address: PresentationAddress) -> bool {
         self.entries
             .iter()

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -325,9 +325,17 @@ call site opens a genuinely second native window through \
 one, through the legacy displacing `install_platform_realm`) -- that native \
 wiring, plus `ExitPolicy` actually gating a live winit loop's exit instead \
 of the platform backend's own unconditional "last window closed" signal, is \
-this issue's native-lifecycle follow-up; and a REALM hosting more than one \
-PRESENTATION (the element forest) is a separate, still-unstarted claim this \
-contract does not yet make.
+this issue's native-lifecycle follow-up. A REALM hosting more than one \
+PRESENTATION is no longer a still-unstarted claim: issue #555's \
+addressed-routing slice lifted `PresentationForest`'s former `len()<=1` \
+ratchet and gave a second presentation a real `WindowRegistry` mapping and \
+addressed input/semantics/keyboard routing (see \
+`multi-presentation-forest-gate`, `input-domain-per-presentation`, \
+`focus-coordination-per-realm`) -- what remains unstarted is specifically \
+the NATIVE embedder wiring that would let a real second OS window drive \
+`install_presentation_alongside`, the same native-lifecycle gap named above \
+for the sibling multi-realm path, not the ownership/routing mechanism \
+itself.
 
 `with_owner_platform`'s fence (c) (ADR-0039 §6, trigger #22's runtime \
 backstop) re-points onto this struct: `AppRuntime::installed_realm_phase` \
@@ -364,10 +372,10 @@ longer exist at all, and `two_realms_coexist_same_thread` / \
 `cross_realm_duplicate_global_key_mounts_succeed_in_both` prove two \
 directly-constructed `UiRealm`s share no widget/focus/gesture-arena/scheduler \
 state, on one thread or two. This state stays "partial", not "implemented", \
-because the remaining gaps stated above (native second-window wiring, a \
-realm hosting more than one presentation) are real and unclosed -- marking \
-this contract fully "implemented" would overclaim past what has actually \
-landed.\
+because the remaining gap stated above -- native embedder wiring for a \
+genuine second OS window, for both a second realm and a second presentation \
+of an existing realm -- is real and unclosed; marking this contract fully \
+"implemented" would overclaim past what has actually landed.\
 """
 state = "partial"
 domain = "application"
@@ -648,14 +656,24 @@ defaulting to the realm's initial presentation) and is the sole thing \
 event always routes to the coordinator's ACTIVE presentation, never to \
 whichever presentation the event happens to be stamped for -- covering the \
 race/stray-event case where the two disagree \
-(`keyboard_routes_to_active_presentation_only`). The sole write side, \
-`FocusCoordinator::note_focus_gained`, fires from `PlatformToUi::WindowFocus(true)` \
-handling (`runner.rs`), stamped with the presentation that event's own \
-dispatcher was addressed to; `WindowFocus(false)` (focus LOST) never moves \
-the active presentation (`focus_lost_does_not_move_the_active_presentation`) \
--- losing focus names no new owner, matching Flutter's own focus-retention \
-model. A focus-gained notification naming a presentation this realm no \
-longer hosts is a traced no-op, never a panic \
+(`keyboard_routes_to_active_presentation_only`). \
+`FocusCoordinator::note_focus_gained` has TWO write sides, not one: \
+`PlatformToUi::WindowFocus(true)` handling (`runner.rs`) fires it with the \
+presentation that event's own dispatcher was addressed to, driven \
+end-to-end through the real `dispatch_platform_realm` seam (not a direct \
+call) by `window_focus_true_moves_active_presentation_end_to_end_and_false_\
+does_not` (`runner.rs`); `WindowFocus(false)` (focus LOST) never moves the \
+active presentation there -- losing focus names no new owner, matching \
+Flutter's own focus-retention model. The second write side is \
+`UiRealm::close_presentation_entered`, re-stamping active to the surviving \
+primary (`primary_id_excluding`) BEFORE dispose hooks run (mirroring \
+`RealmSlot::address`'s own re-stamp-before-dispose ordering) whenever the \
+presentation being closed is the currently active one -- without this, \
+closing the active presentation would leave the coordinator pointing at a \
+dead id, and every keyboard event would drop traced until a fresh \
+`WindowFocus(true)` happened to arrive (`keyboard_after_closing_the_active_\
+presentation_routes_to_the_survivor`). A focus-gained notification naming a \
+presentation this realm no longer hosts is a traced no-op, never a panic \
 (`focus_gained_for_an_unknown_presentation_is_a_traced_no_op`).\
 """
 state = "implemented"
@@ -669,8 +687,9 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn notify_presentation_focus_gained" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn presentation_and_widget_tree_share_the_exact_focus_owner" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn keyboard_routes_to_active_presentation_only" },
-    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn focus_lost_does_not_move_the_active_presentation" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn window_focus_true_moves_active_presentation_end_to_end_and_false_does_not" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn focus_gained_for_an_unknown_presentation_is_a_traced_no_op" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn keyboard_after_closing_the_active_presentation_routes_to_the_survivor" },
 ]
 
 [[contract]]
@@ -763,9 +782,15 @@ dispatcher is refused at the SAME authority a fresh dispatch would resolve \
 against, never a second source of truth. `runner.rs::install_presentation_alongside` \
 is the production entry point that mints a NEW presentation's real \
 registry mapping alongside an existing one -- the "non-primary presentations \
-get real mappings when installed" residual the forest slice \
-(`docs/pr-notes-555-3.md`) left open. Remains "partial" overall: `WindowHost` \
-itself is still not a real owner OBJECT with its own cancellation tokens \
+get real mappings when installed" residual the forest slice left open. \
+Ordering is load-bearing there too: the presentation is assembled \
+(`UiRealm::assemble_presentation`) but NOT installed into the forest until \
+AFTER its registry mapping is confirmed, so a registration failure leaves \
+nothing forest-resident to roll back -- the assembled-but-unregistered \
+`PresentationState` is simply dropped \
+(`install_presentation_alongside_leaves_the_forest_unchanged_on_registration_\
+failure`). Remains "partial" overall: `WindowHost` itself is still not a \
+real owner OBJECT with its own cancellation tokens \
 (`cancellable-platform-callbacks` tracks that separately), and per-window \
 resize/lifecycle events are still realm-wide, not yet addressed to the exact \
 presentation the way input/IME/semantics now are.\
@@ -780,6 +805,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn contains_address" },
     { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn install_presentation_alongside" },
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn install_presentation" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn assemble_presentation" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn install_presentation_alongside_leaves_the_forest_unchanged_on_registration_failure" },
 ]
 
 [[contract]]
@@ -888,16 +915,23 @@ closed window drops the update). `UiRealm::handle_input_addressed` \
 (issue #555's addressed-routing slice) is the hop-2 entry point that makes \
 this genuinely cross-presentation: it resolves the exact addressed \
 presentation from the realm's forest (a presentation this realm no longer \
-hosts is a traced drop, never a fall-through to the primary) and delivers \
+hosts -- an id that never existed, or a real id already closed -- is a \
+traced drop, never a fall-through to the primary) and delivers \
 Pointer/IME/DragDrop to THAT presentation's own gesture/text-input state \
 only -- never a sibling's, proven now that a second presentation can \
-actually exist (`input_stamped_for_a_never_reaches_bs_arena`, \
-`ime_attach_on_a_does_not_detach_bs_session`). Keyboard is the documented \
-exception -- see `focus-coordination-per-realm`. `handle_input_entered` \
-(no explicit id) is the pre-addressed-routing convenience that still \
-resolves to the primary, kept for every single-presentation call site; \
-production dispatch (`runner.rs`'s `PlatformToUi::run`) always calls the \
-addressed form with the real stamped id.\
+actually exist (`input_stamped_for_b_never_reaches_as_arena`, \
+`ime_event_addressed_to_b_does_not_reach_as_session`, both deliberately \
+addressing the NON-primary presentation B, not A: an A-addressed fixture \
+cannot distinguish "delivered to the addressed presentation" from \
+"delivered to the primary", since A already is the primary; \
+`input_addressed_to_a_closed_or_unknown_presentation_drops_traced_never_\
+falls_through` pins the no-fallback half for both an id that never existed \
+and a real id already closed). Keyboard is the documented exception -- see \
+`focus-coordination-per-realm`. `handle_input_entered` (no explicit id) is \
+the pre-addressed-routing convenience that still resolves to the primary, \
+kept for every single-presentation call site; production dispatch \
+(`runner.rs`'s `PlatformToUi::run`) always calls the addressed form with \
+the real stamped id.\
 """
 state = "implemented"
 domain = "presentation"
@@ -907,8 +941,9 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "gestures: GestureBinding" },
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn handle_input_addressed" },
     { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn mouse_tracker_applies_cursor_to_the_exact_owned_window" },
-    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn input_stamped_for_a_never_reaches_bs_arena" },
-    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn ime_attach_on_a_does_not_detach_bs_session" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn input_stamped_for_b_never_reaches_as_arena" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn ime_event_addressed_to_b_does_not_reach_as_session" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn input_addressed_to_a_closed_or_unknown_presentation_drops_traced_never_falls_through" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn redraw_request_from_a_does_not_wake_bs_window" },
 ]
 

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -412,15 +412,25 @@ mechanical = false
 key = "idle-only-commit-points"
 statement = """
 Cross-thread commands and worker results commit only while the realm's \
-scheduler phase is Idle — never inside the frame transaction.\
+scheduler phase is Idle — never inside the frame transaction. Owned by \
+issue #553; touched (not renegotiated) by issue #555's addressed-routing \
+slice, which extended `drain_commands`'s `SemanticsAction` arm from a \
+primary-only equality check to a genuine `PresentationForest` membership \
+check (a presentation generation this realm no longer hosts drops traced, \
+whether it was ever the primary or not) — the Idle-only commit gate itself \
+is unchanged; only which presentation a committed command resolves against \
+became addressed instead of primary-only.\
 """
 state = "implemented"
 domain = "realm"
+owner_issue = 553
 mechanical = true
 mechanism = "drain_commands asserts/gates on SchedulerPhase::Idle; owner-thread commit pinned by test"
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "SchedulerPhase::Idle" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn cross_thread_navigation_command_drains_on_owner_thread" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn semantics_action_addressed_to_a_live_non_primary_presentation_is_invoked" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn semantics_action_with_stale_presentation_generation_drops_traced" },
 ]
 
 [[contract]]
@@ -629,16 +639,38 @@ key = "focus-coordination-per-realm"
 statement = """
 One `FocusTree` per presentation with realm-level active-presentation \
 arbitration. The per-presentation `FocusManager` is real (owned by \
-`PresentationState`); the multi-presentation `FocusCoordinator` arbitration \
-cannot exist before the element forest.\
+`PresentationState`, unchanged since the forest slice); `FocusCoordinator` \
+(`ui_realm.rs`, private) is the multi-presentation arbitration this contract \
+was waiting on the element forest for -- it tracks exactly which \
+presentation currently owns OS keyboard focus (`Cell<PresentationId>`, \
+defaulting to the realm's initial presentation) and is the sole thing \
+`UiRealm::handle_input_addressed`'s `Keyboard` arm consults: a keyboard \
+event always routes to the coordinator's ACTIVE presentation, never to \
+whichever presentation the event happens to be stamped for -- covering the \
+race/stray-event case where the two disagree \
+(`keyboard_routes_to_active_presentation_only`). The sole write side, \
+`FocusCoordinator::note_focus_gained`, fires from `PlatformToUi::WindowFocus(true)` \
+handling (`runner.rs`), stamped with the presentation that event's own \
+dispatcher was addressed to; `WindowFocus(false)` (focus LOST) never moves \
+the active presentation (`focus_lost_does_not_move_the_active_presentation`) \
+-- losing focus names no new owner, matching Flutter's own focus-retention \
+model. A focus-gained notification naming a presentation this realm no \
+longer hosts is a traced no-op, never a panic \
+(`focus_gained_for_an_unknown_presentation_is_a_traced_no_op`).\
 """
-state = "partial"
+state = "implemented"
 domain = "presentation"
 owner_issue = 555
 mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "fn focus_manager" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "struct FocusCoordinator" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn note_focus_gained" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn notify_presentation_focus_gained" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn presentation_and_widget_tree_share_the_exact_focus_owner" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn keyboard_routes_to_active_presentation_only" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn focus_lost_does_not_move_the_active_presentation" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn focus_gained_for_an_unknown_presentation_is_a_traced_no_op" },
 ]
 
 [[contract]]
@@ -714,9 +746,29 @@ cancellation. The loop side now has an explicit owner object — \
 (`RealmHost`) that used to sit directly in `runner.rs`; the runner's own \
 dispatch functions (`install_platform_realm`, `dispatch_platform_realm`, \
 `teardown_platform_realm`) and per-window callbacks still stand in for the \
-rest of `WindowHost`'s stated responsibilities (routing/cancellation as a \
-method surface on the owner object itself, not free functions closing over \
-its TLS slot) — that reshaping is not claimed here.\
+rest of `WindowHost`'s stated responsibilities (as free functions closing \
+over the TLS slot, not yet a method surface on the owner object itself) — \
+that reshaping is not claimed here.
+
+**Demux remainder cleared (issue #555's addressed-routing slice):** \
+`dispatch_platform_realm`'s presentation check is now a genuine per-dispatch \
+`WindowRegistry` membership read (`registry.contains_address(dispatcher.address)`), \
+not equality against a single cached `RealmSlot.address` value -- the same \
+authority every window's own install/close path writes through, consulted \
+fresh at every dispatch. This is "resolve-at-dispatch" in the sense hop-1 \
+demux requires it: a window's captured `RealmDispatcher` is only ever valid \
+for as long as the registry still maps its exact address, so a reinstalled \
+window (the panic-recovery replace path) or a closed presentation's stale \
+dispatcher is refused at the SAME authority a fresh dispatch would resolve \
+against, never a second source of truth. `runner.rs::install_presentation_alongside` \
+is the production entry point that mints a NEW presentation's real \
+registry mapping alongside an existing one -- the "non-primary presentations \
+get real mappings when installed" residual the forest slice \
+(`docs/pr-notes-555-3.md`) left open. Remains "partial" overall: `WindowHost` \
+itself is still not a real owner OBJECT with its own cancellation tokens \
+(`cancellable-platform-callbacks` tracks that separately), and per-window \
+resize/lifecycle events are still realm-wide, not yet addressed to the exact \
+presentation the way input/IME/semantics now are.\
 """
 state = "partial"
 domain = "application"
@@ -725,6 +777,9 @@ mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
     { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(crate) struct AppRuntime" },
+    { kind = "symbol", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn contains_address" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn install_presentation_alongside" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn install_presentation" },
 ]
 
 [[contract]]
@@ -734,10 +789,18 @@ Generational `PresentationId` exists, is stamped on `PresentationState`, \
 `SceneSnapshot`, and every `RasterAck`/`PumpOutcome` variant, and \
 `flui-app`'s private `WindowRegistry` (`window_registry.rs`) is the sole \
 `WindowId -> PresentationAddress` mint authority, read at install (a self-check) and \
-teardown (`remove_realm`). Remainder: the registry is not yet the routing \
-demux — platform callbacks still deliver through captured addresses rather \
-than a `resolve` lookup — and it is not yet lifted into a public \
-multi-window `AppRuntime`.\
+teardown (`remove_realm`). Issue #555's addressed-routing slice closed the \
+routing-demux half of this remainder: `dispatch_platform_realm` now checks \
+`registry.contains_address` fresh at every dispatch (`WindowId` itself \
+stays confined to `window_registry.rs`, so a caller compares by address, \
+never a raw window id) rather than trusting a captured dispatcher's address \
+unconditionally -- a window whose mapping was replaced (panic-recovery \
+reinstall) or removed (presentation close) is refused at the SAME authority \
+a fresh dispatch would resolve against. What remains open: this is not yet \
+lifted into a public multi-window `AppRuntime`, and no production embedder \
+call site opens a second presentation from a real second native window yet \
+(`runner.rs::install_presentation_alongside` exists and is exercised by \
+tests, mirroring `install_realm_alongside`'s own precedent).\
 """
 state = "partial"
 domain = "application"
@@ -820,18 +883,33 @@ evidence = [
 key = "input-domain-per-presentation"
 statement = """
 Each presentation owns one complete input domain (gesture arena, mouse \
-tracker, focus tree, cursor to the exact window; a closed window drops the \
-update). Implemented for the single presentation that can exist today; the \
-cross-presentation isolation clauses are untestable until the element forest \
-allows a second presentation.\
+tracker, focus tree, text-input session, cursor to the exact window; a \
+closed window drops the update). `UiRealm::handle_input_addressed` \
+(issue #555's addressed-routing slice) is the hop-2 entry point that makes \
+this genuinely cross-presentation: it resolves the exact addressed \
+presentation from the realm's forest (a presentation this realm no longer \
+hosts is a traced drop, never a fall-through to the primary) and delivers \
+Pointer/IME/DragDrop to THAT presentation's own gesture/text-input state \
+only -- never a sibling's, proven now that a second presentation can \
+actually exist (`input_stamped_for_a_never_reaches_bs_arena`, \
+`ime_attach_on_a_does_not_detach_bs_session`). Keyboard is the documented \
+exception -- see `focus-coordination-per-realm`. `handle_input_entered` \
+(no explicit id) is the pre-addressed-routing convenience that still \
+resolves to the primary, kept for every single-presentation call site; \
+production dispatch (`runner.rs`'s `PlatformToUi::run`) always calls the \
+addressed form with the real stamped id.\
 """
-state = "partial"
+state = "implemented"
 domain = "presentation"
 owner_issue = 555
 mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "gestures: GestureBinding" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn handle_input_addressed" },
     { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn mouse_tracker_applies_cursor_to_the_exact_owned_window" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn input_stamped_for_a_never_reaches_bs_arena" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn ime_attach_on_a_does_not_detach_bs_session" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn redraw_request_from_a_does_not_wake_bs_window" },
 ]
 
 [[contract]]
@@ -915,22 +993,31 @@ not a second source of truth — both are written only by \
 `install_platform_realm`/`teardown_platform_realm`, inside the same TLS \
 borrow, in that order: registry first on install, registry removal first on \
 teardown (so map removal stops new routing before queued old-generation \
-events drop). Remainder: the registry mints and is read at install/teardown, \
-but it is not yet the routing demux — platform callbacks still deliver \
-through per-window closures with captured addresses rather than a `resolve` \
-lookup — and `AppRuntime` hosts it as a single-slot owner, not yet the \
-public multi-window registry it grows once the element forest lets a realm \
-host multiple presentations.\
+events drop). Issue #555's addressed-routing slice added the routing-demux \
+half: `dispatch_platform_realm` (`runner.rs`) checks `registry.contains_address` \
+fresh at every dispatch, so a per-window closure's captured address is only \
+ever trusted as far as this registry currently backs it -- a replaced or \
+removed mapping is refused there, not silently honored from the closure's \
+own stale copy. `runner.rs::install_presentation_alongside` mints a second \
+presentation's registry mapping alongside an existing one, in the same call \
+that installs it into the forest (`UiRealm::install_presentation`), so no \
+hosted presentation is ever forest-resident without a registry mapping of \
+its own. Remainder: `AppRuntime` still hosts the registry as a single-slot \
+owner, not yet the public multi-window registry it grows once a real \
+embedder opens a genuine second native window through this path.\
 """
 state = "partial"
 domain = "application"
 owner_issue = 552
 mechanical = true
-mechanism = "forbidden_pattern scoped scan confines the WindowId token to window_registry.rs (plus two test-only PlatformWindow-mock allow-listed files) within crates/flui-app/src"
+mechanism = "forbidden_pattern scoped scan confines the WindowId token to window_registry.rs (plus three test-only PlatformWindow-mock allow-listed files) within crates/flui-app/src"
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/window_registry.rs", contains = "pub(crate) struct WindowRegistry" },
+    { kind = "symbol", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn contains_address" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn install_presentation_alongside" },
     { kind = "test", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn remove_realm_returns_the_installed_entry" },
     { kind = "test", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn try_register_rejects_duplicate_window" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn closing_a_presentation_unregisters_its_window_mapping" },
 ]
 
 [[contract]]
@@ -953,20 +1040,29 @@ evidence = [
 key = "multi-presentation-forest-gate"
 statement = """
 `UiRealm` hosts an insertion-ordered `PresentationForest` (ADR-0043 §1), not \
-a single `PresentationState` field — but production topology stays gated at \
-exactly one presentation per realm through the forest's own mechanical \
-ratchet: `PresentationForest::install` panics with `BUG:` if the forest \
-already holds a presentation, and has no production caller (opening a second \
-independent window installs a second REALM instead, through the multi-realm \
-`AppRuntime`). `push_for_test` is the isolation suite's only bypass, \
-`cfg(test)`-gated. Every presentation is its own bundle (own \
-`WidgetsBinding`, `RenderingFlutterBinding`, focus/IME/gestures/semantics) \
-assembled via `PresentationState::new`'s `RealmCapabilities` parameter, which \
-installs the realm's `GlobalKeyScope` before any realm-shared dispatch handle \
-and before attach/mount. Addressed routing across a genuine N>1 forest \
-(`PresentationForest::get`/`remove` by id) is wired but has no production \
-entry point yet -- a later addressed-routing slice adds one; lifting the \
-ratchet is deferred to it, not to this contract's ownership shape. \
+a single `PresentationState` field. **The former mechanical ratchet is \
+lifted (issue #555's addressed-routing slice, landed in the SAME commit as \
+the addressed entry points below):** `PresentationForest::install` no \
+longer panics past one presentation -- it is the production entry point \
+`UiRealm::install_presentation` calls to assemble and grow the forest, and \
+`runner.rs::install_presentation_alongside` is the caller that also mints \
+the fresh presentation's real `WindowRegistry` mapping in the same step \
+(mirroring `install_realm_alongside`'s own "no production embedder call \
+site opens a second window yet, exercised directly by this module's own \
+tests" precedent -- opening a genuine second OS window is still this \
+issue's native-lifecycle follow-up). The isolation suite's former \
+`cfg(test)`-only `push_for_test` bypass is deleted: every test now grows a \
+forest through the SAME production `install` call \
+(`install_presentation_grows_the_forest_past_one`). Every presentation is \
+its own bundle (own `WidgetsBinding`, `RenderingFlutterBinding`, \
+focus/IME/gestures/semantics) assembled via `PresentationState::new`'s \
+`RealmCapabilities` parameter, which installs the realm's `GlobalKeyScope` \
+before any realm-shared dispatch handle and before attach/mount. Addressed \
+routing across a genuine N>1 forest (`PresentationForest::get`/`remove` by \
+id) now has real production entry points: `UiRealm::handle_input_addressed` \
+(hop-2, see `input-domain-per-presentation`), `drain_commands`'s \
+`SemanticsAction` arm (forest membership, see `idle-only-commit-points`), \
+and `FocusCoordinator` (see `focus-coordination-per-realm`). \
 `UiRealm::draw_frame_entered`'s pump processes every presentation once each, \
 in mount order: each presentation's own wake bit (`PresentationState::
 redraw_pending`) is cleared at the START of its segment, before its dirty \
@@ -1016,22 +1112,29 @@ self-deadlock, not a race, and was caught (the test hung) by this \
 contract's own red-exploit test before the exclusion existed. Excluding it \
 costs nothing real: every OTHER presentation still resolves normally, and \
 a presentation cannot meaningfully resolve one of its OWN keys through a \
-registry that is mid-teardown anyway.\
+registry that is mid-teardown anyway. \
+Stays "partial", not "implemented": the ratchet lift and the addressed \
+routing it unblocks are both real and exercised, but no production embedder \
+call site opens a genuine second native window and installs a second \
+presentation through this path yet -- the same native-lifecycle gap \
+`app-runtime-composition-host`/`window-host-is-explicit-composition-owner` \
+name for the sibling multi-realm path.\
 """
 state = "partial"
 domain = "realm"
 owner_issue = 555
 mechanical = true
-mechanism = "PresentationForest symbol + its install-ratchet panic message pinned; a lifted ratchet or renamed panic would change these strings"
+mechanism = "PresentationForest::install and its production callers pinned; the six-step teardown contract's symbols pinned"
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "presentations: PresentationForest" },
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "widgets: WidgetsBinding" },
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "renderer: RenderingFlutterBinding" },
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "redraw_pending: Cell<bool>" },
-    { kind = "symbol", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "BUG: PresentationForest::install called while the ratchet is" },
-    { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn install_panics_once_the_forest_already_holds_a_presentation" },
-    { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn push_for_test_bypasses_the_ratchet" },
-    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn push_for_test_bypasses_the_production_ratchet" },
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "pub(crate) fn install" },
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn install_presentation" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn install_presentation_alongside" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation_forest.rs", contains = "fn install_accepts_any_number_of_presentations" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn install_presentation_grows_the_forest_past_one" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn reassemble_fans_out_to_all_presentations_in_mount_order" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropping_the_realm_closes_every_presentation" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn sibling_presentations_flush_independently" },
@@ -1047,6 +1150,7 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn closing_presentation_a_leaves_sibling_layer_tree_identical" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropped_presentations_surviving_pipeline_handles_fail_closed" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn dispose_opening_a_window_mid_teardown_defers_and_does_not_reenter" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn closing_a_presentation_unregisters_its_window_mapping" },
 ]
 
 [[contract]]
@@ -2213,19 +2317,24 @@ bare WindowId, so runner.rs and friends never name the type). Proxy-gate \
 disclaimer: `let id = window.id();` with an inferred local type defeats a \
 substring scan on its own -- the manual backstop is that no flui-app \
 routing API outside window_registry.rs accepts or returns WindowId. \
-runtime.rs and presentation.rs are allow-listed only for their test-only \
-PlatformWindow mock implementations, which must restate the trait's \
-required `fn id(&self) -> WindowId` signature to implement it at all; \
-that is a structural trait-conformance fact, not a routing-logic \
-exception, and neither file's production code may accept or return the \
-type. The retired `AppBinding`'s equivalent test mock (`binding.rs`) moved \
-to `runtime.rs`'s `wake_and_clipboard_tests` alongside the wake mechanism \
-it exercises.\
+runtime.rs, presentation.rs, and ui_realm.rs are allow-listed only for \
+their test-only PlatformWindow mock implementations, which must restate \
+the trait's required `fn id(&self) -> WindowId` signature to implement it \
+at all; that is a structural trait-conformance fact, not a routing-logic \
+exception, and none of the three files' production code may accept or \
+return the type. The retired `AppBinding`'s equivalent test mock \
+(`binding.rs`) moved to `runtime.rs`'s `wake_and_clipboard_tests` alongside \
+the wake mechanism it exercises. `ui_realm.rs`'s own mock \
+(`RedrawCountingWindow`, in its `redraw_wake_routing` test module, issue \
+#555's addressed-routing slice) exists to observe per-presentation \
+`request_redraw` calls -- proving one presentation's redraw request pokes \
+only its own native window, never a sibling's.\
 """
 allow_files = [
     "crates/flui-app/src/app/window_registry.rs",
     "crates/flui-app/src/app/runtime.rs",
     "crates/flui-app/src/app/presentation.rs",
+    "crates/flui-app/src/app/ui_realm.rs",
 ]
 
 [[forbidden_pattern]]


### PR DESCRIPTION
Slice 4 of #555, on top of the forest (#607).

## What

- **Two-hop exact routing**: hop 1 — `WindowRegistry` resolves every native window to its `PresentationAddress` at dispatch (non-primary presentations now carry real mappings; the forest slice's residual is closed and its skipped teardown self-checks are re-enabled); hop 2 — realm entry points take the stamped `PresentationId` and deliver to exactly that presentation's arena/focus/IME/semantics. Stale or unknown stamps drop traced — no delivery ever falls back to the primary (`handle_input_entered` is now test-only, proven by `expect(dead_code)`).
- **`FocusCoordinator`**: realm-level arbitration of the active presentation; keyboard routes to the active presentation only; platform `WindowFocus` moves it through the real dispatch seam. Closing the active presentation re-stamps arbitration to the survivor before dispose hooks run — same ordering discipline as the slot address re-stamp — so keyboard routing stays defined through the close window.
- **Ratchet lifted in the same commit** the addressed entry points land: `PresentationForest::install` is production-multi; the registry pin moved from the panic-string ratchet to the addressed-entry-point invariants; every isolation test now runs through production install (`push_for_test` deleted). Alongside-install now registers the window before installing into the forest — a registration failure leaves nothing forest-resident (classified `InstallPresentationError`).
- **Semantics**: stamp validation generalized to forest membership with per-presentation generational drops; platform accessibility bridge wiring remains named-deferred in the registry — nothing faked.
- Registry: `focus-coordination-per-realm` and `input-domain-per-presentation` → `implemented` (evidence mutant-verified); `window-host-is-explicit-composition-owner` demux remainder cleared; the two #553-owned contracts revised with ownership history intact; `app-runtime-composition-host` stays `partial` (native wiring is the last slice).

## Evidence

- 831/831 tests (`flui-app` + `flui-view`); full `just ci` exit 0; workspace clippy, 30-combination feature-matrix, wasm-check, rustdoc `-D warnings`, conformance (47), port-check, taplo, typos all clean.
- Review caught the initial headline exploits stamping the PRIMARY (observationally identical to always-primary routing — the mutant survived); re-fixtured to address the non-primary and assert both receipt and sibling non-receipt. Final pass: reviewer re-ran the reroute-to-primary and unconditional-focus-gain mutants — all killed; verdict CLEAN at 32d9232f.

Part of #555. Remaining: the window-policy/native-lifecycle slice, which flips `app-runtime-composition-host` to `implemented`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du3J3bDcsRaSU3tKgYKvni