### PR TITLE
docs(agents): say how to restore the gitignored .flutter reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,15 @@ When changing render-tree, sliver, layout, paint, hit-test, semantics, schedulin
 
 **Read the reference for *what* and *why*, then write Rust from that understanding — do not transcribe.** Loyalty is to observable behavior (output, edge cases, ordering), not to Dart's structure, naming, or file layout. Confirm the match before reporting done — see [Definition of Done](#definition-of-done-anti-cheating).
 
+**The references are gitignored local clones, so they can be absent — check before citing one.** `ls .flutter` costs nothing and a missing reference has already produced hollow "verified against Flutter" claims here. Restore with a sparse shallow clone (~62 MB):
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/flutter/flutter.git .flutter
+cd .flutter && git sparse-checkout set packages/flutter/lib packages/flutter/test
+```
+
+If the reference is unavailable, say so explicitly instead of reasoning from memory — an unverified parity claim is worse than a stated gap.
+
 ## Documentation
 
 | Document | Path | When to read |


### PR DESCRIPTION
`AGENTS.md` makes verifying against `.flutter/` a Definition-of-Done requirement in three places, but never says the reference is a **gitignored local clone** rather than checked-in content. It was absent from a working checkout, which meant the requirement was silently unsatisfiable — and parity claims were made anyway.

This adds the check and the restore command (sparse shallow clone, ~62 MB), plus the rule that an unavailable reference must be stated rather than worked around from memory.

Not hypothetical: within minutes of restoring it, the reference settled an open review dispute in #556 verbatim — `rendering/binding.dart` shows `sendFramesToEngine` gates the submit only, which turned "I think the deferral shouldn't skip layout" into a cited fact and caught a real regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du3J3bDcsRaSU3tKgYKvni