### PR TITLE
fix(app): a lost device retries — wake on recovery failure, with a bounded backoff

### DIFF
--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -268,6 +268,75 @@ fn merge_wake_deadlines(
     [a, b].into_iter().flatten().min()
 }
 
+/// Whether an armed device-recovery deadline should actually be reported to
+/// [`install_wake_deadline_hook`]'s secondary-source closure this call —
+/// pulled out as its own pure function for the same reason `frame_is_dirty`
+/// was: the real closure captures `APP_RUNTIME` state no unit test can drive
+/// directly, so the decision this function makes is tested here in
+/// isolation instead, and the closure calls this rather than reimplementing
+/// it (round 6's own lesson about what happens to a predicate reimplemented
+/// in two places).
+///
+/// `frames_enabled == false` suppresses the deadline unconditionally,
+/// regardless of how soon it is due: while frames are disabled
+/// (`AppLifecycleState::Hidden`/`Paused`/`Detached`), the frame closure's
+/// `WakeAction::PumpAsync` arm returns before `render_frame_with_device_
+/// recovery` ever runs, so nothing on that path would consume a reported
+/// deadline — reporting it anyway hands `about_to_wait` the SAME past
+/// instant on every idle iteration once it comes due, which is
+/// `WinitApp::new_events`'s own named `WaitUntil(past)` busy-spin, forced by
+/// this hook instead of a stale realm deadline. The deadline is not lost by
+/// staying unreported while disabled: frames re-enabling already redirties
+/// the root unconditionally (`UiRealm::redirty_root_for_frames_reenable`),
+/// which wakes the loop through the ordinary `needs_redraw` channel and
+/// lets a real `WakeAction::Render` resume the retry then.
+#[cfg(not(target_os = "ios"))]
+fn desktop_secondary_wake_deadline(
+    next_attempt_at: Option<web_time::Instant>,
+    frames_enabled: bool,
+) -> Option<web_time::Instant> {
+    if frames_enabled {
+        next_attempt_at
+    } else {
+        None
+    }
+}
+
+#[cfg(all(test, not(target_os = "ios")))]
+mod desktop_secondary_wake_deadline_tests {
+    use web_time::Instant;
+
+    use super::desktop_secondary_wake_deadline;
+
+    #[test]
+    fn an_armed_deadline_is_reported_while_frames_are_enabled() {
+        let deadline = Instant::now();
+        assert_eq!(
+            desktop_secondary_wake_deadline(Some(deadline), true),
+            Some(deadline)
+        );
+    }
+
+    #[test]
+    fn an_armed_deadline_is_suppressed_while_frames_are_disabled() {
+        let deadline = Instant::now();
+        assert_eq!(
+            desktop_secondary_wake_deadline(Some(deadline), false),
+            None,
+            "a deadline nothing can act on must not be reported -- reporting it would hand \
+             `about_to_wait` the same past instant forever (the PumpAsync arm never consumes \
+             it), the exact WaitUntil(past) busy-spin `WinitApp::new_events` names, one layer \
+             up from where round 4 fixed the equivalent hole on the Render path"
+        );
+    }
+
+    #[test]
+    fn no_armed_deadline_stays_none_either_way() {
+        assert_eq!(desktop_secondary_wake_deadline(None, true), None);
+        assert_eq!(desktop_secondary_wake_deadline(None, false), None);
+    }
+}
+
 #[cfg(all(test, not(target_os = "ios")))]
 mod merge_wake_deadlines_tests {
     use std::time::Duration;
@@ -6271,6 +6340,35 @@ fn wake_action(frames_enabled: bool, dirty: bool, frame_scheduled: bool) -> Wake
     }
 }
 
+/// The frame closure's `dirty` gate, shared verbatim by both backends' own
+/// closures AND their tests — pulled out for the identical reason
+/// `wake_action`/`keeps_frame_gate_open`/`no_present_fallback_pace`/
+/// `merge_wake_deadlines` already are one level up: a test that reimplements
+/// a one-line predicate in its own body instead of calling the production
+/// code silently stops pinning it. That happened here once already — both
+/// `the_real_closure_gate_...` tests below used to compute this boolean
+/// inline, so reverting the REAL `next_attempt_at().is_some()` term in
+/// either closure below left the tests green (they were asserting against
+/// their own copy of the old logic, not the production line) even though
+/// the fix it was meant to pin was gone.
+///
+/// Four sources, all required: `inbox_redraw` (a command drained this frame
+/// boundary asked for a redraw), `needs_redraw`/`has_pending_work` (the
+/// realm's own pre-existing dirty state), and `next_attempt_at.is_some()` —
+/// an armed device-recovery retry deadline. Dropping that last term is
+/// exactly the bug `DeviceRecoveryBackoff`'s own doc describes: a deadline
+/// wired into the wake-deadline hook but invisible to this gate reaches
+/// `WakeAction::Skip` and returns before `render_frame_with_device_recovery`
+/// is ever called, no matter how faithfully the platform actuates the wake.
+fn frame_is_dirty(
+    inbox_redraw: bool,
+    needs_redraw: bool,
+    has_pending_work: bool,
+    next_attempt_at: Option<web_time::Instant>,
+) -> bool {
+    inbox_redraw || needs_redraw || has_pending_work || next_attempt_at.is_some()
+}
+
 /// Whether another frame will be requested regardless of this one's
 /// outcome: `needs_redraw`, a scheduled ticker, or dirty
 /// pipeline/build work left over from the frame that just ran.
@@ -7442,7 +7540,9 @@ mod device_recovery_tests {
     use flui_engine::{EngineError, RasterBackend};
     use web_time::Instant;
 
-    use super::{DeviceRecovery, DeviceRecoveryBackoff, render_frame_with_device_recovery};
+    use super::{
+        DeviceRecovery, DeviceRecoveryBackoff, frame_is_dirty, render_frame_with_device_recovery,
+    };
 
     #[derive(Clone)]
     struct LeafView;
@@ -8148,14 +8248,20 @@ mod device_recovery_tests {
         let mut armed_deadlines = vec![seed.next_attempt_at.expect("wake 1 armed a deadline")];
 
         for wake in 2..=12u32 {
-            // The desktop closure's own gate, verbatim (minus
-            // `inbox_redraw`, always false in this scenario and orthogonal
-            // to the property under test): `realm.needs_redraw() || realm.
-            // has_pending_work() || device_recovery_backoff.next_attempt_
-            // at().is_some()`.
-            let dirty = realm.needs_redraw()
-                || realm.has_pending_work()
-                || backoff.next_attempt_at().is_some();
+            // The PRODUCTION `frame_is_dirty` call, not a local
+            // reimplementation — `inbox_redraw` is always `false` in this
+            // scenario (orthogonal to the property under test), the other
+            // three arguments read live off `realm`/`backoff`. Round 6's own
+            // finding: this test used to recompute the boolean inline, which
+            // meant reverting the real closure's `next_attempt_at().is_some()`
+            // term left this assertion green — it was checking its own copy
+            // of the old logic, not the line the fix actually changed.
+            let dirty = frame_is_dirty(
+                false, // inbox_redraw: never true in this scenario
+                realm.needs_redraw(),
+                realm.has_pending_work(),
+                backoff.next_attempt_at(),
+            );
             assert!(
                 dirty,
                 "wake {wake}: the real closure gate went Skip and returned before even \
@@ -8212,19 +8318,27 @@ mod device_recovery_tests {
 
     /// The Android counterpart of
     /// `the_real_closure_gate_keeps_retrying_across_the_immediate_poke_and_the_deadline_wake`
-    /// above: Android's `bootstrap_android` closure computes `dirty` from
-    /// `inbox_redraw || realm.needs_redraw() || has_pending ||
-    /// device_recovery_backoff.next_attempt_at().is_some()` — the identical
-    /// shape (`has_pending` is just that closure's own local name for
-    /// `realm.has_pending_work()`) — so this drives the same gate, with one
-    /// deliberate difference in how the "deadline wake" is simulated: this
-    /// backend has no `ControlFlow::WaitUntil` to actuate it exactly on
-    /// time. `flui-platform`'s `AndroidPlatform::run` instead re-checks
-    /// `is_deadline_due` once per already-running ~16ms idle poll (that
-    /// function's own doc), so a due deadline is caught within one
-    /// granularity step of it, not AT it — simulated here as `now` landing
-    /// `NO_PRESENT_FALLBACK_PACE` (16ms) past the deadline rather than
-    /// exactly on it.
+    /// above, driving the same `frame_is_dirty` call `bootstrap_android`'s
+    /// closure makes (`has_pending` is just that closure's own local name
+    /// for `realm.has_pending_work()`).
+    ///
+    /// **What this pins, precisely — and what it does not.** This test
+    /// exercises only the `flui-app`-side gate: `frame_is_dirty` and
+    /// `DeviceRecoveryBackoff` are plain functions/types this crate owns and
+    /// can call directly. It does NOT drive `flui-platform`'s
+    /// `AndroidPlatform::run` loop — `is_deadline_due`, the `resumed` state
+    /// machine, `should_render`, or the 0ms/16ms `timeout` switch — because
+    /// that loop needs a live `AndroidApp`, which has no test double on any
+    /// host (see `is_deadline_due`'s own module for the parts of that state
+    /// machine that ARE unit-tested there, in isolation, without `run`
+    /// itself). The one adjustment made here to acknowledge that gap: `now`
+    /// lands `NO_PRESENT_FALLBACK_PACE` (16ms) past each armed deadline
+    /// rather than exactly on it, approximating that `is_deadline_due` is
+    /// polled once per ~16ms idle tick rather than actuated exactly at the
+    /// instant like desktop's `ControlFlow::WaitUntil`. Do not read this
+    /// test's `total_attempts` as a measurement of the native loop's actual
+    /// retry cadence — it measures the shared `flui-app` gate/backoff
+    /// invariant under a coarser deadline-catch approximation, nothing more.
     #[test]
     fn the_real_closure_gate_keeps_retrying_on_android_across_the_immediate_poke_and_the_16ms_poll()
     {
@@ -8252,12 +8366,16 @@ mod device_recovery_tests {
         let mut poke_pending = true;
 
         for wake in 2..=12u32 {
-            let inbox_redraw = false; // never true in this scenario
             let has_pending = realm.has_pending_work();
-            let dirty = inbox_redraw
-                || realm.needs_redraw()
-                || has_pending
-                || backoff.next_attempt_at().is_some();
+            // The PRODUCTION `frame_is_dirty` call — see this test's own doc
+            // for why reimplementing it inline here would silently stop
+            // pinning the fix.
+            let dirty = frame_is_dirty(
+                false, // inbox_redraw: never true in this scenario
+                realm.needs_redraw(),
+                has_pending,
+                backoff.next_attempt_at(),
+            );
             assert!(
                 dirty,
                 "wake {wake}: Android's closure gate went Skip and returned before even \
@@ -8492,17 +8610,6 @@ where
         // `DeviceRecoveryBackoff`'s own doc.
         let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
 
-        // 0d. Wire the wall-clock-wake hook: the winit
-        // backend's `about_to_wait` consults this every idle iteration
-        // instead of blocking forever, so a pending gesture-arena deadline
-        // (a long-press hold, a double-tap give-up) or an armed device-
-        // recovery retry still wakes the loop at the right instant even
-        // while nothing else is dirty and no animation is running.
-        install_wake_deadline_hook({
-            let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
-            move || device_recovery_backoff.next_attempt_at()
-        });
-
         // 1. Open window now that the event loop is running. Window creation is
         // an environment failure (display server hiccup, resource exhaustion),
         // not a `BUG:` invariant, and — unlike platform init above — this DOES
@@ -8621,6 +8728,42 @@ where
         *rebuild_registration_slot.borrow_mut() =
             Some(worker_reload.register_rebuild_hook(hot_reload_sender));
 
+        // 3d. Wire the wall-clock-wake hook, now that `realm_dispatch`
+        // exists — the winit backend's `about_to_wait` consults this every
+        // idle iteration instead of blocking forever, so a pending gesture-
+        // arena deadline (a long-press hold, a double-tap give-up) or an
+        // armed device-recovery retry still wakes the loop at the right
+        // instant even while nothing else is dirty and no animation is
+        // running. Moved here from directly after step 0c (this window's
+        // `device_recovery_backoff` construction) specifically so this
+        // closure can capture `realm_dispatch.address.realm_id` and look up
+        // THIS realm's `frames_enabled` state each time it runs — see the
+        // closure body's own comment for why that lookup, not just
+        // `next_attempt_at()`, is required.
+        install_wake_deadline_hook({
+            let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
+            let realm_id = realm_dispatch.address.realm_id;
+            move || {
+                // The frames-enabled gate itself is `desktop_secondary_
+                // wake_deadline` — a pure, unit-tested function (see its own
+                // doc for why an unconditional report here would reproduce
+                // `WinitApp::new_events`'s named busy-spin one layer up).
+                // Only the `frames_enabled` LOOKUP is inline here, since it
+                // needs live `APP_RUNTIME` state no pure function can carry.
+                let frames_enabled = APP_RUNTIME.with(|slot| {
+                    slot.borrow()
+                        .realms
+                        .get(&realm_id)
+                        .and_then(|realm_slot| realm_slot.realm.as_ref())
+                        .is_some_and(|realm| realm.scheduler().frames_enabled())
+                });
+                desktop_secondary_wake_deadline(
+                    device_recovery_backoff.next_attempt_at(),
+                    frames_enabled,
+                )
+            }
+        });
+
         // 4. Wrap renderer for callback sharing
         let renderer = Arc::new(Mutex::new(renderer));
 
@@ -8700,18 +8843,26 @@ where
 
                     // `device_recovery_backoff.next_attempt_at().is_some()` is a
                     // REQUIRED fourth dirty source, not an optional extra: a
-                    // deadline wired into the wake-deadline hook (installed at
-                    // step 0d above) but absent from THIS predicate reaches
-                    // `WakeAction::Skip` and returns before
+                    // deadline wired into the wake-deadline hook (installed
+                    // below, after this realm exists) but absent from THIS
+                    // predicate reaches `WakeAction::Skip` and returns before
                     // `render_frame_with_device_recovery` is ever called, no
                     // matter how faithfully the platform actuates the wake —
                     // see `DeviceRecoveryBackoff`'s own doc for the two paired
                     // obligations a wake-deadline source carries and the
-                    // dropped-attempt trace that motivated this line.
-                    let dirty = inbox_redraw
-                        || realm.needs_redraw()
-                        || realm.has_pending_work()
-                        || device_recovery_backoff.next_attempt_at().is_some();
+                    // dropped-attempt trace that motivated this line. Calls
+                    // the shared `frame_is_dirty` (not a local reimplementation)
+                    // for the same reason `wake_action` itself is a named
+                    // function here and not inlined: this closure's own
+                    // `dirty` computation and the tests that pin it must run
+                    // the identical code, or a regression in one is invisible
+                    // to the other.
+                    let dirty = frame_is_dirty(
+                        inbox_redraw,
+                        realm.needs_redraw(),
+                        realm.has_pending_work(),
+                        device_recovery_backoff.next_attempt_at(),
+                    );
                     match wake_action(
                         scheduler.frames_enabled(),
                         dirty,
@@ -9782,11 +9933,15 @@ where
                     // absent from `dirty` reaches `WakeAction::Skip` and
                     // returns before this closure ever calls `render_frame_
                     // with_device_recovery`, no matter how faithfully the
-                    // platform actuates the wake.
-                    let dirty = inbox_redraw
-                        || realm.needs_redraw()
-                        || has_pending
-                        || device_recovery_backoff.next_attempt_at().is_some();
+                    // platform actuates the wake. Calls the shared
+                    // `frame_is_dirty` — see that function's own doc for why
+                    // this must not be reimplemented locally.
+                    let dirty = frame_is_dirty(
+                        inbox_redraw,
+                        realm.needs_redraw(),
+                        has_pending,
+                        device_recovery_backoff.next_attempt_at(),
+                    );
                     let scheduler = realm.scheduler();
                     match wake_action(
                         scheduler.frames_enabled(),

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -6883,6 +6883,713 @@ mod desktop_pacing_tests {
     }
 }
 
+// ============================================================================
+// GPU device-loss recovery (App.1 device-recovery wake)
+// ============================================================================
+//
+// The sync device-rebuild seam plus the shared retry/backoff logic the
+// desktop and Android frame drivers both use around
+// `UiRealm::render_frame_entered`. Web's own recovery (`bootstrap_web`)
+// stays un-unified: its `recover()` is driven through
+// `wasm_bindgen_futures::spawn_local`, not a synchronous call this trait
+// could wrap — see that call site's own comment for why.
+
+/// The sync device-rebuild seam the frame driver needs from its renderer.
+///
+/// [`flui_engine::RasterBackend`] deliberately excludes recovery — it is
+/// async and window-handle-specific (see `flui-engine/src/raster.rs`'s
+/// trait doc) — so the runners narrow the concrete renderer to this seam
+/// instead of widening the public trait. The production impl wraps
+/// `Renderer::recover` in `pollster::block_on`; test fakes script the
+/// outcome. `is_device_lost` is NOT duplicated here — it already lives on
+/// `RasterBackend`, and every consumer bounds on both traits.
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+trait DeviceRecovery {
+    /// Attempt to rebuild the lost device synchronously on the runner
+    /// thread.
+    fn try_recover_device(&mut self) -> Result<(), flui_engine::EngineError>;
+}
+
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+impl DeviceRecovery for flui_engine::wgpu::Renderer {
+    fn try_recover_device(&mut self) -> Result<(), flui_engine::EngineError> {
+        // `pollster` is already a dep and safe to use here — the
+        // desktop/Android runners own synchronous platform callbacks, not
+        // an async executor.
+        pollster::block_on(self.recover())
+    }
+}
+
+/// Exponential backoff for the [`DeviceRecovery::try_recover_device`] retry
+/// loop: paces how often an attempt is made while the device stays lost,
+/// growing from one frame interval up to a capped ceiling and resetting on
+/// the first successful recovery.
+///
+/// Deliberately never gives up permanently (no attempt-count ceiling):
+/// device loss is expected to clear eventually on every platform this runs
+/// on — a driver TDR reset, an app coming back from the background, an
+/// eGPU replug — so a hard cap would turn a recoverable condition into a
+/// dead app. An UNBOUNDED, un-backed-off retry loop is equally wrong (a
+/// full `recover()` rebuilds the instance/adapter/device/surface/painter/
+/// offscreen target — not cheap to repeat every wake), so this paces the
+/// ATTEMPT itself, not just the log line.
+///
+/// `Send + Sync` (atomics, not `Cell`): captured behind an `Arc` by the
+/// platform's `on_request_frame` callback, which every backend's
+/// `Window::on_request_frame` requires to be `Send`
+/// (`flui-platform/src/traits/window.rs`).
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+struct DeviceRecoveryBackoff {
+    /// Consecutive failures since the last success (or since construction).
+    consecutive_failures: std::sync::atomic::AtomicU32,
+    /// Whether the "backoff reached its cap" error has already been logged
+    /// once this losing streak — re-armed on the next success.
+    cap_logged: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+impl DeviceRecoveryBackoff {
+    /// The base interval: the same cadence [`NO_PRESENT_FALLBACK_PACE`]
+    /// already paces a no-present frame at, reused rather than inventing a
+    /// second pacing constant for the same "roughly one frame interval"
+    /// shape.
+    const BASE: std::time::Duration = NO_PRESENT_FALLBACK_PACE;
+    /// The ceiling: "on the order of a second", per this module's device-
+    /// recovery retry policy.
+    const CAP: std::time::Duration = std::time::Duration::from_secs(1);
+    /// `BASE << SHIFT_CAP >= CAP` already holds well before this shift is
+    /// reached, so capping the shift itself (rather than only the final
+    /// `.min(CAP)`) avoids ever computing `1u32 << n` for an
+    /// unboundedly long losing streak.
+    const SHIFT_CAP: u32 = 6;
+
+    fn new() -> Self {
+        Self {
+            consecutive_failures: std::sync::atomic::AtomicU32::new(0),
+            cap_logged: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Record a failed recovery attempt and return the interval the caller
+    /// must wait before the platform is allowed to wake this loop again.
+    ///
+    /// Logs the first failure of a losing streak at `error`, every
+    /// subsequent one at `debug`, and re-emits `error` exactly once more
+    /// when the backoff reaches [`Self::CAP`] — a permanently dead GPU
+    /// says so once more at that point, not on every attempt after it.
+    fn record_failure(&self, error: &flui_engine::EngineError) -> std::time::Duration {
+        use std::sync::atomic::Ordering;
+
+        let failures_before = self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
+        let shift = failures_before.min(Self::SHIFT_CAP);
+        let interval = (Self::BASE * (1u32 << shift)).min(Self::CAP);
+        let at_cap = interval >= Self::CAP;
+
+        if failures_before == 0 {
+            tracing::error!(error = ?error, "GPU device recovery failed; retrying with backoff");
+        } else if at_cap && !self.cap_logged.swap(true, Ordering::Relaxed) {
+            tracing::error!(
+                error = ?error,
+                backoff = ?interval,
+                "GPU device recovery still failing at the backoff cap; retries continue \
+                 silently from here"
+            );
+        } else {
+            tracing::debug!(
+                error = ?error,
+                backoff = ?interval,
+                "GPU device recovery failed; retrying"
+            );
+        }
+        interval
+    }
+
+    /// Reset the backoff after a successful recovery.
+    fn record_success(&self) {
+        use std::sync::atomic::Ordering;
+
+        self.consecutive_failures.store(0, Ordering::Relaxed);
+        self.cap_logged.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Attempt one synchronous device rebuild, updating `backoff` and arming
+/// the retry wake on FAILURE ONLY.
+///
+/// A successful recovery renders the very frame this call is nested inside
+/// of — either about to run (the pre-frame case) or just finished running
+/// (the mid-frame case, where `render_frame_entered`'s own
+/// `mark_rendered()` already clobbered any redraw flag two statements
+/// ago) — so an extra `wake_frame()` here would be immediately wasted,
+/// producing nothing but a spurious platform `request_redraw`. A failed
+/// recovery, by contrast, has nothing else that will ever retry it on a
+/// quiescent loop: `wake_frame()` (not `request_redraw`) so an idle winit
+/// loop actually queues a `RedrawRequested`.
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+fn attempt_device_recovery<R: DeviceRecovery>(
+    renderer: &mut R,
+    realm: &super::ui_realm::UiRealm,
+    backoff: &DeviceRecoveryBackoff,
+) -> Option<std::time::Duration> {
+    match renderer.try_recover_device() {
+        Ok(()) => {
+            tracing::warn!("GPU device lost — recovered successfully");
+            backoff.record_success();
+            None
+        }
+        Err(e) => {
+            let pace = backoff.record_failure(&e);
+            realm.wake_frame();
+            Some(pace)
+        }
+    }
+}
+
+/// Outcome of driving one frame through [`render_frame_with_device_recovery`].
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+struct FrameRecoveryOutcome {
+    /// Whether the frame reached `present()` — same meaning as
+    /// [`super::ui_realm::UiRealm::render_frame_entered`]'s own return.
+    presented: bool,
+    /// `Some(pace)` when a device-recovery attempt FAILED this call: the
+    /// caller must sleep at least this long before the platform is allowed
+    /// to wake the loop again, in place of (never alongside) its normal
+    /// no-present fallback pace. `None` otherwise — a healthy device, or a
+    /// recovery attempt that just succeeded.
+    recovery_pace: Option<std::time::Duration>,
+}
+
+/// Drive one frame through `realm` against `renderer`, rebuilding a lost
+/// device around it, at most once per call.
+///
+/// A device already lost at frame start gets ONE backoff-paced recovery
+/// attempt here, BEFORE [`super::ui_realm::UiRealm::render_frame_entered`]
+/// — but `render_frame_entered` runs regardless of whether that attempt
+/// succeeded. Skipping it on a still-lost device was the original bug this
+/// function fixes: `render_frame_entered` is the only caller of
+/// `drain_deferred_arena_resolutions`, `flush_pending_moves`,
+/// `draw_frame_entered`, and `mouse_tracker().update_all_devices()`, all of
+/// which must keep advancing while the device is down (gesture-arena
+/// deadlines, coalesced pointer moves, and every Vsync ticker included) —
+/// and `Renderer::acquire_surface_texture` already bails out on the same
+/// `device_lost` flag before touching the GPU, so running it costs nothing
+/// extra on a still-dead device.
+///
+/// A device lost MID-frame (the wgpu device-lost callback firing while
+/// `render_scene` ran) gets its own single recovery attempt AFTER —
+/// `was_lost_pre_frame` gates this so a device that was already lost going
+/// in, and is still lost coming out, is not attempted TWICE in the same
+/// call (which would silently double the effective retry rate the backoff
+/// above exists to bound).
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+fn render_frame_with_device_recovery<R>(
+    realm: &super::ui_realm::UiRealm,
+    renderer: &mut R,
+    backoff: &DeviceRecoveryBackoff,
+) -> FrameRecoveryOutcome
+where
+    R: flui_engine::RasterBackend + DeviceRecovery,
+{
+    let was_lost_pre_frame = renderer.is_device_lost();
+    let mut recovery_pace = if was_lost_pre_frame {
+        attempt_device_recovery(renderer, realm, backoff)
+    } else {
+        None
+    };
+
+    let presented = realm.render_frame_entered(renderer);
+
+    if !was_lost_pre_frame && renderer.is_device_lost() {
+        recovery_pace = attempt_device_recovery(renderer, realm, backoff);
+    }
+
+    FrameRecoveryOutcome {
+        presented,
+        recovery_pace,
+    }
+}
+
+/// The device-loss recovery contract of
+/// [`render_frame_with_device_recovery`] against scripted backends and the
+/// [`DeviceRecoveryBackoff`] pacing it: a pre-frame loss recovers BEFORE
+/// the frame build and ALWAYS runs it regardless of outcome, a mid-frame
+/// loss recovers after, only a FAILED attempt arms anything, and a
+/// persistently failing device is retried on a bounded, growing cadence —
+/// never abandoned.
+#[cfg(all(
+    test,
+    not(target_os = "android"),
+    not(target_os = "ios"),
+    not(target_arch = "wasm32")
+))]
+mod device_recovery_tests {
+    use std::time::Duration;
+
+    use flui_engine::{EngineError, RasterBackend};
+
+    use super::{DeviceRecovery, DeviceRecoveryBackoff, render_frame_with_device_recovery};
+
+    #[derive(Clone)]
+    struct LeafView;
+
+    impl flui_view::RenderView for LeafView {
+        type Protocol = flui_rendering::protocol::BoxProtocol;
+        type RenderObject = flui_objects::RenderSizedBox;
+
+        fn create_render_object(
+            &self,
+            _ctx: &flui_view::RenderObjectContext<'_>,
+        ) -> flui_objects::RenderSizedBox {
+            flui_objects::RenderSizedBox::shrink()
+        }
+
+        fn update_render_object(
+            &self,
+            _ctx: &flui_view::RenderObjectContext<'_>,
+            render_object: &mut flui_objects::RenderSizedBox,
+        ) {
+            *render_object = flui_objects::RenderSizedBox::shrink();
+        }
+    }
+
+    impl flui_view::View for LeafView {
+        fn create_element(&self) -> flui_view::element::ElementKind {
+            flui_view::element::ElementKind::render_variable(self)
+        }
+    }
+
+    fn mount_root() -> super::super::ui_realm::UiRealm {
+        let realm = super::super::ui_realm::UiRealm::for_test();
+        realm
+            .enter(|realm| realm.attach_root_widget(&LeafView))
+            .expect("attach succeeds");
+        realm
+    }
+
+    struct ScriptedDeviceBackend {
+        /// Current device-lost flag (what `RasterBackend::is_device_lost` reports).
+        lost: bool,
+        /// `render_scene` outcome once the scene reaches it (`take`n —
+        /// `EngineError` is not `Clone`).
+        scene_outcome: Option<Result<bool, EngineError>>,
+        /// `try_recover_device` outcome (`take`n, same reason).
+        recover_outcome: Option<Result<(), EngineError>>,
+        /// Whether a successful recovery clears the lost flag (a failing
+        /// driver reset leaves it set).
+        recover_clears_lost: bool,
+        /// Flip the lost flag from INSIDE `render_scene` — the wgpu
+        /// device-lost callback firing mid-frame.
+        lose_on_render: bool,
+        render_calls: u32,
+        recover_attempts: u32,
+    }
+
+    impl ScriptedDeviceBackend {
+        fn healthy() -> Self {
+            Self {
+                lost: false,
+                scene_outcome: Some(Ok(true)),
+                recover_outcome: Some(Ok(())),
+                recover_clears_lost: true,
+                lose_on_render: false,
+                render_calls: 0,
+                recover_attempts: 0,
+            }
+        }
+    }
+
+    impl RasterBackend for ScriptedDeviceBackend {
+        fn render_scene(&mut self, _scene: &flui_layer::Scene) -> Result<bool, EngineError> {
+            self.render_calls += 1;
+            if self.lose_on_render {
+                self.lost = true;
+            }
+            self.scene_outcome
+                .take()
+                .expect("render_scene called more than once in a single-frame test")
+        }
+        fn resize(&mut self, _width: u32, _height: u32) {}
+        fn is_device_lost(&self) -> bool {
+            self.lost
+        }
+        fn mark_dirty(&mut self, _rect: flui_types::Rect<flui_types::geometry::Pixels>) {}
+        fn mark_full_repaint(&mut self) {}
+        fn has_damage(&self) -> bool {
+            true
+        }
+        fn size(&self) -> (u32, u32) {
+            (800, 600)
+        }
+        fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+            Ok(())
+        }
+    }
+
+    impl DeviceRecovery for ScriptedDeviceBackend {
+        fn try_recover_device(&mut self) -> Result<(), EngineError> {
+            self.recover_attempts += 1;
+            let outcome = self
+                .recover_outcome
+                .take()
+                .expect("try_recover_device called more than once in a single-frame test");
+            if outcome.is_ok() && self.recover_clears_lost {
+                self.lost = false;
+            }
+            outcome
+        }
+    }
+
+    #[test]
+    fn a_healthy_device_renders_without_any_recovery() {
+        let realm = mount_root();
+        let mut backend = ScriptedDeviceBackend::healthy();
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+
+        assert!(outcome.presented, "Ok(true) reaches present()");
+        assert_eq!(backend.render_calls, 1, "the scene reached render_scene");
+        assert_eq!(
+            backend.recover_attempts, 0,
+            "no recovery on a healthy device"
+        );
+        assert!(
+            outcome.recovery_pace.is_none(),
+            "no recovery attempt failed, so nothing arms a backoff pace"
+        );
+        assert!(
+            !realm.needs_redraw(),
+            "a successful frame clears the redraw flag"
+        );
+    }
+
+    #[test]
+    fn a_pre_frame_loss_with_a_successful_recovery_renders_the_same_frame_and_arms_nothing() {
+        let realm = mount_root();
+        let mut backend = ScriptedDeviceBackend {
+            lost: true,
+            ..ScriptedDeviceBackend::healthy()
+        };
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+
+        assert_eq!(
+            backend.recover_attempts, 1,
+            "the pre-frame loss is recovered"
+        );
+        assert!(
+            !backend.lost,
+            "the scripted successful recovery cleared the lost flag"
+        );
+        assert_eq!(
+            backend.render_calls, 1,
+            "after a successful recovery the SAME frame renders — no extra wake needed"
+        );
+        assert!(outcome.presented, "the recovered frame reaches present()");
+        assert!(
+            outcome.recovery_pace.is_none(),
+            "a SUCCESSFUL recovery must not arm a backoff pace — there is nothing to retry"
+        );
+        // The original bug this pins: `a_pre_frame_loss_with_a_successful_
+        // recovery_renders_the_same_frame` (the earlier version of this
+        // test) never asserted `needs_redraw()`, which is exactly where a
+        // spurious wake on the success arm hid — a successful pre-frame
+        // recovery is immediately followed by rendering this very frame,
+        // and that render's own `mark_rendered()` would silently clobber
+        // an extra `wake_frame()` two statements later, leaving only a
+        // wasted platform `request_redraw` with no test ever catching it.
+        assert!(
+            !realm.needs_redraw(),
+            "a successful pre-frame recovery followed by a presented frame must leave no \
+             spurious wake armed"
+        );
+    }
+
+    #[test]
+    fn a_pre_frame_loss_with_a_failing_recovery_still_renders_the_frame_and_backs_off() {
+        let realm = mount_root();
+        let mut backend = ScriptedDeviceBackend {
+            lost: true,
+            // The real `Renderer::acquire_surface_texture` bails on the
+            // `device_lost` flag before touching the GPU — scripted here
+            // as `render_scene` itself reporting `DeviceLost`, since the
+            // device is still down when this frame's build reaches it.
+            scene_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_clears_lost: false,
+            ..ScriptedDeviceBackend::healthy()
+        };
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+
+        assert!(!outcome.presented, "a still-lost device presents nothing");
+        assert_eq!(backend.recover_attempts, 1, "the recovery was attempted");
+        // The fix this test exists to pin: the earlier version of this
+        // function returned `false` here WITHOUT calling
+        // `render_frame_entered` at all on a still-lost device, so
+        // `render_calls` would read 0. `render_frame_entered` must ALWAYS
+        // run — see this module's own doc for why (gesture-arena
+        // deadlines, coalesced pointer moves, and every Vsync ticker all
+        // depend on it).
+        assert_eq!(
+            backend.render_calls, 1,
+            "render_frame_entered must run even when the pre-frame recovery attempt \
+             failed — a dead device must not stop the non-GPU half of the frame"
+        );
+        assert_eq!(
+            outcome.recovery_pace,
+            Some(DeviceRecoveryBackoff::BASE),
+            "the first failed attempt backs off by exactly the base interval"
+        );
+        assert!(
+            realm.needs_redraw(),
+            "the failed recovery must arm the retry wake: on a quiescent loop — no \
+             input, no animations — nothing else would ever schedule the next \
+             recovery attempt"
+        );
+    }
+
+    #[test]
+    fn a_mid_frame_loss_with_a_failing_recovery_backs_off() {
+        let realm = mount_root();
+        let mut backend = ScriptedDeviceBackend {
+            lose_on_render: true,
+            recover_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_clears_lost: false,
+            ..ScriptedDeviceBackend::healthy()
+        };
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+
+        assert_eq!(
+            backend.render_calls, 1,
+            "the frame rendered before the loss landed"
+        );
+        assert!(
+            outcome.presented,
+            "the frame that rendered still reaches present()"
+        );
+        assert_eq!(
+            backend.recover_attempts, 1,
+            "the mid-frame loss is recovered after the render"
+        );
+        assert_eq!(
+            outcome.recovery_pace,
+            Some(DeviceRecoveryBackoff::BASE),
+            "the failed post-render recovery backs off by the base interval, same as a \
+             pre-frame failure"
+        );
+        assert!(
+            realm.needs_redraw(),
+            "the post-render recovery wake must survive render_frame_entered's own \
+             mark_rendered(), so the recovered renderer renders again on a quiescent \
+             loop"
+        );
+    }
+
+    /// The mid-frame counterpart to
+    /// `a_pre_frame_loss_with_a_successful_recovery_renders_the_same_frame_and_arms_nothing`:
+    /// a device that dies DURING `render_scene` but recovers immediately
+    /// afterward must arm nothing either — the frame that just rendered
+    /// already presented (or not) on its own merits, and there is no
+    /// retry to arm for a device that is healthy again.
+    #[test]
+    fn a_mid_frame_loss_with_a_successful_recovery_arms_nothing() {
+        let realm = mount_root();
+        let mut backend = ScriptedDeviceBackend {
+            lose_on_render: true,
+            ..ScriptedDeviceBackend::healthy()
+        };
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+
+        assert_eq!(
+            backend.render_calls, 1,
+            "the frame rendered before the loss landed"
+        );
+        assert!(
+            outcome.presented,
+            "the frame that rendered still reaches present()"
+        );
+        assert_eq!(
+            backend.recover_attempts, 1,
+            "the mid-frame loss is recovered after the render"
+        );
+        assert!(
+            !backend.lost,
+            "the scripted successful recovery cleared the lost flag"
+        );
+        assert!(
+            outcome.recovery_pace.is_none(),
+            "a SUCCESSFUL post-render recovery must not arm a backoff pace"
+        );
+        assert!(
+            !realm.needs_redraw(),
+            "a presented frame followed by a successful recovery must leave no spurious \
+             wake armed"
+        );
+    }
+
+    /// The 🔴 fix, pinned directly against the observable the deleted
+    /// pre-frame `return false` used to kill: a gesture-arena long-press
+    /// deadline. `render_frame_entered`'s very first two calls
+    /// (`drain_deferred_arena_resolutions`, `flush_pending_moves`) — and
+    /// `draw_frame_entered`'s own Vsync tick right after — must all still
+    /// run while the device stays lost and every recovery attempt fails,
+    /// because they are the ONLY thing that ever resolves a timed-out
+    /// gesture, flushes a coalesced pointer move, or ticks an animation.
+    /// Before the fix, a still-lost device after a failed pre-frame
+    /// recovery attempt returned `false` immediately, and this deadline
+    /// would never resolve at all.
+    #[test]
+    fn a_pre_frame_device_loss_still_resolves_a_pending_gesture_arena_deadline() {
+        use flui_interaction::{
+            GestureRecognizer, GestureSettings, LongPressGestureRecognizer, PointerId,
+        };
+
+        let realm = mount_root();
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let arena = realm.gestures().arena().clone();
+        let long_press_fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let fired_for_callback = std::sync::Arc::clone(&long_press_fired);
+        let recognizer = LongPressGestureRecognizer::with_settings(
+            arena,
+            GestureSettings::touch_defaults().with_long_press_timeout(Duration::from_millis(1)),
+        )
+        .with_on_long_press(move || {
+            fired_for_callback.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+        let pointer = PointerId::new(3).expect("nonzero pointer id");
+        recognizer.add_pointer(
+            pointer,
+            flui_types::Offset::new(
+                flui_types::geometry::px(10.0),
+                flui_types::geometry::px(10.0),
+            ),
+        );
+        assert!(
+            realm.gestures().has_pending_deadlines(),
+            "precondition: the long-press deadline is actually armed"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+
+        // A permanently lost device whose recovery never succeeds — the
+        // worst case for the deleted early return, and the one production
+        // scenario (driver still mid-reset) this fix must keep advancing
+        // through.
+        let mut backend = ScriptedDeviceBackend {
+            lost: true,
+            scene_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_clears_lost: false,
+            ..ScriptedDeviceBackend::healthy()
+        };
+
+        let _ = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+
+        assert!(
+            long_press_fired.load(std::sync::atomic::Ordering::SeqCst),
+            "a pre-frame device loss with a failing recovery must still resolve a due \
+             gesture-arena deadline — render_frame_entered's non-GPU work must never be \
+             skipped just because the device stayed lost"
+        );
+    }
+
+    /// A persistently failing recovery must be attempted a BOUNDED number
+    /// of times over a fixed wall-clock window, not once per delivered
+    /// platform frame — the same shape as issue #556's
+    /// `no_present_fallback_bounds_repeating_no_present_wakes` spin
+    /// measurement, applied to [`DeviceRecoveryBackoff`] directly. A
+    /// fixed, un-backed-off cadence (the bug this guards against) would
+    /// rack up roughly `window / DeviceRecoveryBackoff::BASE` attempts —
+    /// tens of them in this window; the backoff must land an order of
+    /// magnitude below that.
+    #[test]
+    fn device_recovery_backoff_bounds_a_persistently_failing_retry_loop() {
+        use std::time::Instant;
+
+        let backoff = DeviceRecoveryBackoff::new();
+        let window = Duration::from_millis(600);
+        let deadline = Instant::now() + window;
+        let mut attempts = 0u32;
+
+        while Instant::now() < deadline {
+            attempts += 1;
+            let pace = backoff.record_failure(&EngineError::DeviceLost);
+            std::thread::sleep(pace);
+        }
+
+        let unbacked_off_attempts =
+            u32::try_from(window.as_millis() / DeviceRecoveryBackoff::BASE.as_millis())
+                .unwrap_or(u32::MAX);
+        assert!(
+            attempts <= 10,
+            "the backoff failed to bound the retry loop: {attempts} attempts in {window:?} \
+             (an un-backed-off fixed cadence would rack up roughly \
+             {unbacked_off_attempts} in the same window)",
+        );
+        assert!(
+            attempts >= 2,
+            "sanity: the loop must actually retry more than once, not just give up after \
+             the first failure (attempts={attempts})"
+        );
+    }
+
+    #[test]
+    fn device_recovery_backoff_resets_to_the_base_interval_after_a_success() {
+        let backoff = DeviceRecoveryBackoff::new();
+
+        let first = backoff.record_failure(&EngineError::DeviceLost);
+        let second = backoff.record_failure(&EngineError::DeviceLost);
+        assert_eq!(first, DeviceRecoveryBackoff::BASE);
+        assert!(
+            second > first,
+            "the backoff must grow across consecutive failures with no success in between"
+        );
+
+        backoff.record_success();
+        let after_reset = backoff.record_failure(&EngineError::DeviceLost);
+        assert_eq!(
+            after_reset,
+            DeviceRecoveryBackoff::BASE,
+            "a success must reset the backoff to its base interval, not continue growing \
+             from where it left off"
+        );
+    }
+
+    #[test]
+    fn device_recovery_backoff_caps_at_the_ceiling_and_never_gives_up() {
+        let backoff = DeviceRecoveryBackoff::new();
+        let mut last = Duration::ZERO;
+
+        // Comfortably past the point the shift itself saturates.
+        for _ in 0..20u32 {
+            last = backoff.record_failure(&EngineError::DeviceLost);
+        }
+
+        assert_eq!(
+            last,
+            DeviceRecoveryBackoff::CAP,
+            "the interval must stop growing at the cap instead of overflowing or \
+             continuing to double"
+        );
+        // "Never gives up" is an absence: there is no attempt-count field
+        // anywhere on this type that could refuse a 21st call — the type
+        // itself has no such state to check, which is the point.
+    }
+}
+
 #[cfg(all(
     not(target_os = "android"),
     not(target_os = "ios"),
@@ -7147,161 +7854,171 @@ where
         // 6. Register frame callback -> scheduler + UiRealm::render_frame_entered()
         let renderer_frame = Arc::clone(&renderer);
         let worker_reload_frame = worker_reload.clone();
+        // One backoff per window, living across every wake this closure is
+        // called for — see `DeviceRecoveryBackoff`'s own doc for why this
+        // needs to be `Arc`'d (not just moved) the same way `renderer_frame`
+        // is: a fresh clone is threaded into each `RealmTask::Frame` this
+        // closure builds, but the underlying counters must persist.
+        let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
         window.on_request_frame(Box::new(move || {
-        let renderer_frame = Arc::clone(&renderer_frame);
-        let worker_reload_frame = worker_reload_frame.clone();
-        let _ = dispatch_platform_realm(realm_dispatch, RealmTask::Frame(Box::new(move |realm| {
-            worker_reload_frame.poll_and_apply(realm);
+            let renderer_frame = Arc::clone(&renderer_frame);
+            let worker_reload_frame = worker_reload_frame.clone();
+            let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Frame(Box::new(move |realm| {
+                    worker_reload_frame.poll_and_apply(realm);
 
-            let scheduler = realm.scheduler();
+                    let scheduler = realm.scheduler();
 
-        // Every fire of this callback is a genuine platform-delivered
-        // frame-request signal on this backend (`WinitWindowEvent::
-        // RedrawRequested` -> `dispatch_request_frame` -> here; see
-        // `docs/adr/ADR-0044-driver-loop-hybrid.md`'s per-platform table for which backends
-        // pace this via the compositor vs. deliver it immediately).
-        // Recorded unconditionally, before the dirty/wake_action gate below
-        // decides whether anything actually runs this pump: pacing
-        // feedback is about observing the PLATFORM's own delivery timing,
-        // independent of whether this particular delivery ends up idle.
-        // `now` is read ONCE here and reused ~60 lines below at this
-        // closure's `drive_frame_with_lane(now, ...)` call, past the
-        // `wake_action` match below (that later call site's own comment
-        // points back to this one) — this pump's pacing-feedback sample
-        // and its own frame-drive instant must agree, the same
-        // single-`now`-per-pump discipline every other call site in this
-        // closure already follows.
-            let now = web_time::Instant::now();
-            realm.record_compositor_tick(now);
+                    // Every fire of this callback is a genuine platform-delivered
+                    // frame-request signal on this backend (`WinitWindowEvent::
+                    // RedrawRequested` -> `dispatch_request_frame` -> here; see
+                    // `docs/adr/ADR-0044-driver-loop-hybrid.md`'s per-platform table for which backends
+                    // pace this via the compositor vs. deliver it immediately).
+                    // Recorded unconditionally, before the dirty/wake_action gate below
+                    // decides whether anything actually runs this pump: pacing
+                    // feedback is about observing the PLATFORM's own delivery timing,
+                    // independent of whether this particular delivery ends up idle.
+                    // `now` is read ONCE here and reused ~60 lines below at this
+                    // closure's `drive_frame_with_lane(now, ...)` call, past the
+                    // `wake_action` match below (that later call site's own comment
+                    // points back to this one) — this pump's pacing-feedback sample
+                    // and its own frame-drive instant must agree, the same
+                    // single-`now`-per-pump discipline every other call site in this
+                    // closure already follows.
+                    let now = web_time::Instant::now();
+                    realm.record_compositor_tick(now);
 
-        // Owner-inbox drain: commands and worker results
-        // commit HERE, at the frame boundary while the scheduler phase is
-        // Idle — never inside the frame transaction below. Runs before the
-        // dirty gate so a command-driven redraw request is observed by the
-        // very frame its wake produced.
-        //
-        // The runtime is TAKEN out of the slot for the drain (and restored
-        // after) so drained user closures never run under the RefCell
-        // borrow: a command that re-enters this frame callback through a
-        // nested platform pump then finds an empty slot and skips the
-        // drain, instead of panicking the borrow.
-            let inbox_redraw = drain_owner_inbox(realm);
-
-            let dirty =
-                inbox_redraw || realm.needs_redraw() || realm.has_pending_work();
-            match wake_action(scheduler.frames_enabled(), dirty, scheduler.is_frame_scheduled()) {
-                WakeAction::Skip => return,
-                WakeAction::PumpAsync => {
-                    // Frames disabled (Hidden/Paused/Detached): the mid-frame
-                    // `drive_async_tasks` poll inside `handle_begin_frame`
-                    // never runs because no frame runs at all — this
-                    // explicit call is the ONLY thing keeping a spawned
-                    // future progressing while backgrounded. No begin/draw
-                    // frame, no tickers, no pipeline, no present.
+                    // Owner-inbox drain: commands and worker results
+                    // commit HERE, at the frame boundary while the scheduler phase is
+                    // Idle — never inside the frame transaction below. Runs before the
+                    // dirty gate so a command-driven redraw request is observed by the
+                    // very frame its wake produced.
                     //
-                    // `finish_async_pump` MUST run first, not after: nothing
-                    // else ever clears the scheduler's `frame_scheduled`
-                    // latch on this path (only `handle_begin_frame` does,
-                    // and it never runs here), so without this call a LATER,
-                    // independent wake (a network response's `Waker::wake`,
-                    // arriving after this pump cycle returns) would find the
-                    // latch already set, never re-fire `on_frame_scheduled`,
-                    // and never wake this loop again — see
-                    // `UpdateScheduler::finish_async_pump`'s doc for the full
-                    // starvation hazard and why the ordering matters.
-                    scheduler.finish_async_pump();
-                    scheduler.drive_async_tasks();
-                    // Reuse the existing no-present throttle: a backgrounded
-                    // wake with dirty/pending work re-requesting another
-                    // wake every loop tick has the identical busy-spin risk
-                    // an un-presented frame with an open gate has, and
-                    // nothing else paces it while frames are disabled.
+                    // The runtime is TAKEN out of the slot for the drain (and restored
+                    // after) so drained user closures never run under the RefCell
+                    // borrow: a command that re-enters this frame callback through a
+                    // nested platform pump then finds an empty slot and skips the
+                    // drain, instead of panicking the borrow.
+                    let inbox_redraw = drain_owner_inbox(realm);
+
+                    let dirty = inbox_redraw || realm.needs_redraw() || realm.has_pending_work();
+                    match wake_action(
+                        scheduler.frames_enabled(),
+                        dirty,
+                        scheduler.is_frame_scheduled(),
+                    ) {
+                        WakeAction::Skip => return,
+                        WakeAction::PumpAsync => {
+                            // Frames disabled (Hidden/Paused/Detached): the mid-frame
+                            // `drive_async_tasks` poll inside `handle_begin_frame`
+                            // never runs because no frame runs at all — this
+                            // explicit call is the ONLY thing keeping a spawned
+                            // future progressing while backgrounded. No begin/draw
+                            // frame, no tickers, no pipeline, no present.
+                            //
+                            // `finish_async_pump` MUST run first, not after: nothing
+                            // else ever clears the scheduler's `frame_scheduled`
+                            // latch on this path (only `handle_begin_frame` does,
+                            // and it never runs here), so without this call a LATER,
+                            // independent wake (a network response's `Waker::wake`,
+                            // arriving after this pump cycle returns) would find the
+                            // latch already set, never re-fire `on_frame_scheduled`,
+                            // and never wake this loop again — see
+                            // `UpdateScheduler::finish_async_pump`'s doc for the full
+                            // starvation hazard and why the ordering matters.
+                            scheduler.finish_async_pump();
+                            scheduler.drive_async_tasks();
+                            // Reuse the existing no-present throttle: a backgrounded
+                            // wake with dirty/pending work re-requesting another
+                            // wake every loop tick has the identical busy-spin risk
+                            // an un-presented frame with an open gate has, and
+                            // nothing else paces it while frames are disabled.
+                            let keeps_gate_open = keeps_frame_gate_open(
+                                realm.needs_redraw(),
+                                scheduler.is_frame_scheduled(),
+                                realm.has_pending_work(),
+                            );
+                            if let Some(pace) = no_present_fallback_pace(false, keeps_gate_open) {
+                                std::thread::sleep(pace);
+                            }
+                            return;
+                        }
+                        WakeAction::Render => {}
+                    }
+
+                    // The `now` used below is the SAME instant bound near the top of
+                    // this closure and already recorded into `record_compositor_tick`
+                    // there (see the comment at that earlier `let now` binding) --
+                    // reused here, not re-read fresh.
+                    // UpdateScheduler callbacks (animations). NOTE: the global `UpdateScheduler` is driven
+                    // off this per-frame `Instant::now()`, while the tree-bound `Vsync`
+                    // (`UiRealm::draw_frame`) ticks off the realm's own `start` origin —
+                    // two separate clocks ON PURPOSE: the controller sets are disjoint (implicit
+                    // animations register with `Vsync`; plain controllers carry a private
+                    // `UpdateScheduler` ticker, never the global one), so the origins never need to
+                    // agree and no controller is advanced twice.
+                    // The ONE shared frame ordering — begin (transient +
+                    // microtasks + the single async-driver poll) -> persistent callbacks ->
+                    // the pipeline below -> post-frame callbacks -> Idle. `HeadlessBinding`
+                    // drives the same helper on its binding-local scheduler.
+                    let outcome = scheduler.drive_frame_with_lane(
+                        now,
+                        flui_scheduler::IdleDeadline::far_future(now),
+                        || {
+                            // Render frame via the realm, rebuilding a lost GPU device
+                            // around it: BEFORE the frame build when the loss predates
+                            // the frame (a dead device never pays extra for it — the
+                            // frame builds anyway, see this function's own doc for why),
+                            // and AFTER when the wgpu device-lost callback fired
+                            // mid-frame — see `render_frame_with_device_recovery`.
+                            let mut r = renderer_frame.lock();
+                            render_frame_with_device_recovery(
+                                realm,
+                                &mut *r,
+                                &device_recovery_backoff,
+                            )
+                        },
+                        realm.local_post_frame_lane(),
+                    );
+
+                    // No-present fallback throttle. Fifo present (the default, see
+                    // `select_present_mode`) blocks every PRESENTED frame at display
+                    // cadence — that IS the steady-state pacing, which is why the fixed
+                    // frame-budget sleep this replaced is gone. A frame that never
+                    // reaches `present()` (no damage, occluded surface, surface lost)
+                    // gets none of that blocking, so if nothing else is going to wake
+                    // this loop, an unpaced wake is harmless: the loop falls back to
+                    // `ControlFlow::Wait` and blocks on the next real event. The
+                    // busy-spin this guards against (observed: ~30 000 fps) only
+                    // happens when a ticker/animation keeps re-requesting a frame every
+                    // wake with nothing pacing it — `no_present_fallback_pace` fires
+                    // only in exactly that combination.
                     let keeps_gate_open = keeps_frame_gate_open(
                         realm.needs_redraw(),
                         scheduler.is_frame_scheduled(),
                         realm.has_pending_work(),
                     );
-                    if let Some(pace) = no_present_fallback_pace(false, keeps_gate_open) {
+                    // A failed device-recovery attempt this wake overrides the
+                    // fixed no-present pace with `DeviceRecoveryBackoff`'s growing
+                    // one: reusing `NO_PRESENT_FALLBACK_PACE`'s fixed 16ms here
+                    // for a persistently-lost device would attempt a full
+                    // instance/adapter/device/surface rebuild every ~16ms forever
+                    // — see `DeviceRecoveryBackoff`'s own doc.
+                    let pace = outcome
+                        .recovery_pace
+                        .or_else(|| no_present_fallback_pace(outcome.presented, keeps_gate_open));
+                    if let Some(pace) = pace {
+                        // This runs on the platform event-loop thread, so the sleep
+                        // blocks input dispatch for its duration — acceptable here
+                        // because this path only fires for an occluded/undamaged
+                        // window with a ticker still running, not an interactive one.
                         std::thread::sleep(pace);
                     }
-                    return;
-                }
-                WakeAction::Render => {}
-            }
-
-        // The `now` used below is the SAME instant bound near the top of
-        // this closure and already recorded into `record_compositor_tick`
-        // there (see the comment at that earlier `let now` binding) --
-        // reused here, not re-read fresh.
-        // UpdateScheduler callbacks (animations). NOTE: the global `UpdateScheduler` is driven
-        // off this per-frame `Instant::now()`, while the tree-bound `Vsync`
-        // (`UiRealm::draw_frame`) ticks off the realm's own `start` origin —
-        // two separate clocks ON PURPOSE: the controller sets are disjoint (implicit
-        // animations register with `Vsync`; plain controllers carry a private
-        // `UpdateScheduler` ticker, never the global one), so the origins never need to
-        // agree and no controller is advanced twice.
-        // The ONE shared frame ordering — begin (transient +
-        // microtasks + the single async-driver poll) -> persistent callbacks ->
-        // the pipeline below -> post-frame callbacks -> Idle. `HeadlessBinding`
-        // drives the same helper on its binding-local scheduler.
-            let presented = scheduler.drive_frame_with_lane(now, flui_scheduler::IdleDeadline::far_future(now), || {
-            // Render frame via the realm
-            let mut r = renderer_frame.lock();
-                let did_present = realm.render_frame_entered(&mut *r);
-
-            // GPU device-loss recovery: if the device was lost during this frame
-            // (detected by the wgpu callback that fired between render_frame calls),
-            // attempt a synchronous rebuild on the runner thread. `pollster` is
-            // already a dep and safe to use here — the desktop runner owns this
-            // synchronous callback, not an async executor.
-            if r.is_device_lost() {
-                match pollster::block_on(r.recover()) {
-                    Ok(()) => {
-                        tracing::warn!("GPU device lost — recovered successfully");
-                        // `wake_frame` (not `request_redraw`) so an idle winit loop
-                        // actually queues a `RedrawRequested`: device loss is
-                        // detected on a quiescent loop, where only flipping the
-                        // `needs_redraw` flag would leave the recovered renderer
-                        // idle until the next external input/resize.
-                        realm.wake_frame();
-                    }
-                    Err(e) => {
-                        // Driver may still be resetting. Log and let the next frame
-                        // retry; the device-lost flag remains set so recover() will
-                        // be tried again.
-                        tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
-                    }
-                }
-            }
-                did_present
-            }, realm.local_post_frame_lane());
-
-        // No-present fallback throttle. Fifo present (the default, see
-        // `select_present_mode`) blocks every PRESENTED frame at display
-        // cadence — that IS the steady-state pacing, which is why the fixed
-        // frame-budget sleep this replaced is gone. A frame that never
-        // reaches `present()` (no damage, occluded surface, surface lost)
-        // gets none of that blocking, so if nothing else is going to wake
-        // this loop, an unpaced wake is harmless: the loop falls back to
-        // `ControlFlow::Wait` and blocks on the next real event. The
-        // busy-spin this guards against (observed: ~30 000 fps) only
-        // happens when a ticker/animation keeps re-requesting a frame every
-        // wake with nothing pacing it — `no_present_fallback_pace` fires
-        // only in exactly that combination.
-            let keeps_gate_open = keeps_frame_gate_open(
-                realm.needs_redraw(),
-                scheduler.is_frame_scheduled(),
-                realm.has_pending_work(),
+                })),
             );
-            if let Some(pace) = no_present_fallback_pace(presented, keeps_gate_open) {
-                // This runs on the platform event-loop thread, so the sleep
-                // blocks input dispatch for its duration — acceptable here
-                // because this path only fires for an occluded/undamaged
-                // window with a ticker still running, not an interactive one.
-                std::thread::sleep(pace);
-            }
-        })));
-    }));
+        }));
 
         // 7. Register resize callback -> typed Resized event; the applier
         // installed above (not this closure) actually touches the renderer.
@@ -8198,9 +8915,16 @@ where
         // 6. Register frame callback -- with hot-reload plugin override
         let renderer_frame = Arc::clone(&renderer);
         let hot_reload_frame = hot_reload.clone();
+        // One backoff per window, living across every wake this closure is
+        // called for — same `Arc`'d-and-recloned shape as
+        // `renderer_frame`/`bootstrap_desktop`'s own copy; see
+        // `DeviceRecoveryBackoff`'s own doc for why it needs to be `Arc`'d
+        // at all rather than just moved.
+        let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
         window.on_request_frame(Box::new(move || {
             let renderer_frame = Arc::clone(&renderer_frame);
             let hot_reload_frame = hot_reload_frame.clone();
+            let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
             let _ = dispatch_platform_realm(
                 realm_dispatch,
                 RealmTask::Frame(Box::new(move |realm| {
@@ -8228,8 +8952,11 @@ where
                     let has_pending = realm.has_pending_work();
                     let dirty = inbox_redraw || realm.needs_redraw() || has_pending;
                     let scheduler = realm.scheduler();
-                    match wake_action(scheduler.frames_enabled(), dirty, scheduler.is_frame_scheduled())
-                    {
+                    match wake_action(
+                        scheduler.frames_enabled(),
+                        dirty,
+                        scheduler.is_frame_scheduled(),
+                    ) {
                         WakeAction::Skip => return,
                         WakeAction::PumpAsync => {
                             // Frames disabled: pump only the async driver — no
@@ -8258,22 +8985,36 @@ where
                     // UpdateScheduler callbacks and rendering share ONE `UiRealm::enter`
                     // dynamic extent; callbacks may legally resolve realm-local
                     // capabilities throughout the complete frame transaction.
-                    scheduler.drive_frame_with_lane(now, flui_scheduler::IdleDeadline::far_future(now), || {
-                        let mut r = renderer_frame.lock();
-                        realm.render_frame_entered(&mut *r);
-
-                        if r.is_device_lost() {
-                            match pollster::block_on(r.recover()) {
-                                Ok(()) => {
-                                    tracing::warn!("GPU device lost — recovered successfully");
-                                    realm.wake_frame();
-                                }
-                                Err(e) => {
-                                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
-                                }
-                            }
-                        }
-                    }, realm.local_post_frame_lane());
+                    let recovery_pace = scheduler.drive_frame_with_lane(
+                        now,
+                        flui_scheduler::IdleDeadline::far_future(now),
+                        || {
+                            // Device-loss recovery around the frame, same
+                            // shape as the desktop path — see
+                            // `render_frame_with_device_recovery`.
+                            let mut r = renderer_frame.lock();
+                            render_frame_with_device_recovery(
+                                realm,
+                                &mut *r,
+                                &device_recovery_backoff,
+                            )
+                            .recovery_pace
+                        },
+                        realm.local_post_frame_lane(),
+                    );
+                    // Unlike desktop, this closure has no `no_present_
+                    // fallback_pace`/`keeps_frame_gate_open` gate of its
+                    // own to fall back to — nothing here paces a healthy
+                    // frame that never presents. But a FAILED device
+                    // recovery still must not be retried unbounded: without
+                    // this sleep, `DeviceRecoveryBackoff`'s own growing
+                    // interval would only ever be recorded, never actually
+                    // waited on, and this closure would wake -> recover ->
+                    // fail -> wake again at whatever rate the platform
+                    // delivers frames.
+                    if let Some(pace) = recovery_pace {
+                        std::thread::sleep(pace);
+                    }
                 })),
             );
         }));
@@ -8639,7 +9380,41 @@ where
                                         wake();
                                     }
                                     Err(e) => {
-                                        tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                                        // Driver may still be resetting. Arm
+                                        // the retry wake in the failure arm
+                                        // too — RAF alone re-pumps an ACTIVE
+                                        // tab, but a backgrounded tab's RAF
+                                        // is suspended, and without this wake
+                                        // the recovery is never retried once
+                                        // the tab comes back to the front.
+                                        //
+                                        // No `DeviceRecoveryBackoff` here —
+                                        // web stays un-unified with the
+                                        // desktop/Android `DeviceRecovery`
+                                        // seam (its `recover()` is async,
+                                        // driven through `spawn_local`, not
+                                        // a synchronous call that trait
+                                        // could wrap) — and needs no backoff
+                                        // of its own either: the renderer
+                                        // slot stays `None` for the
+                                        // duration of this `.await`, so the
+                                        // outer closure's own `let Some(r)
+                                        // = slot.as_mut() else { return; }`
+                                        // above already refuses to spawn a
+                                        // second recovery while one is in
+                                        // flight, and once it returns the
+                                        // browser's own `requestAnimationFrame`
+                                        // cadence bounds how often a new one
+                                        // can start (~16ms, the same order
+                                        // as desktop/Android's base backoff
+                                        // interval) — see the `PumpAsync`
+                                        // arm's own comment above for why
+                                        // RAF is a sufficient pacer here.
+                                        tracing::error!(
+                                            error = ?e,
+                                            "GPU device recovery failed; retry armed for the next wake"
+                                        );
+                                        wake();
                                     }
                                 }
                             });

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -290,7 +290,11 @@ fn merge_wake_deadlines(
 /// the root unconditionally (`UiRealm::redirty_root_for_frames_reenable`),
 /// which wakes the loop through the ordinary `needs_redraw` channel and
 /// lets a real `WakeAction::Render` resume the retry then.
-#[cfg(not(target_os = "ios"))]
+// Desktop-only, like its sole caller `bootstrap_desktop`: wasm has no
+// `ControlFlow`/`WaitUntil` to feed and iOS has no bootstrap here, so
+// compiling it on either target is dead code the `-D warnings` wasm gate
+// rejects.
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn desktop_secondary_wake_deadline(
     next_attempt_at: Option<web_time::Instant>,
     frames_enabled: bool,
@@ -6360,6 +6364,10 @@ fn wake_action(frames_enabled: bool, dirty: bool, frame_scheduled: bool) -> Wake
 /// wired into the wake-deadline hook but invisible to this gate reaches
 /// `WakeAction::Skip` and returns before `render_frame_with_device_recovery`
 /// is ever called, no matter how faithfully the platform actuates the wake.
+// Absent on wasm: its two production callers are the desktop and Android
+// frame closures, neither of which exists there, and the web runner has
+// no `DeviceRecoveryBackoff` deadline term to fold in.
+#[cfg(not(target_arch = "wasm32"))]
 fn frame_is_dirty(
     inbox_redraw: bool,
     needs_redraw: bool,

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -206,7 +206,21 @@ fn install_exit_policy_hook(policy: ExitPolicy) {
 /// full contract. Call once, alongside [`install_exit_policy_hook`], from
 /// every backend that wants this: today, that is `run_desktop` only —
 /// Android/web bootstraps never call this (their platforms don't override
-/// that trait method either, so it would be inert there anyway).
+/// that trait method either, so it would be inert there anyway; see
+/// `DeviceRecoveryBackoff`'s own doc for what that means for a device-
+/// recovery deadline specifically on Android).
+///
+/// `secondary_deadline` merges an additional wake-deadline SOURCE into this
+/// hook's answer (the earliest of the two wins) without this function
+/// needing to know what produces it — `bootstrap_desktop` passes a closure
+/// over its own `DeviceRecoveryBackoff`, so a device stuck retrying under
+/// backoff still gets `ControlFlow::WaitUntil`'s efficient wait instead of
+/// this hook silently only ever answering the realm's own deadline. Kept
+/// generic (not `DeviceRecoveryBackoff`-typed) so this function's own `cfg`
+/// gate can stay as broad as it already is (`not(ios)`, wider than that
+/// type's `not(ios), not(wasm32)`) without needing a matching narrow gate
+/// here too — only the (already desktop-only) call site's closure captures
+/// the concrete backoff type.
 ///
 /// The hook itself re-enters `APP_RUNTIME` only when the PLATFORM calls it
 /// later (`about_to_wait`) — never synchronously from this function, which
@@ -224,10 +238,20 @@ fn install_exit_policy_hook(policy: ExitPolicy) {
                   never call this"
     )
 )]
-fn install_wake_deadline_hook() {
+fn install_wake_deadline_hook(
+    secondary_deadline: impl Fn() -> Option<web_time::Instant> + Send + Sync + 'static,
+) {
     with_owner_platform(|owner| {
-        owner.shared().set_wake_deadline_hook(Box::new(|| {
-            APP_RUNTIME.with(|slot| slot.borrow().next_wake())
+        owner.shared().set_wake_deadline_hook(Box::new(move || {
+            // Same "no opinion is absence, not zero" fold `AppRuntime::
+            // next_wake` itself uses across realms — `None` from either
+            // source drops out rather than winning a `min` against a real
+            // deadline.
+            let realm_deadline = APP_RUNTIME.with(|slot| slot.borrow().next_wake());
+            [realm_deadline, secondary_deadline()]
+                .into_iter()
+                .flatten()
+                .min()
         }));
     });
 }
@@ -6921,7 +6945,7 @@ impl DeviceRecovery for flui_engine::wgpu::Renderer {
 }
 
 /// Exponential backoff for the [`DeviceRecovery::try_recover_device`] retry
-/// loop: paces how often an attempt is made while the device stays lost,
+/// loop: paces how often an ATTEMPT is made while the device stays lost,
 /// growing from one frame interval up to a capped ceiling and resetting on
 /// the first successful recovery.
 ///
@@ -6934,17 +6958,47 @@ impl DeviceRecovery for flui_engine::wgpu::Renderer {
 /// offscreen target — not cheap to repeat every wake), so this paces the
 /// ATTEMPT itself, not just the log line.
 ///
-/// `Send + Sync` (atomics, not `Cell`): captured behind an `Arc` by the
-/// platform's `on_request_frame` callback, which every backend's
-/// `Window::on_request_frame` requires to be `Send`
-/// (`flui-platform/src/traits/window.rs`).
+/// This is a DEADLINE, not a sleep: [`Self::next_attempt_at`] reports the
+/// earliest instant an attempt is allowed, and the caller's only obligation
+/// is to skip attempting before it — never to block the calling thread
+/// waiting for it. A `thread::sleep` sized to this backoff's own interval
+/// (climbing to a full second at the cap) was tried and rejected: on the
+/// platform event-loop thread that call runs on, it blocks input dispatch
+/// for its duration on every backend, and on Android specifically it also
+/// blocks `MainEvent` lifecycle delivery (`AndroidPlatform::run`'s poll
+/// loop calls `process_input_events`/`dispatch_request_frame` inline, on
+/// the SAME thread) — repeated one-second stalls there are ANR territory.
+/// Desktop wires [`DeviceRecoveryBackoff::next_attempt_at`] into the
+/// existing wall-clock wake-deadline hook instead (`install_wake_deadline_
+/// hook`), so the platform's own idle wait carries the deadline; see that
+/// function's own doc for exactly what it can express, and `bootstrap_
+/// android`'s frame closure for why Android — which has no such hook
+/// (`Platform::set_wake_deadline_hook`'s own doc names it explicitly) —
+/// degrades instead to retrying on its next externally-caused wake.
+///
+/// `Send + Sync`: captured behind an `Arc` by the platform's
+/// `on_request_frame` callback, which every backend's `Window::
+/// on_request_frame` requires to be `Send` (`flui-platform/src/traits/
+/// window.rs`). State lives behind one `parking_lot::Mutex` rather than
+/// several independent atomics — this is read/written at most once per
+/// frame wake, never contended, and a single lock rules out the counters
+/// and the deadline ever being updated out of step with each other.
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 struct DeviceRecoveryBackoff {
+    state: parking_lot::Mutex<DeviceRecoveryBackoffState>,
+}
+
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+struct DeviceRecoveryBackoffState {
     /// Consecutive failures since the last success (or since construction).
-    consecutive_failures: std::sync::atomic::AtomicU32,
+    consecutive_failures: u32,
     /// Whether the "backoff reached its cap" error has already been logged
     /// once this losing streak — re-armed on the next success.
-    cap_logged: std::sync::atomic::AtomicBool,
+    cap_logged: bool,
+    /// The earliest instant the next attempt is allowed. `None` before the
+    /// first failure of a streak (attempt immediately) or right after a
+    /// success.
+    next_attempt_at: Option<std::time::Instant>,
 }
 
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
@@ -6965,29 +7019,46 @@ impl DeviceRecoveryBackoff {
 
     fn new() -> Self {
         Self {
-            consecutive_failures: std::sync::atomic::AtomicU32::new(0),
-            cap_logged: std::sync::atomic::AtomicBool::new(false),
+            state: parking_lot::Mutex::new(DeviceRecoveryBackoffState {
+                consecutive_failures: 0,
+                cap_logged: false,
+                next_attempt_at: None,
+            }),
         }
     }
 
-    /// Record a failed recovery attempt and return the interval the caller
-    /// must wait before the platform is allowed to wake this loop again.
+    /// The earliest instant the next attempt is allowed, if a failure has
+    /// armed one. `None` when ready right now (never failed, or the last
+    /// outcome was a success).
+    fn next_attempt_at(&self) -> Option<std::time::Instant> {
+        self.state.lock().next_attempt_at
+    }
+
+    /// Record a failed recovery attempt at `now`, arm the next deadline,
+    /// and return it.
     ///
     /// Logs the first failure of a losing streak at `error`, every
     /// subsequent one at `debug`, and re-emits `error` exactly once more
     /// when the backoff reaches [`Self::CAP`] — a permanently dead GPU
     /// says so once more at that point, not on every attempt after it.
-    fn record_failure(&self, error: &flui_engine::EngineError) -> std::time::Duration {
-        use std::sync::atomic::Ordering;
-
-        let failures_before = self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
-        let shift = failures_before.min(Self::SHIFT_CAP);
+    fn record_failure(
+        &self,
+        error: &flui_engine::EngineError,
+        now: std::time::Instant,
+    ) -> std::time::Instant {
+        let mut state = self.state.lock();
+        let shift = state.consecutive_failures.min(Self::SHIFT_CAP);
         let interval = (Self::BASE * (1u32 << shift)).min(Self::CAP);
         let at_cap = interval >= Self::CAP;
+        let is_first = state.consecutive_failures == 0;
+        state.consecutive_failures += 1;
+        let deadline = now + interval;
+        state.next_attempt_at = Some(deadline);
 
-        if failures_before == 0 {
+        if is_first {
             tracing::error!(error = ?error, "GPU device recovery failed; retrying with backoff");
-        } else if at_cap && !self.cap_logged.swap(true, Ordering::Relaxed) {
+        } else if at_cap && !state.cap_logged {
+            state.cap_logged = true;
             tracing::error!(
                 error = ?error,
                 backoff = ?interval,
@@ -7001,46 +7072,57 @@ impl DeviceRecoveryBackoff {
                 "GPU device recovery failed; retrying"
             );
         }
-        interval
+        deadline
     }
 
     /// Reset the backoff after a successful recovery.
     fn record_success(&self) {
-        use std::sync::atomic::Ordering;
-
-        self.consecutive_failures.store(0, Ordering::Relaxed);
-        self.cap_logged.store(false, Ordering::Relaxed);
+        let mut state = self.state.lock();
+        state.consecutive_failures = 0;
+        state.cap_logged = false;
+        state.next_attempt_at = None;
     }
 }
 
-/// Attempt one synchronous device rebuild, updating `backoff` and arming
-/// the retry wake on FAILURE ONLY.
-///
-/// A successful recovery renders the very frame this call is nested inside
-/// of — either about to run (the pre-frame case) or just finished running
-/// (the mid-frame case, where `render_frame_entered`'s own
-/// `mark_rendered()` already clobbered any redraw flag two statements
-/// ago) — so an extra `wake_frame()` here would be immediately wasted,
-/// producing nothing but a spurious platform `request_redraw`. A failed
-/// recovery, by contrast, has nothing else that will ever retry it on a
-/// quiescent loop: `wake_frame()` (not `request_redraw`) so an idle winit
-/// loop actually queues a `RedrawRequested`.
+/// Outcome of one call to [`attempt_device_recovery`].
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+enum RecoveryAttempt {
+    /// The backoff's armed deadline had not yet elapsed — no attempt was
+    /// made. Carries that SAME deadline (not a freshly computed one).
+    Deferred(std::time::Instant),
+    /// A fresh attempt was made and failed. Carries the NEW deadline the
+    /// failure just armed.
+    Failed(std::time::Instant),
+    /// A fresh attempt was made and succeeded.
+    Recovered,
+}
+
+/// Attempt one synchronous device rebuild — but only if `backoff`'s deadline
+/// has elapsed; otherwise returns immediately without touching the renderer
+/// or the backoff's counters. See [`DeviceRecoveryBackoff`]'s own doc for
+/// why this is a deadline CHECK, never a sleep: skipping is the only
+/// non-blocking way to pace an attempt that can cost a full GPU stack
+/// rebuild.
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn attempt_device_recovery<R: DeviceRecovery>(
     renderer: &mut R,
-    realm: &super::ui_realm::UiRealm,
     backoff: &DeviceRecoveryBackoff,
-) -> Option<std::time::Duration> {
+    now: std::time::Instant,
+) -> RecoveryAttempt {
+    if let Some(deadline) = backoff.next_attempt_at()
+        && now < deadline
+    {
+        return RecoveryAttempt::Deferred(deadline);
+    }
     match renderer.try_recover_device() {
         Ok(()) => {
             tracing::warn!("GPU device lost — recovered successfully");
             backoff.record_success();
-            None
+            RecoveryAttempt::Recovered
         }
         Err(e) => {
-            let pace = backoff.record_failure(&e);
-            realm.wake_frame();
-            Some(pace)
+            let deadline = backoff.record_failure(&e, now);
+            RecoveryAttempt::Failed(deadline)
         }
     }
 }
@@ -7051,23 +7133,52 @@ struct FrameRecoveryOutcome {
     /// Whether the frame reached `present()` — same meaning as
     /// [`super::ui_realm::UiRealm::render_frame_entered`]'s own return.
     presented: bool,
-    /// `Some(pace)` when a device-recovery attempt FAILED this call: the
-    /// caller must sleep at least this long before the platform is allowed
-    /// to wake the loop again, in place of (never alongside) its normal
-    /// no-present fallback pace. `None` otherwise — a healthy device, or a
-    /// recovery attempt that just succeeded.
-    recovery_pace: Option<std::time::Duration>,
+    /// Set exactly when a NEW recovery attempt failed this call — never on
+    /// a merely-deferred attempt (the backoff deadline had not elapsed) and
+    /// never on success. Only this arms the retry wake; see this function's
+    /// own doc for why raising it here, not inside the attempt helper
+    /// itself, is what makes the wake survive.
+    ///
+    /// Read only by this module's own tests today: production callers
+    /// (`bootstrap_desktop`/`bootstrap_android`) consult the persistent
+    /// `DeviceRecoveryBackoff` directly (via its own `next_attempt_at`) for
+    /// the wake-deadline hook rather than this per-call snapshot, so this
+    /// field carries no separate production obligation of its own — kept
+    /// on the struct anyway because it is what makes the wake-on-failure-
+    /// only contract independently checkable per call.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "read by this module's own tests only -- see field doc"
+        )
+    )]
+    just_failed: bool,
+    /// The earliest instant the next recovery attempt is allowed, if the
+    /// device is still (or newly) lost. `None` once healthy.
+    ///
+    /// Read only by this module's own tests today, for the same reason as
+    /// [`Self::just_failed`] — production callers consult
+    /// `DeviceRecoveryBackoff::next_attempt_at` directly instead.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "read by this module's own tests only -- see field doc"
+        )
+    )]
+    next_attempt_at: Option<std::time::Instant>,
 }
 
 /// Drive one frame through `realm` against `renderer`, rebuilding a lost
-/// device around it, at most once per call.
+/// device around it.
 ///
-/// A device already lost at frame start gets ONE backoff-paced recovery
+/// A device already lost at frame start gets a backoff-gated recovery
 /// attempt here, BEFORE [`super::ui_realm::UiRealm::render_frame_entered`]
 /// — but `render_frame_entered` runs regardless of whether that attempt
-/// succeeded. Skipping it on a still-lost device was the original bug this
-/// function fixes: `render_frame_entered` is the only caller of
-/// `drain_deferred_arena_resolutions`, `flush_pending_moves`,
+/// happened or what it returned. Skipping it on a still-lost device was the
+/// original bug this function fixes: `render_frame_entered` is the only
+/// caller of `drain_deferred_arena_resolutions`, `flush_pending_moves`,
 /// `draw_frame_entered`, and `mouse_tracker().update_all_devices()`, all of
 /// which must keep advancing while the device is down (gesture-arena
 /// deadlines, coalesced pointer moves, and every Vsync ticker included) —
@@ -7075,47 +7186,123 @@ struct FrameRecoveryOutcome {
 /// `device_lost` flag before touching the GPU, so running it costs nothing
 /// extra on a still-dead device.
 ///
-/// A device lost MID-frame (the wgpu device-lost callback firing while
-/// `render_scene` ran) gets its own single recovery attempt AFTER —
-/// `was_lost_pre_frame` gates this so a device that was already lost going
-/// in, and is still lost coming out, is not attempted TWICE in the same
-/// call (which would silently double the effective retry rate the backoff
-/// above exists to bound).
+/// A device lost or re-lost MID-frame (the wgpu device-lost callback firing
+/// while `render_scene` ran) gets its own attempt AFTER. The post-frame
+/// check is gated on `next_attempt_at.is_none()`, not on "was the device
+/// lost before this call": a pre-frame attempt that SUCCEEDS leaves
+/// `next_attempt_at` at `None`, so if the SAME call's `render_frame_entered`
+/// then loses the device again, the post-frame check still fires — a
+/// `was_lost_pre_frame`-style gate would silently miss exactly that
+/// recovered-then-re-lost-mid-frame case, since it only ever asks about the
+/// PRE-frame state. Either check finding a non-`None` `next_attempt_at`
+/// means a decision (failed or deferred) was already recorded THIS call, so
+/// the other one skips — attempting twice in one wake would silently double
+/// the effective retry rate the backoff exists to bound.
+///
+/// A SUCCESSFUL PRE-frame attempt calls [`super::ui_realm::UiRealm::
+/// mark_primary_needs_full_repaint`] — never [`super::ui_realm::UiRealm::
+/// wake_frame`], and never bare [`super::ui_realm::UiRealm::request_redraw`]
+/// either. Neither of those alone is enough: `wake_frame` does not open
+/// `render_frame_entered`'s OWN per-presentation dirty gate
+/// (`presentation.take_redraw_pending()`, `ui_realm.rs`'s
+/// `draw_frame_entered`) at all, and `request_redraw` alone opens that gate
+/// but still leaves `PipelineOwner`'s OWN independent dirty tracking
+/// untouched — confirmed by a probe, not assumed: with `request_redraw`
+/// alone, `draw_frame_entered`'s segment gate correctly read `Produce`, and
+/// the pipeline STILL emitted `Idle` because nothing told it there was work
+/// to redo. `mark_primary_needs_full_repaint` does both: it is what a
+/// recovered device — whose own backing store was invalidated by the loss;
+/// `Renderer::recover` already primes a full repaint via `mark_full_repaint`
+/// for whatever scene reaches it next — needs to actually get a fresh scene
+/// submitted, rather than staying visually blank until something unrelated
+/// happens to dirty the tree. No platform poke alongside it (unlike a
+/// failure): this call's OWN `render_frame_entered` below runs
+/// synchronously right after, in the very same wake, so there is nothing
+/// external left to wake. The POST-frame (mid-frame-loss) success arm calls
+/// neither: that frame already had its own chance to present before the
+/// loss was even noticed, so there is no known-blank backing store to force
+/// a fresh submit for.
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn render_frame_with_device_recovery<R>(
     realm: &super::ui_realm::UiRealm,
     renderer: &mut R,
     backoff: &DeviceRecoveryBackoff,
+    now: std::time::Instant,
 ) -> FrameRecoveryOutcome
 where
     R: flui_engine::RasterBackend + DeviceRecovery,
 {
-    let was_lost_pre_frame = renderer.is_device_lost();
-    let mut recovery_pace = if was_lost_pre_frame {
-        attempt_device_recovery(renderer, realm, backoff)
-    } else {
-        None
-    };
+    let mut just_failed = false;
+    let mut next_attempt_at = None;
+
+    if renderer.is_device_lost() {
+        match attempt_device_recovery(renderer, backoff, now) {
+            // Pre-frame only: nothing has presented since the device died,
+            // so the recovered backing store needs a genuinely fresh
+            // submit — see `UiRealm::mark_primary_needs_full_repaint`'s
+            // own doc for why `request_redraw` alone does not get one.
+            RecoveryAttempt::Recovered => realm.mark_primary_needs_full_repaint(),
+            RecoveryAttempt::Failed(deadline) => {
+                just_failed = true;
+                next_attempt_at = Some(deadline);
+            }
+            RecoveryAttempt::Deferred(deadline) => next_attempt_at = Some(deadline),
+        }
+    }
 
     let presented = realm.render_frame_entered(renderer);
 
-    if !was_lost_pre_frame && renderer.is_device_lost() {
-        recovery_pace = attempt_device_recovery(renderer, realm, backoff);
+    if next_attempt_at.is_none() && renderer.is_device_lost() {
+        match attempt_device_recovery(renderer, backoff, now) {
+            // Post-frame (mid-frame loss) success arms NOTHING, unlike the
+            // pre-frame case above: the frame that just ran already had
+            // its own chance to present before the loss was noticed, so
+            // there is no known-blank backing store to force a fresh
+            // submit for here — forcing one anyway would just be a
+            // spurious extra repaint with no correctness reason behind it.
+            RecoveryAttempt::Recovered => {}
+            RecoveryAttempt::Failed(deadline) => {
+                just_failed = true;
+                next_attempt_at = Some(deadline);
+            }
+            RecoveryAttempt::Deferred(deadline) => next_attempt_at = Some(deadline),
+        }
+    }
+
+    if just_failed {
+        // Raised AFTER `render_frame_entered`, never before: that method's
+        // own tail (`if retry_needed { wake_frame() } else {
+        // mark_rendered() }`) runs unconditionally on EVERY call, and
+        // `mark_rendered()` silently clobbers an earlier `wake_frame()`
+        // whenever this frame's tree had nothing new to paint
+        // (`draw_frame_entered` returns `Idle`, so `retry_needed` stays
+        // `false` at the `ui_realm` layer). That is exactly what happens
+        // on every wake AFTER the first against a permanently dead device,
+        // once the initial mount's content is already consumed — a
+        // pre-frame `wake_frame()` call here self-extinguishes one hop
+        // later and the device stays dead for the life of the process.
+        // Raising it here, after `render_frame_entered` has already run
+        // its own tail, is the only place a failed recovery's wake
+        // survives it.
+        realm.wake_frame();
     }
 
     FrameRecoveryOutcome {
         presented,
-        recovery_pace,
+        just_failed,
+        next_attempt_at,
     }
 }
 
 /// The device-loss recovery contract of
 /// [`render_frame_with_device_recovery`] against scripted backends and the
-/// [`DeviceRecoveryBackoff`] pacing it: a pre-frame loss recovers BEFORE
-/// the frame build and ALWAYS runs it regardless of outcome, a mid-frame
-/// loss recovers after, only a FAILED attempt arms anything, and a
-/// persistently failing device is retried on a bounded, growing cadence —
-/// never abandoned.
+/// [`DeviceRecoveryBackoff`] pacing it: a pre-frame loss recovers BEFORE the
+/// frame build and ALWAYS runs it regardless of outcome, a mid-frame loss
+/// recovers after, only a NEW failure arms the retry wake (never a success,
+/// never a merely-deferred attempt), a successful recovery marks the
+/// presentation dirty so it actually paints again, and a persistently
+/// failing device is retried on a bounded, non-blocking, growing deadline —
+/// never abandoned, never slept on.
 #[cfg(all(
     test,
     not(target_os = "android"),
@@ -7123,7 +7310,7 @@ where
     not(target_arch = "wasm32")
 ))]
 mod device_recovery_tests {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use flui_engine::{EngineError, RasterBackend};
 
@@ -7245,8 +7432,9 @@ mod device_recovery_tests {
         let mut backend = ScriptedDeviceBackend::healthy();
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
 
         assert!(outcome.presented, "Ok(true) reaches present()");
         assert_eq!(backend.render_calls, 1, "the scene reached render_scene");
@@ -7255,8 +7443,12 @@ mod device_recovery_tests {
             "no recovery on a healthy device"
         );
         assert!(
-            outcome.recovery_pace.is_none(),
-            "no recovery attempt failed, so nothing arms a backoff pace"
+            !outcome.just_failed,
+            "no recovery attempt failed, so nothing arms the retry wake"
+        );
+        assert!(
+            outcome.next_attempt_at.is_none(),
+            "a healthy device has no pending recovery deadline"
         );
         assert!(
             !realm.needs_redraw(),
@@ -7273,8 +7465,9 @@ mod device_recovery_tests {
         };
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
 
         assert_eq!(
             backend.recover_attempts, 1,
@@ -7290,12 +7483,15 @@ mod device_recovery_tests {
         );
         assert!(outcome.presented, "the recovered frame reaches present()");
         assert!(
-            outcome.recovery_pace.is_none(),
-            "a SUCCESSFUL recovery must not arm a backoff pace — there is nothing to retry"
+            !outcome.just_failed,
+            "a SUCCESSFUL recovery must not report a failure — there is nothing to retry"
         );
-        // The original bug this pins: `a_pre_frame_loss_with_a_successful_
-        // recovery_renders_the_same_frame` (the earlier version of this
-        // test) never asserted `needs_redraw()`, which is exactly where a
+        assert!(
+            outcome.next_attempt_at.is_none(),
+            "a successful recovery leaves no pending deadline"
+        );
+        // The original bug this pins: an earlier version of this test
+        // never asserted `needs_redraw()`, which is exactly where a
         // spurious wake on the success arm hid — a successful pre-frame
         // recovery is immediately followed by rendering this very frame,
         // and that render's own `mark_rendered()` would silently clobber
@@ -7305,6 +7501,56 @@ mod device_recovery_tests {
             !realm.needs_redraw(),
             "a successful pre-frame recovery followed by a presented frame must leave no \
              spurious wake armed"
+        );
+    }
+
+    #[test]
+    fn a_successful_recovery_forces_the_recovered_devices_next_frame_to_actually_paint() {
+        let realm = mount_root();
+        let mut backend = ScriptedDeviceBackend::healthy();
+        let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
+
+        // Consume the mount's own pending paint FIRST, so the presentation's
+        // wake-only redraw bit (`PresentationState::mark_redraw_pending`,
+        // read by `draw_frame_entered`'s `take_redraw_pending`) is
+        // definitely false going into the recovery below — otherwise this
+        // test could pass by riding the mount's own leftover demand
+        // instead of proving what the recovery success arm itself does.
+        let warm_up = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        assert!(
+            warm_up.presented,
+            "precondition: the mount's own first frame presented"
+        );
+        assert_eq!(backend.render_calls, 1);
+
+        // Now the device dies and recovers, with NOTHING else marking the
+        // tree dirty in between (no input, no animation, no resize).
+        backend.lost = true;
+        backend.scene_outcome = Some(Ok(true));
+        backend.recover_outcome = Some(Ok(()));
+
+        let recovery = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+
+        // The fix this test pins: `wake_frame()` alone (the realm-level
+        // flag plus a platform poke) does NOT set `PresentationState::
+        // redraw_pending` — only `UiRealm::request_redraw` does, and that
+        // bit is what `draw_frame_entered`'s segment gate actually reads.
+        // Without marking it on a SUCCESSFUL recovery, this second call
+        // would find nothing dirty, `draw_frame_entered` would return
+        // `Idle`, and `render_scene` would never be reached — the
+        // recovered device would stay visually blank (its own backing
+        // store was invalidated by the loss; `Renderer::recover` primes a
+        // full repaint for whatever gets submitted next, but nothing
+        // submits at all without this).
+        assert_eq!(
+            backend.render_calls, 2,
+            "a successful recovery must force the recovered device's next frame to reach \
+             render_scene, not silently stay Idle"
+        );
+        assert!(
+            recovery.presented,
+            "the forced repaint must reach present()"
         );
     }
 
@@ -7324,8 +7570,9 @@ mod device_recovery_tests {
         };
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
 
         assert!(!outcome.presented, "a still-lost device presents nothing");
         assert_eq!(backend.recover_attempts, 1, "the recovery was attempted");
@@ -7341,9 +7588,10 @@ mod device_recovery_tests {
             "render_frame_entered must run even when the pre-frame recovery attempt \
              failed — a dead device must not stop the non-GPU half of the frame"
         );
+        assert!(outcome.just_failed, "a fresh attempt genuinely failed");
         assert_eq!(
-            outcome.recovery_pace,
-            Some(DeviceRecoveryBackoff::BASE),
+            outcome.next_attempt_at,
+            Some(now + DeviceRecoveryBackoff::BASE),
             "the first failed attempt backs off by exactly the base interval"
         );
         assert!(
@@ -7351,6 +7599,152 @@ mod device_recovery_tests {
             "the failed recovery must arm the retry wake: on a quiescent loop — no \
              input, no animations — nothing else would ever schedule the next \
              recovery attempt"
+        );
+    }
+
+    #[test]
+    fn a_deferred_attempt_before_the_deadline_does_not_touch_the_renderer() {
+        let realm = mount_root();
+        let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
+
+        let mut backend = ScriptedDeviceBackend {
+            lost: true,
+            scene_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_outcome: Some(Err(EngineError::DeviceLost)),
+            recover_clears_lost: false,
+            ..ScriptedDeviceBackend::healthy()
+        };
+        let first = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        assert!(
+            first.just_failed,
+            "precondition: the first attempt genuinely failed"
+        );
+        assert_eq!(backend.recover_attempts, 1);
+
+        // Refilled so a genuine second attempt, if this test's premise is
+        // wrong, fails loudly on its own assertions below rather than
+        // panicking on a `.take()` of `None`.
+        backend.scene_outcome = Some(Err(EngineError::DeviceLost));
+        backend.recover_outcome = Some(Err(EngineError::DeviceLost));
+
+        // Same instant, well before the backoff's own deadline (BASE, 16ms).
+        let second = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+
+        assert_eq!(
+            backend.recover_attempts, 1,
+            "a wake before the backoff's deadline must not touch the renderer at all — the \
+             whole point of a deadline CHECK over a sleep is that a still-too-early wake \
+             costs nothing"
+        );
+        assert!(
+            !second.just_failed,
+            "a deferred (not attempted) call must not report a fresh failure"
+        );
+        assert_eq!(
+            second.next_attempt_at, first.next_attempt_at,
+            "a deferred call must report the SAME deadline the earlier failure armed, not \
+             a freshly computed one"
+        );
+    }
+
+    /// A backend that recovers successfully on EVERY `try_recover_device`
+    /// call (no `.take()`-once panic guard — this test's whole point is
+    /// calling it twice) and dies again during `render_scene` exactly
+    /// once, right after the first recovery cleared `lost`.
+    struct AlwaysRecoversButDiesOnFirstRenderBackend {
+        lost: bool,
+        died_on_render: bool,
+        render_calls: u32,
+        recover_attempts: u32,
+    }
+
+    impl AlwaysRecoversButDiesOnFirstRenderBackend {
+        fn new() -> Self {
+            Self {
+                lost: true,
+                died_on_render: false,
+                render_calls: 0,
+                recover_attempts: 0,
+            }
+        }
+    }
+
+    impl RasterBackend for AlwaysRecoversButDiesOnFirstRenderBackend {
+        fn render_scene(&mut self, _scene: &flui_layer::Scene) -> Result<bool, EngineError> {
+            self.render_calls += 1;
+            if !self.died_on_render {
+                self.died_on_render = true;
+                // Dies again mid-frame, right after the pre-frame recovery
+                // (below) just cleared `lost`.
+                self.lost = true;
+            }
+            Ok(true)
+        }
+        fn resize(&mut self, _width: u32, _height: u32) {}
+        fn is_device_lost(&self) -> bool {
+            self.lost
+        }
+        fn mark_dirty(&mut self, _rect: flui_types::Rect<flui_types::geometry::Pixels>) {}
+        fn mark_full_repaint(&mut self) {}
+        fn has_damage(&self) -> bool {
+            true
+        }
+        fn size(&self) -> (u32, u32) {
+            (800, 600)
+        }
+        fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+            Ok(())
+        }
+    }
+
+    impl DeviceRecovery for AlwaysRecoversButDiesOnFirstRenderBackend {
+        fn try_recover_device(&mut self) -> Result<(), EngineError> {
+            self.recover_attempts += 1;
+            self.lost = false;
+            Ok(())
+        }
+    }
+
+    /// Pins the review's finding #2: gating the post-frame recovery check
+    /// on "was the device lost BEFORE this call" (`!was_lost_pre_frame`, the
+    /// earlier shape) silently misses a device that recovers successfully
+    /// pre-frame and then dies AGAIN during the very `render_frame_entered`
+    /// call that follows — `was_lost_pre_frame` reads `true` going in, so
+    /// that gate would skip the post-frame check entirely, and the fresh
+    /// mid-frame loss would never be attempted or armed at all. Gating on
+    /// `next_attempt_at.is_none()` instead correctly re-checks, because a
+    /// SUCCESSFUL pre-frame attempt leaves no deadline armed.
+    #[test]
+    fn a_pre_frame_recovery_success_does_not_block_a_fresh_mid_frame_loss() {
+        let realm = mount_root();
+        let mut backend = AlwaysRecoversButDiesOnFirstRenderBackend::new();
+        realm.mark_rendered();
+        let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
+
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+
+        assert_eq!(
+            backend.recover_attempts, 2,
+            "the device recovered pre-frame, died again mid-frame, and must be attempted \
+             a SECOND time in the same call"
+        );
+        assert_eq!(
+            backend.render_calls, 1,
+            "the frame still rendered exactly once"
+        );
+        assert!(
+            !backend.lost,
+            "the second, post-frame recovery attempt succeeded"
+        );
+        assert!(
+            outcome.presented,
+            "the frame rendered before the second loss reaches present()"
+        );
+        assert!(
+            !outcome.just_failed,
+            "the second attempt succeeded too, so nothing failed this call"
         );
     }
 
@@ -7365,8 +7759,9 @@ mod device_recovery_tests {
         };
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
 
         assert_eq!(
             backend.render_calls, 1,
@@ -7380,9 +7775,13 @@ mod device_recovery_tests {
             backend.recover_attempts, 1,
             "the mid-frame loss is recovered after the render"
         );
+        assert!(
+            outcome.just_failed,
+            "a fresh post-render attempt genuinely failed"
+        );
         assert_eq!(
-            outcome.recovery_pace,
-            Some(DeviceRecoveryBackoff::BASE),
+            outcome.next_attempt_at,
+            Some(now + DeviceRecoveryBackoff::BASE),
             "the failed post-render recovery backs off by the base interval, same as a \
              pre-frame failure"
         );
@@ -7409,8 +7808,9 @@ mod device_recovery_tests {
         };
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
 
         assert_eq!(
             backend.render_calls, 1,
@@ -7429,8 +7829,12 @@ mod device_recovery_tests {
             "the scripted successful recovery cleared the lost flag"
         );
         assert!(
-            outcome.recovery_pace.is_none(),
-            "a SUCCESSFUL post-render recovery must not arm a backoff pace"
+            !outcome.just_failed,
+            "a SUCCESSFUL post-render recovery must not report a failure"
+        );
+        assert!(
+            outcome.next_attempt_at.is_none(),
+            "a successful post-render recovery leaves no pending deadline"
         );
         assert!(
             !realm.needs_redraw(),
@@ -7459,6 +7863,7 @@ mod device_recovery_tests {
         let realm = mount_root();
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
         let arena = realm.gestures().arena().clone();
         let long_press_fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -7496,7 +7901,7 @@ mod device_recovery_tests {
             ..ScriptedDeviceBackend::healthy()
         };
 
-        let _ = render_frame_with_device_recovery(&realm, &mut backend, &backoff);
+        let _ = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
 
         assert!(
             long_press_fired.load(std::sync::atomic::Ordering::SeqCst),
@@ -7506,38 +7911,83 @@ mod device_recovery_tests {
         );
     }
 
+    /// Direct reproduction of the review's self-extinguishing-retry finding:
+    /// with `wake_frame()` raised INSIDE the recovery attempt (BEFORE
+    /// `render_frame_entered` runs, the shape this test would fail
+    /// against), `render_frame_entered`'s own tail (`mark_rendered()`,
+    /// since a quiescent tree with nothing new to paint produces `Idle`,
+    /// not `Errored`) silently clobbers it one hop later. A two-frame drive
+    /// does not catch this: the FIRST frame still has the mount's own
+    /// pending paint, reaches `render_scene`, and `ui_realm`'s OWN
+    /// `DeviceLost` arm independently arms `needs_redraw` too (`retry_needed
+    /// = true` there, from this same issue's `ui_realm.rs` fix) — the bug
+    /// only shows up once that leftover demand is exhausted, on the frame
+    /// AFTER, which is exactly why this drives (and checks) three.
+    #[test]
+    fn needs_redraw_stays_armed_across_three_consecutive_frames_against_a_permanently_dead_device()
+    {
+        let realm = mount_root();
+        let backoff = DeviceRecoveryBackoff::new();
+        let mut now = Instant::now();
+
+        for frame in 1..=3u32 {
+            let mut backend = ScriptedDeviceBackend {
+                lost: true,
+                scene_outcome: Some(Err(EngineError::DeviceLost)),
+                recover_outcome: Some(Err(EngineError::DeviceLost)),
+                recover_clears_lost: false,
+                ..ScriptedDeviceBackend::healthy()
+            };
+            let _ = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+            assert!(
+                realm.needs_redraw(),
+                "needs_redraw must still be armed after frame {frame} against a \
+                 permanently dead device — a device that never recovers must never let \
+                 this flag settle back to false, or nothing will ever wake the loop to \
+                 retry again"
+            );
+            // Space frames out past the backoff's own growing deadline so
+            // each one is a genuine NEW attempt, not one silently deferred
+            // by the backoff (which would make this loop pass trivially,
+            // for the wrong reason — a deferred attempt reports no fresh
+            // failure at all).
+            now += Duration::from_secs(2);
+        }
+    }
+
     /// A persistently failing recovery must be attempted a BOUNDED number
-    /// of times over a fixed wall-clock window, not once per delivered
-    /// platform frame — the same shape as issue #556's
-    /// `no_present_fallback_bounds_repeating_no_present_wakes` spin
-    /// measurement, applied to [`DeviceRecoveryBackoff`] directly. A
-    /// fixed, un-backed-off cadence (the bug this guards against) would
-    /// rack up roughly `window / DeviceRecoveryBackoff::BASE` attempts —
-    /// tens of them in this window; the backoff must land an order of
-    /// magnitude below that.
+    /// of times over a fixed window, not once per delivered platform frame
+    /// — the same property issue #556's `no_present_fallback_bounds_
+    /// repeating_no_present_wakes` measures for the no-present pace,
+    /// applied here to [`DeviceRecoveryBackoff`] directly. Driven entirely
+    /// in VIRTUAL time (`now` advanced by hand to each returned deadline,
+    /// never `std::thread::sleep`): the backoff's own API takes `now`
+    /// explicitly for exactly this reason, so a much longer window is
+    /// provable in microseconds of real wall-clock time instead of costing
+    /// the window for real — this test used to be the slowest in the
+    /// suite at ~1s; it no longer sleeps at all.
     #[test]
     fn device_recovery_backoff_bounds_a_persistently_failing_retry_loop() {
-        use std::time::Instant;
-
         let backoff = DeviceRecoveryBackoff::new();
-        let window = Duration::from_millis(600);
-        let deadline = Instant::now() + window;
+        let mut now = Instant::now();
+        let window = Duration::from_mins(10);
+        let window_end = now + window;
         let mut attempts = 0u32;
 
-        while Instant::now() < deadline {
+        while now < window_end {
             attempts += 1;
-            let pace = backoff.record_failure(&EngineError::DeviceLost);
-            std::thread::sleep(pace);
+            now = backoff.record_failure(&EngineError::DeviceLost, now);
         }
 
         let unbacked_off_attempts =
             u32::try_from(window.as_millis() / DeviceRecoveryBackoff::BASE.as_millis())
                 .unwrap_or(u32::MAX);
         assert!(
-            attempts <= 10,
-            "the backoff failed to bound the retry loop: {attempts} attempts in {window:?} \
-             (an un-backed-off fixed cadence would rack up roughly \
-             {unbacked_off_attempts} in the same window)",
+            attempts < 700,
+            "the backoff failed to bound the retry loop: {attempts} attempts over a \
+             simulated {window:?} (an un-backed-off fixed cadence would rack up roughly \
+             {unbacked_off_attempts} in the same window — once capped at one second per \
+             attempt, {window:?} allows at most about 600)",
         );
         assert!(
             attempts >= 2,
@@ -7549,19 +7999,20 @@ mod device_recovery_tests {
     #[test]
     fn device_recovery_backoff_resets_to_the_base_interval_after_a_success() {
         let backoff = DeviceRecoveryBackoff::new();
+        let now = Instant::now();
 
-        let first = backoff.record_failure(&EngineError::DeviceLost);
-        let second = backoff.record_failure(&EngineError::DeviceLost);
-        assert_eq!(first, DeviceRecoveryBackoff::BASE);
+        let first = backoff.record_failure(&EngineError::DeviceLost, now);
+        let second = backoff.record_failure(&EngineError::DeviceLost, now);
+        assert_eq!(first - now, DeviceRecoveryBackoff::BASE);
         assert!(
-            second > first,
+            second - now > first - now,
             "the backoff must grow across consecutive failures with no success in between"
         );
 
         backoff.record_success();
-        let after_reset = backoff.record_failure(&EngineError::DeviceLost);
+        let after_reset = backoff.record_failure(&EngineError::DeviceLost, now);
         assert_eq!(
-            after_reset,
+            after_reset - now,
             DeviceRecoveryBackoff::BASE,
             "a success must reset the backoff to its base interval, not continue growing \
              from where it left off"
@@ -7571,15 +8022,16 @@ mod device_recovery_tests {
     #[test]
     fn device_recovery_backoff_caps_at_the_ceiling_and_never_gives_up() {
         let backoff = DeviceRecoveryBackoff::new();
-        let mut last = Duration::ZERO;
+        let now = Instant::now();
+        let mut last = now;
 
         // Comfortably past the point the shift itself saturates.
         for _ in 0..20u32 {
-            last = backoff.record_failure(&EngineError::DeviceLost);
+            last = backoff.record_failure(&EngineError::DeviceLost, now);
         }
 
         assert_eq!(
-            last,
+            last - now,
             DeviceRecoveryBackoff::CAP,
             "the interval must stop growing at the cap instead of overflowing or \
              continuing to double"
@@ -7696,13 +8148,25 @@ where
         // the backend would otherwise take unconditionally.
         install_exit_policy_hook(config.exit_policy);
 
-        // 0c. Wire the wall-clock-wake hook: the winit
+        // 0c. This window's device-recovery backoff, constructed here (not
+        // down at step 6 alongside the renderer it paces) so the
+        // wake-deadline hook below can be wired to it from the start — one
+        // instance for the whole closure's life, `Arc`'d because a fresh
+        // clone is threaded into each `RealmTask::Frame` the frame closure
+        // builds while the underlying counters/deadline must persist. See
+        // `DeviceRecoveryBackoff`'s own doc.
+        let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
+
+        // 0d. Wire the wall-clock-wake hook: the winit
         // backend's `about_to_wait` consults this every idle iteration
         // instead of blocking forever, so a pending gesture-arena deadline
-        // (a long-press hold, a double-tap give-up) still wakes the loop
-        // at the right instant even while nothing else is dirty and no
-        // animation is running.
-        install_wake_deadline_hook();
+        // (a long-press hold, a double-tap give-up) or an armed device-
+        // recovery retry still wakes the loop at the right instant even
+        // while nothing else is dirty and no animation is running.
+        install_wake_deadline_hook({
+            let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
+            move || device_recovery_backoff.next_attempt_at()
+        });
 
         // 1. Open window now that the event loop is running. Window creation is
         // an environment failure (display server hiccup, resource exhaustion),
@@ -7854,12 +8318,8 @@ where
         // 6. Register frame callback -> scheduler + UiRealm::render_frame_entered()
         let renderer_frame = Arc::clone(&renderer);
         let worker_reload_frame = worker_reload.clone();
-        // One backoff per window, living across every wake this closure is
-        // called for — see `DeviceRecoveryBackoff`'s own doc for why this
-        // needs to be `Arc`'d (not just moved) the same way `renderer_frame`
-        // is: a fresh clone is threaded into each `RealmTask::Frame` this
-        // closure builds, but the underlying counters must persist.
-        let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
+        // Reuses the SAME backoff constructed at step 0c (already wired
+        // into the wake-deadline hook above) — not a fresh one.
         window.on_request_frame(Box::new(move || {
             let renderer_frame = Arc::clone(&renderer_frame);
             let worker_reload_frame = worker_reload_frame.clone();
@@ -7978,6 +8438,7 @@ where
                                 realm,
                                 &mut *r,
                                 &device_recovery_backoff,
+                                now,
                             )
                         },
                         realm.local_post_frame_lane(),
@@ -7994,22 +8455,19 @@ where
                     // busy-spin this guards against (observed: ~30 000 fps) only
                     // happens when a ticker/animation keeps re-requesting a frame every
                     // wake with nothing pacing it — `no_present_fallback_pace` fires
-                    // only in exactly that combination.
+                    // only in exactly that combination. A still-lost device armed for
+                    // a LATER retry does NOT feed this pace: `DeviceRecoveryBackoff`
+                    // paces the ATTEMPT itself (a deadline check, never a sleep — see
+                    // its own doc), and its deadline reaches the platform's own idle
+                    // wait through the wake-deadline hook wired above, not through
+                    // this fallback.
                     let keeps_gate_open = keeps_frame_gate_open(
                         realm.needs_redraw(),
                         scheduler.is_frame_scheduled(),
                         realm.has_pending_work(),
                     );
-                    // A failed device-recovery attempt this wake overrides the
-                    // fixed no-present pace with `DeviceRecoveryBackoff`'s growing
-                    // one: reusing `NO_PRESENT_FALLBACK_PACE`'s fixed 16ms here
-                    // for a persistently-lost device would attempt a full
-                    // instance/adapter/device/surface rebuild every ~16ms forever
-                    // — see `DeviceRecoveryBackoff`'s own doc.
-                    let pace = outcome
-                        .recovery_pace
-                        .or_else(|| no_present_fallback_pace(outcome.presented, keeps_gate_open));
-                    if let Some(pace) = pace {
+                    if let Some(pace) = no_present_fallback_pace(outcome.presented, keeps_gate_open)
+                    {
                         // This runs on the platform event-loop thread, so the sleep
                         // blocks input dispatch for its duration — acceptable here
                         // because this path only fires for an occluded/undamaged
@@ -8985,7 +9443,36 @@ where
                     // UpdateScheduler callbacks and rendering share ONE `UiRealm::enter`
                     // dynamic extent; callbacks may legally resolve realm-local
                     // capabilities throughout the complete frame transaction.
-                    let recovery_pace = scheduler.drive_frame_with_lane(
+                    //
+                    // No sleep here, unlike an earlier version of this
+                    // closure: `DeviceRecoveryBackoff` paces the recovery
+                    // ATTEMPT itself via a non-blocking deadline check (see
+                    // its own doc), never by blocking this thread.
+                    // `AndroidPlatform::run`'s poll loop calls
+                    // `process_input_events`/`dispatch_request_frame`
+                    // inline on this SAME thread, so a sleep here — even
+                    // one bounded to the backoff's own growing interval —
+                    // would stall input and `MainEvent` lifecycle delivery
+                    // (Pause/Destroy/Resize) for its duration, which is ANR
+                    // territory at the backoff's one-second cap. Unlike
+                    // desktop, Android has no non-blocking wait-until
+                    // primitive to carry the backoff's deadline instead
+                    // (`Platform::set_wake_deadline_hook`'s own doc names
+                    // Android explicitly as not overriding it) — so while a
+                    // FAILED recovery attempt still wakes this loop once
+                    // (`render_frame_with_device_recovery`'s own
+                    // `wake_frame()` call, on failure only), a merely
+                    // DEFERRED attempt (backoff not yet elapsed) wakes
+                    // nothing here, and this platform's retry cadence
+                    // degrades to "the next externally-caused wake"
+                    // (input, resize, a lifecycle event) rather than a
+                    // strict wall-clock cadence — strictly better than the
+                    // original bug (no retry, ever, ANDROID included) and
+                    // never worse than every other quiescent-wake path
+                    // this codebase already has on this backend (gesture-
+                    // arena deadlines, animation ticks: none of them have a
+                    // platform timer here either).
+                    scheduler.drive_frame_with_lane(
                         now,
                         flui_scheduler::IdleDeadline::far_future(now),
                         || {
@@ -8993,28 +9480,15 @@ where
                             // shape as the desktop path — see
                             // `render_frame_with_device_recovery`.
                             let mut r = renderer_frame.lock();
-                            render_frame_with_device_recovery(
+                            let _ = render_frame_with_device_recovery(
                                 realm,
                                 &mut *r,
                                 &device_recovery_backoff,
-                            )
-                            .recovery_pace
+                                now,
+                            );
                         },
                         realm.local_post_frame_lane(),
                     );
-                    // Unlike desktop, this closure has no `no_present_
-                    // fallback_pace`/`keeps_frame_gate_open` gate of its
-                    // own to fall back to — nothing here paces a healthy
-                    // frame that never presents. But a FAILED device
-                    // recovery still must not be retried unbounded: without
-                    // this sleep, `DeviceRecoveryBackoff`'s own growing
-                    // interval would only ever be recorded, never actually
-                    // waited on, and this closure would wake -> recover ->
-                    // fail -> wake again at whatever rate the platform
-                    // delivers frames.
-                    if let Some(pace) = recovery_pace {
-                        std::thread::sleep(pace);
-                    }
                 })),
             );
         }));

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -243,17 +243,86 @@ fn install_wake_deadline_hook(
 ) {
     with_owner_platform(|owner| {
         owner.shared().set_wake_deadline_hook(Box::new(move || {
-            // Same "no opinion is absence, not zero" fold `AppRuntime::
-            // next_wake` itself uses across realms — `None` from either
-            // source drops out rather than winning a `min` against a real
-            // deadline.
             let realm_deadline = APP_RUNTIME.with(|slot| slot.borrow().next_wake());
-            [realm_deadline, secondary_deadline()]
-                .into_iter()
-                .flatten()
-                .min()
+            merge_wake_deadlines(realm_deadline, secondary_deadline())
         }));
     });
+}
+
+/// The earlier of two optional wake deadlines, treating `None` as "no
+/// opinion" rather than as a value that could win a `min` against a real
+/// deadline — the same fold `AppRuntime::next_wake` (`runtime.rs`) itself
+/// uses across realms, pulled out here as its own named, unit-tested
+/// function because it is exactly what [`install_wake_deadline_hook`]'s
+/// entire non-blocking desktop design now rests on: this whole module's
+/// device-recovery deadline reaches the platform's `ControlFlow::WaitUntil`
+/// only through this fold correctly picking the earlier of the realm's own
+/// deadline and the secondary (device-recovery) one, and correctly leaving
+/// the realm's deadline untouched when the secondary source has nothing
+/// pending.
+#[cfg(not(target_os = "ios"))]
+fn merge_wake_deadlines(
+    a: Option<web_time::Instant>,
+    b: Option<web_time::Instant>,
+) -> Option<web_time::Instant> {
+    [a, b].into_iter().flatten().min()
+}
+
+#[cfg(all(test, not(target_os = "ios")))]
+mod merge_wake_deadlines_tests {
+    use std::time::Duration;
+
+    use web_time::Instant;
+
+    use super::merge_wake_deadlines;
+
+    #[test]
+    fn picks_the_earlier_of_two_present_deadlines_either_order() {
+        let now = Instant::now();
+        let earlier = now + Duration::from_millis(16);
+        let later = now + Duration::from_secs(1);
+
+        assert_eq!(
+            merge_wake_deadlines(Some(earlier), Some(later)),
+            Some(earlier),
+            "realm-earlier, secondary-later"
+        );
+        assert_eq!(
+            merge_wake_deadlines(Some(later), Some(earlier)),
+            Some(earlier),
+            "realm-later, secondary-earlier -- order must not matter"
+        );
+    }
+
+    #[test]
+    fn a_missing_secondary_leaves_the_realm_deadline_untouched() {
+        let deadline = Instant::now() + Duration::from_millis(16);
+        assert_eq!(
+            merge_wake_deadlines(Some(deadline), None),
+            Some(deadline),
+            "no device-recovery deadline pending must not suppress a real realm deadline"
+        );
+    }
+
+    #[test]
+    fn a_missing_realm_deadline_leaves_the_secondary_deadline_untouched() {
+        let deadline = Instant::now() + Duration::from_millis(16);
+        assert_eq!(
+            merge_wake_deadlines(None, Some(deadline)),
+            Some(deadline),
+            "no realm deadline pending must not suppress a real device-recovery deadline"
+        );
+    }
+
+    #[test]
+    fn both_absent_is_absent() {
+        assert_eq!(
+            merge_wake_deadlines(None, None),
+            None,
+            "neither source has an opinion -- the platform must fall back to its \
+             unconditional Wait, not a spurious WaitUntil(anything)"
+        );
+    }
 }
 
 /// Borrow-style access to the loop-scoped owner-platform capability.
@@ -6968,21 +7037,50 @@ impl DeviceRecovery for flui_engine::wgpu::Renderer {
 /// blocks `MainEvent` lifecycle delivery (`AndroidPlatform::run`'s poll
 /// loop calls `process_input_events`/`dispatch_request_frame` inline, on
 /// the SAME thread) — repeated one-second stalls there are ANR territory.
-/// Desktop wires [`DeviceRecoveryBackoff::next_attempt_at`] into the
-/// existing wall-clock wake-deadline hook instead (`install_wake_deadline_
-/// hook`), so the platform's own idle wait carries the deadline; see that
-/// function's own doc for exactly what it can express, and `bootstrap_
-/// android`'s frame closure for why Android — which has no such hook
-/// (`Platform::set_wake_deadline_hook`'s own doc names it explicitly) —
-/// degrades instead to retrying on its next externally-caused wake.
+/// Both desktop and Android wire [`DeviceRecoveryBackoff::next_attempt_at`]
+/// into a wall-clock wake-deadline hook (`install_wake_deadline_hook` for
+/// desktop; `Platform::set_wake_deadline_hook` on `AndroidPlatform` directly
+/// for Android, added alongside this backoff since the trait's default
+/// implementation is a no-op there) so the platform's own idle wait — or,
+/// on Android, its own already-running ~16ms idle poll — carries the
+/// deadline instead of this crate sleeping on it. See each hook's own doc
+/// for exactly what it can express and at what granularity. **A deadline
+/// wired into either hook is necessary but not sufficient on its own**: it
+/// must also appear in the owning frame closure's `dirty` predicate (`wake_
+/// action`'s input) or the wake it actuates reaches `WakeAction::Skip` and
+/// returns before this backoff is ever consulted again — both closures'
+/// `dirty` computations OR in `next_attempt_at().is_some()` for exactly
+/// this reason.
 ///
 /// `Send + Sync`: captured behind an `Arc` by the platform's
 /// `on_request_frame` callback, which every backend's `Window::
 /// on_request_frame` requires to be `Send` (`flui-platform/src/traits/
 /// window.rs`). State lives behind one `parking_lot::Mutex` rather than
 /// several independent atomics — this is read/written at most once per
-/// frame wake, never contended, and a single lock rules out the counters
-/// and the deadline ever being updated out of step with each other.
+/// frame wake, and a single lock rules out the counters and the deadline
+/// ever being updated out of step with each other.
+///
+/// This mutex has TWO callers, not one: the frame closure itself
+/// (`attempt_device_recovery`/[`Self::record_failure`]/[`Self::record_success`])
+/// and the wake-deadline hook closure ([`Self::next_attempt_at`], called
+/// from desktop's `about_to_wait` or Android's own poll loop). Both run on
+/// this platform's single event-loop thread, never concurrently with each
+/// other — that same-thread invariant is what makes holding this
+/// `parking_lot::Mutex` (non-reentrant: a same-thread re-lock while already
+/// held deadlocks, it does not block-and-wait) safe with no actual
+/// contention today. It is still deliberately never held across a
+/// `tracing` call (whose subscriber may perform I/O) — see
+/// [`Self::record_failure`]'s own comment for where the guard is dropped
+/// before logging, defensively, not because a reentrant call from within a
+/// subscriber has been observed.
+///
+/// [`web_time::Instant`], not `std::time::Instant`: a deliberate match to
+/// every other clock on this frame-driver path (`web_time::Instant::now()`
+/// at the top of both closures, `AppRuntime::next_wake`'s own return type)
+/// rather than an accident of this type compiling only because the two
+/// happen to be the same type off-`wasm32` (this backoff's own `cfg` gate
+/// already excludes `wasm32`, so the distinction is moot today, but the
+/// convention is the same one this whole module already follows).
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 struct DeviceRecoveryBackoff {
     state: parking_lot::Mutex<DeviceRecoveryBackoffState>,
@@ -6998,7 +7096,7 @@ struct DeviceRecoveryBackoffState {
     /// The earliest instant the next attempt is allowed. `None` before the
     /// first failure of a streak (attempt immediately) or right after a
     /// success.
-    next_attempt_at: Option<std::time::Instant>,
+    next_attempt_at: Option<web_time::Instant>,
 }
 
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
@@ -7030,7 +7128,7 @@ impl DeviceRecoveryBackoff {
     /// The earliest instant the next attempt is allowed, if a failure has
     /// armed one. `None` when ready right now (never failed, or the last
     /// outcome was a success).
-    fn next_attempt_at(&self) -> Option<std::time::Instant> {
+    fn next_attempt_at(&self) -> Option<web_time::Instant> {
         self.state.lock().next_attempt_at
     }
 
@@ -7044,33 +7142,62 @@ impl DeviceRecoveryBackoff {
     fn record_failure(
         &self,
         error: &flui_engine::EngineError,
-        now: std::time::Instant,
-    ) -> std::time::Instant {
-        let mut state = self.state.lock();
-        let shift = state.consecutive_failures.min(Self::SHIFT_CAP);
-        let interval = (Self::BASE * (1u32 << shift)).min(Self::CAP);
-        let at_cap = interval >= Self::CAP;
-        let is_first = state.consecutive_failures == 0;
-        state.consecutive_failures += 1;
-        let deadline = now + interval;
-        state.next_attempt_at = Some(deadline);
+        now: web_time::Instant,
+    ) -> web_time::Instant {
+        /// Which line to log, decided while the state lock is held (it
+        /// reads/mutates `cap_logged`); the actual `tracing` call happens
+        /// AFTER the guard drops — see this method's own call site below.
+        enum LogKind {
+            FirstFailure,
+            ReachedCap,
+            Retrying,
+        }
 
-        if is_first {
-            tracing::error!(error = ?error, "GPU device recovery failed; retrying with backoff");
-        } else if at_cap && !state.cap_logged {
-            state.cap_logged = true;
-            tracing::error!(
-                error = ?error,
-                backoff = ?interval,
-                "GPU device recovery still failing at the backoff cap; retries continue \
-                 silently from here"
-            );
-        } else {
-            tracing::debug!(
-                error = ?error,
-                backoff = ?interval,
-                "GPU device recovery failed; retrying"
-            );
+        let (deadline, interval, log_kind) = {
+            let mut state = self.state.lock();
+            let shift = state.consecutive_failures.min(Self::SHIFT_CAP);
+            let interval = (Self::BASE * (1u32 << shift)).min(Self::CAP);
+            let at_cap = interval >= Self::CAP;
+            let is_first = state.consecutive_failures == 0;
+            state.consecutive_failures += 1;
+            let deadline = now + interval;
+            state.next_attempt_at = Some(deadline);
+
+            let log_kind = if is_first {
+                LogKind::FirstFailure
+            } else if at_cap && !state.cap_logged {
+                state.cap_logged = true;
+                LogKind::ReachedCap
+            } else {
+                LogKind::Retrying
+            };
+            (deadline, interval, log_kind)
+            // `state` (the `MutexGuard`) drops here, before any `tracing`
+            // call: this mutex's other caller is the wake-deadline hook
+            // closure (see this type's own doc for why holding it across a
+            // subscriber's possible I/O is undesirable even though no
+            // reentrant call is reachable today).
+        };
+
+        match log_kind {
+            LogKind::FirstFailure => {
+                tracing::error!(error = ?error, "GPU device recovery failed; retrying with backoff");
+            }
+            LogKind::ReachedCap => {
+                tracing::error!(
+                    error = ?error,
+                    backoff = ?interval,
+                    "GPU device recovery still failing at the backoff cap; retries continue \
+                     silently from here"
+                );
+            }
+            LogKind::Retrying => {
+                tracing::debug!(
+                    error = ?error,
+                    backoff = ?interval,
+                    "GPU device recovery failed; retrying"
+                );
+            }
         }
         deadline
     }
@@ -7089,10 +7216,10 @@ impl DeviceRecoveryBackoff {
 enum RecoveryAttempt {
     /// The backoff's armed deadline had not yet elapsed — no attempt was
     /// made. Carries that SAME deadline (not a freshly computed one).
-    Deferred(std::time::Instant),
+    Deferred(web_time::Instant),
     /// A fresh attempt was made and failed. Carries the NEW deadline the
     /// failure just armed.
-    Failed(std::time::Instant),
+    Failed(web_time::Instant),
     /// A fresh attempt was made and succeeded.
     Recovered,
 }
@@ -7107,7 +7234,7 @@ enum RecoveryAttempt {
 fn attempt_device_recovery<R: DeviceRecovery>(
     renderer: &mut R,
     backoff: &DeviceRecoveryBackoff,
-    now: std::time::Instant,
+    now: web_time::Instant,
 ) -> RecoveryAttempt {
     if let Some(deadline) = backoff.next_attempt_at()
         && now < deadline
@@ -7167,7 +7294,7 @@ struct FrameRecoveryOutcome {
             reason = "read by this module's own tests only -- see field doc"
         )
     )]
-    next_attempt_at: Option<std::time::Instant>,
+    next_attempt_at: Option<web_time::Instant>,
 }
 
 /// Drive one frame through `realm` against `renderer`, rebuilding a lost
@@ -7227,7 +7354,7 @@ fn render_frame_with_device_recovery<R>(
     realm: &super::ui_realm::UiRealm,
     renderer: &mut R,
     backoff: &DeviceRecoveryBackoff,
-    now: std::time::Instant,
+    now: web_time::Instant,
 ) -> FrameRecoveryOutcome
 where
     R: flui_engine::RasterBackend + DeviceRecovery,
@@ -7310,9 +7437,10 @@ where
     not(target_arch = "wasm32")
 ))]
 mod device_recovery_tests {
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use flui_engine::{EngineError, RasterBackend};
+    use web_time::Instant;
 
     use super::{DeviceRecovery, DeviceRecoveryBackoff, render_frame_with_device_recovery};
 
@@ -7955,6 +8083,213 @@ mod device_recovery_tests {
         }
     }
 
+    /// The test every prior round's test suite was missing: the three
+    /// tests above (and every other test in this module) call
+    /// `render_frame_with_device_recovery` DIRECTLY, so none of them can
+    /// see what happens at the layer in FRONT of it — the desktop closure's
+    /// own `dirty` predicate and `wake_action` match, the exact place a
+    /// wake-deadline source that never reaches `dirty` returns before this
+    /// function is ever called at all. This test drives that outer gate,
+    /// verbatim (not a simplification), across enough simulated wakes to
+    /// include BOTH failure-mode shapes a real run produces: the immediate
+    /// platform poke `wake_frame()` queues on every failure (arrives before
+    /// ANY real time passes — reproduced here as `now` staying put, not
+    /// advancing), and the deadline-actuated wake the wake-deadline hook
+    /// produces once `DeviceRecoveryBackoff`'s own armed instant is
+    /// actually due (reproduced as `now` jumping straight to
+    /// `next_attempt_at()`). Against the code before this fix (`dirty`
+    /// missing the `next_attempt_at().is_some()` term), the SECOND
+    /// simulated wake — the immediate poke, arriving before the deadline —
+    /// finds nothing else dirty, is silently deferred, and
+    /// `render_frame_entered`'s own tail clears `needs_redraw`; the THIRD
+    /// wake (the deadline itself, correctly actuated) then reads
+    /// `dirty == false` and returns before `render_frame_with_device_
+    /// recovery` is even called — a permanently dead device is attempted
+    /// exactly once, ever, and the closure never runs again.
+    #[test]
+    fn the_real_closure_gate_keeps_retrying_across_the_immediate_poke_and_the_deadline_wake() {
+        let realm = mount_root();
+        let backoff = DeviceRecoveryBackoff::new();
+        let mut now = Instant::now();
+
+        fn permanently_dead_backend() -> ScriptedDeviceBackend {
+            ScriptedDeviceBackend {
+                lost: true,
+                scene_outcome: Some(Err(EngineError::DeviceLost)),
+                recover_outcome: Some(Err(EngineError::DeviceLost)),
+                recover_clears_lost: false,
+                ..ScriptedDeviceBackend::healthy()
+            }
+        }
+
+        // Wake 1: the FIRST detection of the loss. What legitimately
+        // triggers it (a mid-frame loss via `ui_realm`'s own `retry_needed`
+        // arm, or the realm's very first pending paint) is out of scope
+        // for this probe, which exists to check everything AFTER it —
+        // called directly, bypassing the closure's own gate, the same way
+        // every wake in production reaches this function only once
+        // `wake_action` has already decided `Render`.
+        let mut backend = permanently_dead_backend();
+        let seed = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        assert!(
+            seed.just_failed,
+            "precondition: wake 1 is a genuine failure"
+        );
+        let mut total_attempts = 1u32;
+        let mut poke_pending = true;
+        // Measured, not argued: the busy-spin the winit backend's own
+        // `about_to_wait` module doc names (`platforms/winit/platform.rs`'s
+        // `WaitUntil(past)` failure mode) is exactly a hook that keeps
+        // answering the SAME stale deadline forever. Collecting every
+        // deadline the backoff arms across real attempts and asserting
+        // strict growth is the direct check that this hook is never one of
+        // those stale sources: each real attempt computes a FRESH deadline
+        // from the `now` it actually ran at, never reusing an old one.
+        let mut armed_deadlines = vec![seed.next_attempt_at.expect("wake 1 armed a deadline")];
+
+        for wake in 2..=12u32 {
+            // The desktop closure's own gate, verbatim (minus
+            // `inbox_redraw`, always false in this scenario and orthogonal
+            // to the property under test): `realm.needs_redraw() || realm.
+            // has_pending_work() || device_recovery_backoff.next_attempt_
+            // at().is_some()`.
+            let dirty = realm.needs_redraw()
+                || realm.has_pending_work()
+                || backoff.next_attempt_at().is_some();
+            assert!(
+                dirty,
+                "wake {wake}: the real closure gate went Skip and returned before even \
+                 checking device recovery -- the retry chain died here (total_attempts so \
+                 far: {total_attempts})"
+            );
+
+            // The wake that gets here is either the immediate platform
+            // poke `wake_frame()` queued on the previous wake's failure
+            // (arrives before any real time passes), or -- once that
+            // poke's own attempt was deferred (too early) -- the
+            // deadline-actuated wake the wake-deadline hook produces
+            // exactly at the armed instant.
+            now = if poke_pending {
+                now
+            } else {
+                backoff.next_attempt_at().unwrap_or_else(|| {
+                    panic!(
+                        "wake {wake}: dirty was true with no pending poke, so the only \
+                         remaining dirty source must be an armed deadline -- but none is \
+                         armed"
+                    )
+                })
+            };
+
+            let mut backend = permanently_dead_backend();
+            let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+            if backend.recover_attempts == 1 {
+                total_attempts += 1;
+                armed_deadlines.push(
+                    outcome
+                        .next_attempt_at
+                        .expect("a real failed attempt always arms a fresh deadline"),
+                );
+            }
+            poke_pending = outcome.just_failed;
+        }
+
+        assert!(
+            total_attempts >= 4,
+            "a persistently failing device must be retried repeatedly across the \
+             simulated idle window (immediate poke, deferred, deadline wake, repeat), not \
+             collapse to a single attempt -- total_attempts={total_attempts}"
+        );
+        assert!(
+            armed_deadlines.windows(2).all(|pair| pair[1] > pair[0]),
+            "every real attempt must arm a STRICTLY LATER deadline than the one before it \
+             -- a non-growing or repeated deadline is exactly the `WaitUntil(past)` shape \
+             the winit backend's own `about_to_wait` module doc names as a busy-spin \
+             (deadline never refreshed -> `about_to_wait` -> `WaitUntil(past)` -> \
+             `new_events` -> `request_redraw` -> repeat at 100% CPU): {armed_deadlines:?}"
+        );
+    }
+
+    /// The Android counterpart of
+    /// `the_real_closure_gate_keeps_retrying_across_the_immediate_poke_and_the_deadline_wake`
+    /// above: Android's `bootstrap_android` closure computes `dirty` from
+    /// `inbox_redraw || realm.needs_redraw() || has_pending ||
+    /// device_recovery_backoff.next_attempt_at().is_some()` — the identical
+    /// shape (`has_pending` is just that closure's own local name for
+    /// `realm.has_pending_work()`) — so this drives the same gate, with one
+    /// deliberate difference in how the "deadline wake" is simulated: this
+    /// backend has no `ControlFlow::WaitUntil` to actuate it exactly on
+    /// time. `flui-platform`'s `AndroidPlatform::run` instead re-checks
+    /// `is_deadline_due` once per already-running ~16ms idle poll (that
+    /// function's own doc), so a due deadline is caught within one
+    /// granularity step of it, not AT it — simulated here as `now` landing
+    /// `NO_PRESENT_FALLBACK_PACE` (16ms) past the deadline rather than
+    /// exactly on it.
+    #[test]
+    fn the_real_closure_gate_keeps_retrying_on_android_across_the_immediate_poke_and_the_16ms_poll()
+    {
+        let realm = mount_root();
+        let backoff = DeviceRecoveryBackoff::new();
+        let mut now = Instant::now();
+
+        fn permanently_dead_backend() -> ScriptedDeviceBackend {
+            ScriptedDeviceBackend {
+                lost: true,
+                scene_outcome: Some(Err(EngineError::DeviceLost)),
+                recover_outcome: Some(Err(EngineError::DeviceLost)),
+                recover_clears_lost: false,
+                ..ScriptedDeviceBackend::healthy()
+            }
+        }
+
+        let mut backend = permanently_dead_backend();
+        let seed = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        assert!(
+            seed.just_failed,
+            "precondition: wake 1 is a genuine failure"
+        );
+        let mut total_attempts = 1u32;
+        let mut poke_pending = true;
+
+        for wake in 2..=12u32 {
+            let inbox_redraw = false; // never true in this scenario
+            let has_pending = realm.has_pending_work();
+            let dirty = inbox_redraw
+                || realm.needs_redraw()
+                || has_pending
+                || backoff.next_attempt_at().is_some();
+            assert!(
+                dirty,
+                "wake {wake}: Android's closure gate went Skip and returned before even \
+                 checking device recovery -- the retry chain died here (total_attempts so \
+                 far: {total_attempts})"
+            );
+
+            now = if poke_pending {
+                now
+            } else {
+                // Android's own `is_deadline_due` granularity: caught on
+                // the next ~16ms poll, not exactly at the deadline.
+                backoff.next_attempt_at().unwrap_or_else(|| {
+                    panic!("wake {wake}: dirty was true with no pending poke and no armed deadline")
+                }) + super::NO_PRESENT_FALLBACK_PACE
+            };
+
+            let mut backend = permanently_dead_backend();
+            let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+            if backend.recover_attempts == 1 {
+                total_attempts += 1;
+            }
+            poke_pending = outcome.just_failed;
+        }
+
+        assert!(
+            total_attempts >= 4,
+            "a persistently failing device must be retried repeatedly on Android too, not \
+             collapse to a single attempt -- total_attempts={total_attempts}"
+        );
+    }
+
     /// A persistently failing recovery must be attempted a BOUNDED number
     /// of times over a fixed window, not once per delivered platform frame
     /// — the same property issue #556's `no_present_fallback_bounds_
@@ -8363,7 +8698,20 @@ where
                     // drain, instead of panicking the borrow.
                     let inbox_redraw = drain_owner_inbox(realm);
 
-                    let dirty = inbox_redraw || realm.needs_redraw() || realm.has_pending_work();
+                    // `device_recovery_backoff.next_attempt_at().is_some()` is a
+                    // REQUIRED fourth dirty source, not an optional extra: a
+                    // deadline wired into the wake-deadline hook (installed at
+                    // step 0d above) but absent from THIS predicate reaches
+                    // `WakeAction::Skip` and returns before
+                    // `render_frame_with_device_recovery` is ever called, no
+                    // matter how faithfully the platform actuates the wake —
+                    // see `DeviceRecoveryBackoff`'s own doc for the two paired
+                    // obligations a wake-deadline source carries and the
+                    // dropped-attempt trace that motivated this line.
+                    let dirty = inbox_redraw
+                        || realm.needs_redraw()
+                        || realm.has_pending_work()
+                        || device_recovery_backoff.next_attempt_at().is_some();
                     match wake_action(
                         scheduler.frames_enabled(),
                         dirty,
@@ -9281,6 +9629,29 @@ where
         let clipboard = owner_platform_installed(|owner| owner.shared().clipboard());
         APP_RUNTIME.with(|slot| slot.borrow().set_platform_clipboard(clipboard));
 
+        // 0b. This window's device-recovery backoff, constructed here (not
+        // down at step 6 alongside the renderer it paces) so the
+        // wake-deadline hook below can be wired to it from the start — see
+        // `bootstrap_desktop`'s matching comment.
+        let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
+
+        // 0c. Wire the wall-clock-wake hook. Unlike `install_wake_deadline_
+        // hook` (desktop's `bootstrap_desktop`), this does NOT also fold in
+        // `AppRuntime::next_wake()` (realm-level deadlines: gesture-arena
+        // timers, animation continuations) — this backend's `Platform::
+        // set_wake_deadline_hook` override is new in this same change
+        // (`flui-platform`'s `platforms/android/mod.rs`), added
+        // specifically to carry the device-recovery deadline; folding in
+        // realm-level deadlines too would change this backend's existing,
+        // untested-here wake behavior for gesture/animation timers, which
+        // is out of this fix's scope.
+        owner_platform_installed(|owner| {
+            let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
+            owner.shared().set_wake_deadline_hook(Box::new(move || {
+                device_recovery_backoff.next_attempt_at()
+            }));
+        });
+
         // 1. Open window (wraps the existing ANativeWindow). `Ready` is
         // guaranteed inside `on_ready` (ADR-0039 §1).
         let options: WindowOptions = (&config).into();
@@ -9373,12 +9744,8 @@ where
         // 6. Register frame callback -- with hot-reload plugin override
         let renderer_frame = Arc::clone(&renderer);
         let hot_reload_frame = hot_reload.clone();
-        // One backoff per window, living across every wake this closure is
-        // called for — same `Arc`'d-and-recloned shape as
-        // `renderer_frame`/`bootstrap_desktop`'s own copy; see
-        // `DeviceRecoveryBackoff`'s own doc for why it needs to be `Arc`'d
-        // at all rather than just moved.
-        let device_recovery_backoff = Arc::new(DeviceRecoveryBackoff::new());
+        // Reuses the SAME backoff constructed at step 0b (already wired
+        // into the wake-deadline hook above) — not a fresh one.
         window.on_request_frame(Box::new(move || {
             let renderer_frame = Arc::clone(&renderer_frame);
             let hot_reload_frame = hot_reload_frame.clone();
@@ -9408,7 +9775,18 @@ where
                     drop(r);
 
                     let has_pending = realm.has_pending_work();
-                    let dirty = inbox_redraw || realm.needs_redraw() || has_pending;
+                    // See the desktop closure's matching comment: a wake-
+                    // deadline source (here, `set_wake_deadline_hook` forces
+                    // a dispatch once due — `flui-platform`'s
+                    // `platforms/android/mod.rs`'s own `run` loop) that is
+                    // absent from `dirty` reaches `WakeAction::Skip` and
+                    // returns before this closure ever calls `render_frame_
+                    // with_device_recovery`, no matter how faithfully the
+                    // platform actuates the wake.
+                    let dirty = inbox_redraw
+                        || realm.needs_redraw()
+                        || has_pending
+                        || device_recovery_backoff.next_attempt_at().is_some();
                     let scheduler = realm.scheduler();
                     match wake_action(
                         scheduler.frames_enabled(),

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -310,16 +310,17 @@ impl RealmRegistry {
         self.slots.is_empty()
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "shared-reference lookup; every production call site so far checks a slot \
-                      out via get_mut (the checkout-based dispatch/visit pattern) -- exercised \
-                      by this crate's own tests, which only need to read a slot back, never \
-                      mutate it"
-        )
-    )]
+    /// A read-only checkout: unlike [`Self::get_mut`] (the checkout-based
+    /// dispatch/visit pattern every OTHER call site uses), this never removes
+    /// `realm` from its slot — so it is exactly what a peek that must not
+    /// disturb an in-flight checkout needs. First production caller: the
+    /// desktop wake-deadline hook's `frames_enabled` lookup
+    /// (`runner.rs`'s `bootstrap_desktop`, step 3d) reads a realm's
+    /// scheduler state from a callback the platform invokes independently of
+    /// any dispatch, where a `get_mut`-style checkout would be both
+    /// unnecessary and wrong (it has nothing to mutate, and checking a realm
+    /// out here would make it briefly invisible to a real dispatch racing
+    /// against this read).
     pub(super) fn get(&self, id: &RealmId) -> Option<&RealmSlot> {
         self.slots
             .iter()

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -321,6 +321,9 @@ impl RealmRegistry {
     /// unnecessary and wrong (it has nothing to mutate, and checking a realm
     /// out here would make it briefly invisible to a real dispatch racing
     /// against this read).
+    // Its only production caller is the desktop wake-deadline hook, which
+    // wasm does not build.
+    #[cfg(any(test, not(target_arch = "wasm32")))]
     pub(super) fn get(&self, id: &RealmId) -> Option<&RealmSlot> {
         self.slots
             .iter()

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1467,6 +1467,53 @@ impl UiRealm {
         presentation.mark_redraw_pending();
     }
 
+    /// Force the primary presentation to repaint on its next pump segment
+    /// even though nothing in the widget tree itself changed — for a
+    /// renderer-side reason the build/layout/paint pipeline has no way to
+    /// observe on its own. The one production caller today: a GPU device
+    /// recovery (`runner.rs`'s `render_frame_with_device_recovery`), where
+    /// the recovered device's backing store was invalidated by the loss —
+    /// `Renderer::recover` already primes a full repaint
+    /// (`damage_tracker.mark_full_repaint`) for whatever scene reaches it
+    /// next, but nothing reaches it at all unless something forces one.
+    ///
+    /// [`Self::request_redraw`] ALONE is necessary but not sufficient for
+    /// that: it opens `draw_frame_entered`'s per-presentation segment gate
+    /// (`PresentationState::mark_redraw_pending`, read by
+    /// `take_redraw_pending`), which is REQUIRED for the segment to run at
+    /// all — but an otherwise-unchanged tree, even with that gate open,
+    /// still produces `FramePaintOutcome::Idle` and never reaches
+    /// `render_scene`, because `PipelineOwner` tracks its own dirty state
+    /// independently of the clock's demand mechanism (confirmed by a
+    /// probe, not assumed: `should_run_segment()` correctly read `true`
+    /// with `request_redraw` alone, and the pipeline still produced
+    /// `Idle`). Marking the root render object dirty
+    /// (`PipelineOwner::mark_needs_layout`) is what gives the pipeline
+    /// actual work to redo — the same stand-in the `SurfaceLost` retry
+    /// test already uses by hand (`ui_realm.rs`'s
+    /// `surface_lost_retry_preserves_the_original_input_epoch_for_the_presented_frame`),
+    /// promoted here to a real, reusable production path instead of a
+    /// test-only workaround.
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            dead_code,
+            reason = "the only production caller is the desktop/Android device-recovery \
+                      path (runner.rs's render_frame_with_device_recovery); web's own \
+                      recovery stays un-unified and pokes `wake_handle()` directly instead \
+                      -- see that call site's own comment"
+        )
+    )]
+    pub(crate) fn mark_primary_needs_full_repaint(&self) {
+        self.request_redraw();
+        let primary = self.presentations.primary();
+        primary.renderer().root_pipeline_owner().with_mut(|owner| {
+            if let Some(root_id) = owner.root_id() {
+                owner.mark_needs_layout(root_id);
+            }
+        });
+    }
+
     /// Whether a redraw is needed.
     pub(crate) fn needs_redraw(&self) -> bool {
         self.needs_redraw.load(Ordering::Relaxed)
@@ -7439,6 +7486,34 @@ mod tests {
             }
         }
 
+        /// A raster backend that always reports `SurfaceValidation` — this
+        /// module's own minimal double for
+        /// `surface_validation_retry_preserves_the_original_input_epoch_for_the_presented_frame`
+        /// below, the `SurfaceValidation` counterpart of
+        /// [`AlwaysDeviceLostBackend`].
+        struct AlwaysSurfaceValidationBackend;
+
+        impl RasterBackend for AlwaysSurfaceValidationBackend {
+            fn render_scene(&mut self, _scene: &Scene) -> Result<bool, EngineError> {
+                Err(EngineError::SurfaceValidation)
+            }
+            fn resize(&mut self, _width: u32, _height: u32) {}
+            fn is_device_lost(&self) -> bool {
+                false
+            }
+            fn mark_dirty(&mut self, _rect: flui_types::Rect<flui_types::geometry::Pixels>) {}
+            fn mark_full_repaint(&mut self) {}
+            fn has_damage(&self) -> bool {
+                true
+            }
+            fn size(&self) -> (u32, u32) {
+                (800, 600)
+            }
+            fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+                Ok(())
+            }
+        }
+
         /// END-STATE INVARIANT: at N=1 -- a clock that is
         /// never hidden and never backpressured -- the segment gate's
         /// decision (`clock.poll().should_run_segment()`, fed `Dirty`
@@ -8980,6 +9055,80 @@ mod tests {
             // Retry: standing in for the renderer owner's recovery + wake,
             // same as the `SurfaceLost` pin above -- mark the root dirty
             // directly rather than actually rebuilding a device.
+            let primary = realm.presentations.primary();
+            primary.renderer().root_pipeline_owner().with_mut(|owner| {
+                if let Some(root_id) = owner.root_id() {
+                    owner.mark_needs_layout(root_id);
+                }
+            });
+            primary.mark_redraw_pending();
+            let mut succeeding_backend = AlwaysPresentBackend;
+            let presented = realm.render_frame_entered(&mut succeeding_backend);
+            assert!(presented, "the retry must actually reach present()");
+
+            let after_retry = realm.presentations.primary().clock().frames_since(None);
+            assert_eq!(
+                after_retry.len(),
+                2,
+                "the retry adds a second snapshot alongside the failed attempt's"
+            );
+            let retry_snapshot = &after_retry[1];
+            assert_eq!(
+                retry_snapshot.present_outcome,
+                flui_scheduler::PresentOutcome::Presented
+            );
+            assert_eq!(
+                retry_snapshot.latencies().count(),
+                1,
+                "the presented retry frame must carry the ORIGINAL input epoch -- retaining \
+                 it across the failed attempt must not have lost it"
+            );
+        }
+
+        /// The `SurfaceValidation` counterpart to both pins above. Named
+        /// finding: flipping `EpochDisposition::Retain` back to `Drain` on
+        /// the `SurfaceValidation` arm specifically was NOT caught by
+        /// anything in the suite before this test existed — 281/281 stayed
+        /// green under that flip, because `surface_validation_keeps_needs_
+        /// redraw_armed_for_a_retry` only pins the `needs_redraw` half of
+        /// the fix, never epoch attribution. Same input -> failure -> retry
+        /// -> attribution sequence as the two pins above, substituting
+        /// `SurfaceValidation` for `DeviceLost`/`SurfaceLost`.
+        #[test]
+        fn surface_validation_retry_preserves_the_original_input_epoch_for_the_presented_frame() {
+            use flui_interaction::events::{PointerType, make_down_event};
+            use flui_types::geometry::{Offset, Pixels};
+
+            let realm = mount_root_here();
+            let primary_id = realm.presentations.primary().id();
+
+            let down = make_down_event(Offset::new(Pixels(0.0), Pixels(0.0)), PointerType::Mouse);
+            realm.enter(|realm| {
+                realm.handle_input_addressed(primary_id, PlatformInput::Pointer(down));
+            });
+
+            // First attempt: the surface fails validation. A retry is
+            // armed, and the failed attempt's own snapshot must still see
+            // the epoch that was pending (diagnostic value), but must NOT
+            // consume it.
+            let mut failing_backend = AlwaysSurfaceValidationBackend;
+            let presented = realm.render_frame_entered(&mut failing_backend);
+            assert!(!presented, "SurfaceValidation never reaches present()");
+            let after_failure = realm.presentations.primary().clock().frames_since(None);
+            assert_eq!(
+                after_failure.len(),
+                1,
+                "the failed attempt is still recorded, for diagnostics"
+            );
+            assert_eq!(
+                after_failure[0].latencies().count(),
+                1,
+                "the failed attempt's own snapshot still reports the pending epoch"
+            );
+
+            // Retry: standing in for the external reconfigure a later
+            // wake performs, same as the pins above -- mark the root dirty
+            // directly rather than actually reconfiguring a surface.
             let primary = realm.presentations.primary();
             primary.renderer().root_pipeline_owner().with_mut(|owner| {
                 if let Some(root_id) = owner.root_id() {

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1487,13 +1487,25 @@ impl UiRealm {
     /// independently of the clock's demand mechanism (confirmed by a
     /// probe, not assumed: `should_run_segment()` correctly read `true`
     /// with `request_redraw` alone, and the pipeline still produced
-    /// `Idle`). Marking the root render object dirty
-    /// (`PipelineOwner::mark_needs_layout`) is what gives the pipeline
-    /// actual work to redo — the same stand-in the `SurfaceLost` retry
-    /// test already uses by hand (`ui_realm.rs`'s
-    /// `surface_lost_retry_preserves_the_original_input_epoch_for_the_presented_frame`),
-    /// promoted here to a real, reusable production path instead of a
-    /// test-only workaround.
+    /// `Idle`). Marking the root render object dirty is what gives the
+    /// pipeline actual work to redo.
+    ///
+    /// [`PipelineOwner::mark_needs_paint`], deliberately NOT `mark_needs_
+    /// layout`: layout has not changed across a device loss — only the
+    /// PAINTED OUTPUT needs to be resubmitted, since the recovered
+    /// device's backing store (not the widget tree's geometry) is what was
+    /// invalidated. `mark_needs_paint` is sufficient because paint is
+    /// already a full-tree descent every frame in this codebase (see
+    /// `docs/` notes on that shape) — marking just the root non-Idle is
+    /// enough for the descent to cover everything beneath it; forcing a
+    /// full RELAYOUT of the whole tree for a purely renderer-side backing-
+    /// store loss would be strictly heavier than the fix needs. Verified,
+    /// not assumed: swapping this one call site is what the SurfaceLost
+    /// retry test's by-hand stand-in (`ui_realm.rs`'s
+    /// `surface_lost_retry_preserves_the_original_input_epoch_for_the_presented_frame`)
+    /// also uses `mark_needs_layout` for, but that stand-in predates this
+    /// method and was never revisited against the lighter mark — this is
+    /// the first real (non-test) caller, and it takes the lighter one.
     #[cfg_attr(
         target_arch = "wasm32",
         expect(
@@ -1504,12 +1516,20 @@ impl UiRealm {
                       -- see that call site's own comment"
         )
     )]
+    // TODO(#559): marks `self.presentations.primary()` unconditionally --
+    // a realm with a non-primary presentation hosting the device that just
+    // recovered would mark the WRONG presentation's tree. Latent today
+    // only because a secondary window carries no widget content yet
+    // (`open_secondary_window`'s own doc); #559's addressing slice is
+    // where this needs to become presentation-addressed, matching how
+    // `render_frame_with_device_recovery` itself is still single-renderer/
+    // single-presentation shaped.
     pub(crate) fn mark_primary_needs_full_repaint(&self) {
         self.request_redraw();
         let primary = self.presentations.primary();
         primary.renderer().root_pipeline_owner().with_mut(|owner| {
             if let Some(root_id) = owner.root_id() {
-                owner.mark_needs_layout(root_id);
+                owner.mark_needs_paint(root_id);
             }
         });
     }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -2281,26 +2281,66 @@ impl UiRealm {
                 }
                 Err(EngineError::DeviceLost) => {
                     producer.record_frame_dropped();
+                    // `Retain`, not `Drain`: this arm now arms a retry
+                    // (`retry_needed = true` below), and the eventual real
+                    // submit that retry produces must still find the epochs
+                    // that arrived before this failure — see
+                    // `record_submit_telemetry`'s own doc.
                     Self::record_submit_telemetry(
                         producer,
                         submit_at,
                         PresentOutcome::Errored,
-                        EpochDisposition::Drain,
+                        EpochDisposition::Retain,
                     );
+                    // Division of labor with the platform runner's own
+                    // recovery wake (`render_frame_with_device_recovery` in
+                    // `runner.rs`): this arm only ever runs once
+                    // `render_scene` was actually called, i.e. there was
+                    // dirty content to submit — it owns the retry for a
+                    // loss OBSERVED MID-FRAME, for every `RasterBackend`
+                    // consumer (headless included), not just the desktop/
+                    // Android runners. A loss discovered on a quiescent
+                    // loop, before anything is dirty enough to reach
+                    // `render_scene` at all, never reaches this arm
+                    // (`draw_frame_entered` produces `Idle`, nothing to
+                    // submit) — that gap is what the runner's own wake on a
+                    // FAILED pre-frame recovery attempt covers instead. The
+                    // two are non-overlapping, not redundant.
+                    retry_needed = true;
                     tracing::warn!(
-                        "GPU device lost — recovery will be attempted by the platform runner"
+                        "GPU device lost; frame dropped — retry armed, recovery is \
+                         attempted by the renderer owner"
                     );
                 }
                 Err(EngineError::SurfaceValidation) => {
                     producer.record_frame_dropped();
+                    // `Retain`, not `Drain`: this arm now arms a retry, and
+                    // the eventual real submit that retry produces must
+                    // still find the epochs that arrived before this
+                    // failure — see `record_submit_telemetry`'s own doc.
                     Self::record_submit_telemetry(
                         producer,
                         submit_at,
                         PresentOutcome::Errored,
-                        EpochDisposition::Drain,
+                        EpochDisposition::Retain,
                     );
+                    // Retry armed for the same reason as `DeviceLost`
+                    // above. NOTE: as of this change the wgpu backend does
+                    // NOT yet reconfigure the surface before the retry's
+                    // own acquire attempt — `Renderer::acquire_surface_
+                    // texture`'s `Validation` arm gaining its own
+                    // reconfigure-and-retry-once (with its own test) ships
+                    // separately. Until it lands, an armed retry here
+                    // re-attempts the identical acquire and may keep
+                    // failing; arming it anyway is still strictly better
+                    // than the alternative (a permanently dropped frame
+                    // with nothing ever retrying it), and gives a
+                    // transient validation error the chance to clear on a
+                    // later wake.
+                    retry_needed = true;
                     tracing::error!(
-                        "Surface validation error — surface misconfig; external reconfigure required"
+                        "Surface validation error — surface misconfig; retry armed for \
+                         the next wake"
                     );
                 }
                 Err(e) => {
@@ -5381,6 +5421,51 @@ mod tests {
         }
 
         #[test]
+        fn device_lost_keeps_needs_redraw_armed_for_a_retry() {
+            let realm = mount_root();
+            let mut backend = ScriptedRasterBackend::new(Err(EngineError::DeviceLost));
+
+            realm.mark_rendered();
+            let presented = realm.render_frame_entered(&mut backend);
+
+            assert!(!presented, "a DeviceLost frame never reaches present()");
+            assert_eq!(
+                backend.render_scene_calls, 1,
+                "precondition: the mounted scene actually reached render_scene"
+            );
+            assert!(
+                realm.needs_redraw(),
+                "a dropped DeviceLost frame must re-arm needs_redraw: rebuilding the \
+                 device is the renderer owner's job, but on a quiescent loop nothing \
+                 else would ever wake the owner to retry the recovery"
+            );
+        }
+
+        #[test]
+        fn surface_validation_keeps_needs_redraw_armed_for_a_retry() {
+            let realm = mount_root();
+            let mut backend = ScriptedRasterBackend::new(Err(EngineError::SurfaceValidation));
+
+            realm.mark_rendered();
+            let presented = realm.render_frame_entered(&mut backend);
+
+            assert!(
+                !presented,
+                "a SurfaceValidation frame never reaches present()"
+            );
+            assert_eq!(
+                backend.render_scene_calls, 1,
+                "precondition: the mounted scene actually reached render_scene"
+            );
+            assert!(
+                realm.needs_redraw(),
+                "a dropped SurfaceValidation frame must re-arm needs_redraw so a later \
+                 wake gets another acquire attempt instead of parking the misconfigured \
+                 surface forever"
+            );
+        }
+
+        #[test]
         fn a_successful_frame_still_clears_needs_redraw() {
             let realm = mount_root();
             let mut backend = ScriptedRasterBackend::new(Ok(true));
@@ -7325,6 +7410,35 @@ mod tests {
             }
         }
 
+        /// A raster backend that always reports `DeviceLost` — this
+        /// module's own minimal double for
+        /// `device_lost_retry_preserves_the_original_input_epoch_for_the_presented_frame`
+        /// below, kept separate from [`AlwaysErrorsBackend`] (which is
+        /// dedicated to the `SurfaceLost` pin) so each test's backend name
+        /// says exactly which failure it scripts.
+        struct AlwaysDeviceLostBackend;
+
+        impl RasterBackend for AlwaysDeviceLostBackend {
+            fn render_scene(&mut self, _scene: &Scene) -> Result<bool, EngineError> {
+                Err(EngineError::DeviceLost)
+            }
+            fn resize(&mut self, _width: u32, _height: u32) {}
+            fn is_device_lost(&self) -> bool {
+                false
+            }
+            fn mark_dirty(&mut self, _rect: flui_types::Rect<flui_types::geometry::Pixels>) {}
+            fn mark_full_repaint(&mut self) {}
+            fn has_damage(&self) -> bool {
+                true
+            }
+            fn size(&self) -> (u32, u32) {
+                (800, 600)
+            }
+            fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+                Ok(())
+            }
+        }
+
         /// END-STATE INVARIANT: at N=1 -- a clock that is
         /// never hidden and never backpressured -- the segment gate's
         /// decision (`clock.poll().should_run_segment()`, fed `Dirty`
@@ -8794,6 +8908,78 @@ mod tests {
             // driver loop would eventually have from whatever caused this
             // presentation to need a NEW frame. Mark the root dirty
             // directly, standing in for that external cause.
+            let primary = realm.presentations.primary();
+            primary.renderer().root_pipeline_owner().with_mut(|owner| {
+                if let Some(root_id) = owner.root_id() {
+                    owner.mark_needs_layout(root_id);
+                }
+            });
+            primary.mark_redraw_pending();
+            let mut succeeding_backend = AlwaysPresentBackend;
+            let presented = realm.render_frame_entered(&mut succeeding_backend);
+            assert!(presented, "the retry must actually reach present()");
+
+            let after_retry = realm.presentations.primary().clock().frames_since(None);
+            assert_eq!(
+                after_retry.len(),
+                2,
+                "the retry adds a second snapshot alongside the failed attempt's"
+            );
+            let retry_snapshot = &after_retry[1];
+            assert_eq!(
+                retry_snapshot.present_outcome,
+                flui_scheduler::PresentOutcome::Presented
+            );
+            assert_eq!(
+                retry_snapshot.latencies().count(),
+                1,
+                "the presented retry frame must carry the ORIGINAL input epoch -- retaining \
+                 it across the failed attempt must not have lost it"
+            );
+        }
+
+        /// The `DeviceLost` counterpart to
+        /// `surface_lost_retry_preserves_the_original_input_epoch_for_the_presented_frame`
+        /// above: before this change, `DeviceLost` used `EpochDisposition::Drain`
+        /// unconditionally AND never armed a retry, so this pin would have been
+        /// meaningless either way — a mistaken `Drain` on this arm is caught
+        /// here, not just by inspection. Drives the same
+        /// input -> failure -> retry -> attribution sequence, substituting
+        /// `DeviceLost` for `SurfaceLost`.
+        #[test]
+        fn device_lost_retry_preserves_the_original_input_epoch_for_the_presented_frame() {
+            use flui_interaction::events::{PointerType, make_down_event};
+            use flui_types::geometry::{Offset, Pixels};
+
+            let realm = mount_root_here();
+            let primary_id = realm.presentations.primary().id();
+
+            let down = make_down_event(Offset::new(Pixels(0.0), Pixels(0.0)), PointerType::Mouse);
+            realm.enter(|realm| {
+                realm.handle_input_addressed(primary_id, PlatformInput::Pointer(down));
+            });
+
+            // First attempt: the device is lost. A retry is armed, and the
+            // failed attempt's own snapshot must still see the epoch that
+            // was pending (diagnostic value), but must NOT consume it.
+            let mut failing_backend = AlwaysDeviceLostBackend;
+            let presented = realm.render_frame_entered(&mut failing_backend);
+            assert!(!presented, "DeviceLost never reaches present()");
+            let after_failure = realm.presentations.primary().clock().frames_since(None);
+            assert_eq!(
+                after_failure.len(),
+                1,
+                "the failed attempt is still recorded, for diagnostics"
+            );
+            assert_eq!(
+                after_failure[0].latencies().count(),
+                1,
+                "the failed attempt's own snapshot still reports the pending epoch"
+            );
+
+            // Retry: standing in for the renderer owner's recovery + wake,
+            // same as the `SurfaceLost` pin above -- mark the root dirty
+            // directly rather than actually rebuilding a device.
             let primary = realm.presentations.primary();
             primary.renderer().root_pipeline_owner().with_mut(|owner| {
                 if let Some(root_id) = owner.root_id() {

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -574,8 +574,15 @@ enum FramePaintOutcome {
 /// records, or merely reads them without consuming them.
 ///
 /// `Retain` exists for exactly one shape: a submit failure whose own caller
-/// has already armed a retry (`EngineError::SurfaceLost` in
-/// [`UiRealm::render_frame_entered`]) — draining there would leave the
+/// has already armed a retry. **Three** arms in
+/// [`UiRealm::render_frame_entered`] are that shape — `SurfaceLost`,
+/// `DeviceLost` and `SurfaceValidation`. The latter two joined when device
+/// loss gained a retry at all; before that they drained, and this sentence
+/// named only `SurfaceLost`. Each is pinned by its own
+/// `*_retry_preserves_the_original_input_epoch_for_the_presented_frame`
+/// test, so flipping any of the three back to `Drain` turns one red — the
+/// invariant used to be documentation alone. Draining on such an arm
+/// leaves the
 /// eventual retry's own real submit with nothing pending to attribute to
 /// the frame that actually reaches the screen, so the inputs that arrived
 /// before the failure would never be attributed to any frame at all. Every

--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -56,18 +56,61 @@ use crate::{
 };
 
 /// Whether the registered wake-deadline hook's answer means `run`'s loop
-/// should force a frame dispatch THIS iteration, even though nothing
-/// explicitly requested a redraw. Pulled out of `run`'s loop as its own
-/// pure, free function — unlike the rest of that loop, which needs a live
-/// `AndroidApp` (constructible only by the real Android runtime; no test
-/// double exists for it, so `run` itself cannot be exercised in a unit
-/// test on any host) — this one decision is entirely independent of that
-/// and is exactly the property this backend's new wake-deadline actuation
-/// rests on: `None` (no hook installed, or the hook itself has nothing
-/// pending) never forces a dispatch; `Some(deadline)` forces one once, and
-/// only once, `now` has reached it.
+/// should WANT to force a frame dispatch this iteration, even though
+/// nothing explicitly requested a redraw. Pulled out of `run`'s loop as its
+/// own pure, free function — unlike the rest of that loop, which needs a
+/// live `AndroidApp` (constructible only by the real Android runtime; no
+/// test double exists for it, so `run` itself cannot be exercised in a unit
+/// test on any host) — this one decision is entirely independent of that:
+/// `None` (no hook installed, or the hook itself has nothing pending) is
+/// never due; `Some(deadline)` is due once `now` has reached it.
+///
+/// This function is STATELESS and NOT self-limiting: called again with the
+/// same `deadline` and a `now` that has not gone backwards, it answers
+/// `true` again, and keeps answering `true` on every subsequent call until
+/// either `deadline` itself advances/clears or `now` regresses (it never
+/// does). It does not know, and cannot know, whether some earlier call's
+/// `true` already caused a dispatch — it has no memory of ever being
+/// called before. Something else has to be the actuator that stops asking:
+/// either the deadline source's own consumer advances `deadline` in
+/// response to acting on it (the desktop/Android device-recovery backoff
+/// does this — see `DeviceRecoveryBackoff`'s two paired obligations), or
+/// the CALLER stops treating "due" as "act now" once acting is impossible
+/// (`run`'s loop does this by gating this answer's effect on `should_render`
+/// on `resumed` — see that call site's own comment for the busy-spin this
+/// prevents while backgrounded). Read this function's own `true` as "the
+/// deadline has passed", never as "and therefore something happened".
 fn is_deadline_due(deadline: Option<web_time::Instant>, now: web_time::Instant) -> bool {
     deadline.is_some_and(|deadline| now >= deadline)
+}
+
+/// Whether `run`'s loop should force a zero-timeout `poll_events` call (and,
+/// once actually dispatched a few lines later, a frame) THIS iteration.
+///
+/// `redraw_requested` passes through unconditionally: it comes from
+/// [`AndroidWindow::take_redraw_request`](super::window::AndroidWindow::take_redraw_request), which
+/// consumes on read (an atomic swap to `false`), so it is already
+/// self-limiting the way [`is_deadline_due`] is NOT — one call answering
+/// `true` clears it for every subsequent call until something re-arms it.
+///
+/// `deadline_due` is gated on `resumed` because it carries no such
+/// self-limiting property, and round 6 found what happens when it is
+/// counted in unconditionally: with the app paused and a deadline armed —
+/// which device loss and `MainEvent::Pause` are frequently the same
+/// real-world event for — `is_deadline_due` answers `true` on every
+/// iteration (see its own doc: it is stateless), forcing a 0ms
+/// `poll_events` timeout every iteration, while the actual dispatch this
+/// would be for stays gated on `resumed` too (`run`'s loop, a few lines
+/// below this decision) and so never runs — nothing ever consumes the
+/// deadline, and the loop spins at 100% CPU on a backgrounded phone for as
+/// long as it stays paused. Gating here means a due-but-unconsumable
+/// deadline instead falls through to the ordinary ~16ms idle timeout; it is
+/// not lost, only deferred — the moment a real `MainEvent::Resume` arrives,
+/// the wake-deadline hook is re-consulted on the very next iteration (that
+/// read is unconditional and never cached) and a still-due deadline is
+/// caught then.
+fn should_force_render_poll(resumed: bool, deadline_due: bool, redraw_requested: bool) -> bool {
+    (resumed && deadline_due) || redraw_requested
 }
 
 /// Android platform implementation using `android-activity`
@@ -245,22 +288,16 @@ impl Platform for AndroidPlatform {
             let wake_deadline = wake_deadline_hook.and_then(|hook| hook());
             let deadline_due = is_deadline_due(wake_deadline, web_time::Instant::now());
 
-            // Check if we should render before polling. `deadline_due`
-            // forces a dispatch even though nothing explicitly requested a
-            // redraw -- this is what lets a wake-deadline consumer (e.g.
-            // `flui-app`'s device-recovery retry backoff) actually get
-            // re-checked on this backend: unlike winit, Android has no
-            // `ControlFlow::WaitUntil` to fall back on, so the deadline is
-            // actuated by forcing this loop's own already-running ~16ms
-            // idle poll to dispatch a frame once due, rather than by a
-            // separate wait primitive. Granularity is therefore bounded by
-            // the idle timeout below (~16ms), not exact to the deadline.
-            let should_render = deadline_due
-                || platform
-                    .window
-                    .lock()
-                    .as_ref()
-                    .is_some_and(|w| w.take_redraw_request());
+            // Check if we should render before polling — see
+            // `should_force_render_poll`'s own doc for why `deadline_due`'s
+            // contribution is gated on `resumed` and `redraw_requested`'s is
+            // not.
+            let redraw_requested = platform
+                .window
+                .lock()
+                .as_ref()
+                .is_some_and(|w| w.take_redraw_request());
+            let should_render = should_force_render_poll(resumed, deadline_due, redraw_requested);
 
             let timeout = if should_render {
                 Duration::from_millis(0)
@@ -532,22 +569,22 @@ impl PlatformDisplay for AndroidDisplay {
 mod wake_deadline_tests {
     use std::time::Duration;
 
-    use super::is_deadline_due;
+    use super::{is_deadline_due, should_force_render_poll};
 
     #[test]
-    fn no_hook_or_an_empty_hook_never_forces_a_dispatch() {
+    fn no_hook_or_an_empty_hook_is_never_due() {
         assert!(!is_deadline_due(None, web_time::Instant::now()));
     }
 
     #[test]
-    fn a_future_deadline_does_not_force_a_dispatch_yet() {
+    fn a_future_deadline_is_not_due_yet() {
         let now = web_time::Instant::now();
         let deadline = now + Duration::from_millis(16);
         assert!(!is_deadline_due(Some(deadline), now));
     }
 
     #[test]
-    fn a_due_or_past_deadline_forces_a_dispatch() {
+    fn a_due_or_past_deadline_is_due() {
         let now = web_time::Instant::now();
         let deadline = now
             .checked_sub(Duration::from_millis(1))
@@ -557,5 +594,59 @@ mod wake_deadline_tests {
             is_deadline_due(Some(now), now),
             "exactly-now must count as due, not just strictly-past"
         );
+    }
+
+    /// The property this function's own doc leads with: it is stateless, so
+    /// a due deadline stays due across repeated calls with the same
+    /// arguments — it does not remember having already answered `true`. Any
+    /// self-limiting behavior (stopping the loop from re-asking, or
+    /// stopping "due" from re-forcing an action once nothing can act on it)
+    /// has to live in a caller, never here.
+    #[test]
+    fn a_due_deadline_stays_due_across_repeated_calls_with_unchanged_arguments() {
+        let now = web_time::Instant::now();
+        let deadline = now
+            .checked_sub(Duration::from_secs(1))
+            .expect("now is far past the epoch");
+        for _ in 0..5 {
+            assert!(
+                is_deadline_due(Some(deadline), now),
+                "is_deadline_due must not self-extinguish -- it has no state to extinguish"
+            );
+        }
+    }
+
+    /// Round 6's finding, pinned directly: a due deadline must NOT force a
+    /// render poll while paused, because nothing downstream would consume
+    /// it (the actual dispatch is gated on `resumed` too) — reported
+    /// unconditionally, this is a 100% CPU spin on a backgrounded phone for
+    /// as long as it stays paused, since `is_deadline_due` has no memory of
+    /// already having said "yes" once (see its own doc).
+    #[test]
+    fn a_due_deadline_does_not_force_a_render_poll_while_paused() {
+        assert!(
+            !should_force_render_poll(false, true, false),
+            "paused + due + no explicit redraw request must fall through to the ordinary idle \
+             timeout, not force a 0ms poll nobody can act on"
+        );
+    }
+
+    #[test]
+    fn a_due_deadline_forces_a_render_poll_while_resumed() {
+        assert!(should_force_render_poll(true, true, false));
+    }
+
+    #[test]
+    fn an_explicit_redraw_request_forces_a_render_poll_regardless_of_resumed_or_deadline_state() {
+        // `redraw_requested` is already self-limiting (consume-on-read), so
+        // unlike `deadline_due` it is never gated on `resumed` here.
+        assert!(should_force_render_poll(false, false, true));
+        assert!(should_force_render_poll(true, false, true));
+    }
+
+    #[test]
+    fn nothing_pending_never_forces_a_render_poll() {
+        assert!(!should_force_render_poll(false, false, false));
+        assert!(!should_force_render_poll(true, false, false));
     }
 }

--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -55,6 +55,21 @@ use crate::{
     },
 };
 
+/// Whether the registered wake-deadline hook's answer means `run`'s loop
+/// should force a frame dispatch THIS iteration, even though nothing
+/// explicitly requested a redraw. Pulled out of `run`'s loop as its own
+/// pure, free function — unlike the rest of that loop, which needs a live
+/// `AndroidApp` (constructible only by the real Android runtime; no test
+/// double exists for it, so `run` itself cannot be exercised in a unit
+/// test on any host) — this one decision is entirely independent of that
+/// and is exactly the property this backend's new wake-deadline actuation
+/// rests on: `None` (no hook installed, or the hook itself has nothing
+/// pending) never forces a dispatch; `Some(deadline)` forces one once, and
+/// only once, `now` has reached it.
+fn is_deadline_due(deadline: Option<web_time::Instant>, now: web_time::Instant) -> bool {
+    deadline.is_some_and(|deadline| now >= deadline)
+}
+
 /// Android platform implementation using `android-activity`
 ///
 /// Wraps the `AndroidApp` provided by `android_main()` and implements the
@@ -217,12 +232,35 @@ impl Platform for AndroidPlatform {
                 break;
             }
 
-            // Check if we should render before polling
-            let should_render = platform
-                .window
-                .lock()
-                .as_ref()
-                .is_some_and(|w| w.take_redraw_request());
+            // Wall-clock wake (mirrors the winit backend's `about_to_wait`):
+            // consult the registered wake-deadline hook fresh on EVERY
+            // iteration -- a deadline that fires, a new one getting armed,
+            // or every deadline clearing must all be reflected immediately,
+            // not stale from whenever the hook was installed. Lock
+            // discipline (ADR-0038 §5, the same rule winit's own
+            // `about_to_wait` follows): the hook itself re-enters
+            // `flui-app` -- clone the `Arc` out, drop the lock, THEN call
+            // it, never while `platform.handlers` is still held.
+            let wake_deadline_hook = platform.handlers.lock().wake_deadline.clone();
+            let wake_deadline = wake_deadline_hook.and_then(|hook| hook());
+            let deadline_due = is_deadline_due(wake_deadline, web_time::Instant::now());
+
+            // Check if we should render before polling. `deadline_due`
+            // forces a dispatch even though nothing explicitly requested a
+            // redraw -- this is what lets a wake-deadline consumer (e.g.
+            // `flui-app`'s device-recovery retry backoff) actually get
+            // re-checked on this backend: unlike winit, Android has no
+            // `ControlFlow::WaitUntil` to fall back on, so the deadline is
+            // actuated by forcing this loop's own already-running ~16ms
+            // idle poll to dispatch a frame once due, rather than by a
+            // separate wait primitive. Granularity is therefore bounded by
+            // the idle timeout below (~16ms), not exact to the deadline.
+            let should_render = deadline_due
+                || platform
+                    .window
+                    .lock()
+                    .as_ref()
+                    .is_some_and(|w| w.take_redraw_request());
 
             let timeout = if should_render {
                 Duration::from_millis(0)
@@ -395,6 +433,20 @@ impl Platform for AndroidPlatform {
         self.handlers.lock().window_event = Some(callback);
     }
 
+    /// Unlike `winit`'s override (the trait's one other live implementor),
+    /// this backend has no `ControlFlow::WaitUntil` to hand the deadline
+    /// to — `run`'s own loop actuates it directly instead, by checking
+    /// `now >= deadline` once per iteration and forcing a dispatch when due
+    /// (see that loop's own comment). Storage is the identical
+    /// `PlatformHandlers::wake_deadline` slot winit uses, for the same
+    /// `Arc`-cloned-out-of-the-lock consultation discipline (ADR-0038 §5).
+    fn set_wake_deadline_hook(
+        &self,
+        hook: Box<dyn Fn() -> Option<web_time::Instant> + Send + Sync>,
+    ) {
+        self.handlers.lock().wake_deadline = Some(Arc::from(hook));
+    }
+
     fn app_path(&self) -> Result<PathBuf> {
         Ok(PathBuf::from("/data/local/tmp"))
     }
@@ -473,5 +525,37 @@ impl PlatformDisplay for AndroidDisplay {
 
     fn is_primary(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod wake_deadline_tests {
+    use std::time::Duration;
+
+    use super::is_deadline_due;
+
+    #[test]
+    fn no_hook_or_an_empty_hook_never_forces_a_dispatch() {
+        assert!(!is_deadline_due(None, web_time::Instant::now()));
+    }
+
+    #[test]
+    fn a_future_deadline_does_not_force_a_dispatch_yet() {
+        let now = web_time::Instant::now();
+        let deadline = now + Duration::from_millis(16);
+        assert!(!is_deadline_due(Some(deadline), now));
+    }
+
+    #[test]
+    fn a_due_or_past_deadline_forces_a_dispatch() {
+        let now = web_time::Instant::now();
+        let deadline = now
+            .checked_sub(Duration::from_millis(1))
+            .expect("now is far past the epoch");
+        assert!(is_deadline_due(Some(deadline), now));
+        assert!(
+            is_deadline_due(Some(now), now),
+            "exactly-now must count as due, not just strictly-past"
+        );
     }
 }


### PR DESCRIPTION
**Stacked on #632** (the Android lint gate), which must land first. Review this against that branch, not against `main`.

Salvages the real fix from a recovered commit written by another agent. Five review rounds; the first four each found the fix did not actually work, in a different place each time. The engine half is split to #626.

## The bug

On a quiescent loop — no input, no animations — the device-recovery **failure** arm logged the error and returned. `needs_redraw` stayed false, nothing asked for another frame, `recover()` was never retried, and the device stayed dead for the life of the process. Same hole in the wasm `Err` arm.

## Why it took five rounds: the wake had three separate ways to die

Each was found only by probing the production path rather than the function under test.

**It was clobbered.** The wake was raised *before* `render_frame_entered`, which ends in `if retry_needed { wake_frame() } else { mark_rendered() }` — and `mark_rendered()` clears the flag on any frame whose tree was clean. Raised after, instead.

**It was eaten by its own poke.** The failure wake pokes the window *immediately*, so the next wake arrives before the backoff deadline. That attempt is deferred, so nothing re-arms, `mark_rendered()` clears the flag again, and the deadline wake then finds nothing dirty and returns at the gate. An immediate poke and a deferred deadline are not independent. Total attempts against a permanently dead device: **one**.

**It did not repaint even when it worked.** `request_redraw` opens the per-presentation segment gate, but `PipelineOwner` tracks build/layout dirty state independently — so the gate reads `Produce`, the pipeline emits `Idle`, and `render_scene` is never reached. Confirmed by probe. A successful pre-frame recovery now marks the root paint-dirty (`mark_needs_paint`, not the heavier relayout the by-hand test stand-in used).

The general rule this produced: **a deadline source wired into `install_wake_deadline_hook` carries two paired obligations** — it must also appear in the frame closure's `dirty` predicate, or the wake it actuates is skipped before the work runs; and it must be self-clearing, or the hook answers the same past instant forever. `gestures().next_deadline()` is the model that satisfies both. This one satisfied neither.

## Bounding the retry

A retry with no bound is not better than no retry: on a permanently gone GPU, every wake meant a full `recover()` — instance, adapter, device, surface, painter, offscreen — plus one unthrottled `error!` per attempt. The backoff is a **deadline, not a sleep**: the first implementation slept on the event-loop thread, which blocks input for up to a second on desktop and is ANR territory on Android's main thread.

There is deliberately **no permanent give-up**. Device loss is genuinely recoverable on every platform targeted here — driver reset, app resume, eGPU replug — so an attempt cap would turn a recoverable state into a dead app.

Android had no wake-deadline mechanism at all; this adds one. Its loop already re-iterates every ~16 ms when idle, it just never consulted a deadline.

## Evidence, measured rather than argued

The test that would have caught all of this drives the **actual closure gate** — `dirty`, `wake_action`, `Skip => return` — across 12 simulated wakes covering both the immediate poke and the deadline wake. Every earlier test called the recovery function directly, which is why four rounds missed a broken gate sitting in front of it.

Over that window: **6 real recovery attempts on both desktop and Android**, with armed deadlines `16, 32, 64, 128, 256, 512 ms` asserted strictly monotonic — which is also what proves the hook is never left answering a stale past instant, the documented busy-spin shape.

`EpochDisposition::Retain` on both retrying arms, each now pinned: an arm that arms a retry must Retain, or the eventual real submit has nothing pending to attribute and the frame that reaches the screen reports no input latency. Flipping either previously left the whole suite green.

566/566 on `-p flui-app -p flui-engine`; 177/177 on `flui-platform` under the documented CI invocation; clippy clean at `--all-features` and `--no-default-features`; port-check, runtime-conformance, inventory, fmt, typos, wasm target check all clean.

## Named gaps

- **`SurfaceValidation`'s retry is honest but incomplete until #626.** Arming it today re-attempts the identical failing acquire, because no reconfigure happens anywhere yet — `renderer.rs` is untouched per the split. Stated in the arm's own comment rather than shipped silently.
- **`mark_primary_needs_full_repaint` marks the primary presentation unconditionally**, which is wrong for a realm with a forest. Latent only because a secondary window carries no widget content today; tracked under #559's addressing slice, and the method's doc says so.
- Android's new code is now gated by #632's clippy step, but still cannot be *executed* anywhere in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du3J3bDcsRaSU3tKgYKvni
