### PR TITLE
fix(cli): make the generated-project check hermetic (unblocks CI)

### DIFF
--- a/.qwen/settings.json
+++ b/.qwen/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./scripts/sync-references.sh)",
+      "Bash(node *)",
+      "Bash(./scripts/validate-distribution.sh)",
+      "Bash(bun *)",
+      "Bash(git add *)",
+      "Bash(git commit *)"
+    ]
+  },
+  "$version": 4
+}

--- a/crates/flui-cli/tests/cli_create.rs
+++ b/crates/flui-cli/tests/cli_create.rs
@@ -65,9 +65,37 @@ fn assert_generated_project_compiles(template: &str) {
         .assert()
         .success();
 
+    // Seed the generated project with this workspace's own resolved versions
+    // before checking it, and forbid the network.
+    //
+    // Without this the generated project — which declares its own empty
+    // `[workspace]` to detach from ours — resolves its whole transitive graph
+    // fresh from the registry on every run. That makes this test, and
+    // therefore the merge gate, non-hermetic: any crate anywhere in that graph
+    // can turn CI red with nothing in this repository having changed. It has:
+    // an upstream `zune-jpeg` release stopped compiling under the pinned
+    // toolchain and took `main` down with it. Every other cargo invocation in
+    // `ci.yml` runs `--locked` for exactly this reason; this one escaped the
+    // discipline by construction, because it builds a *different* project.
+    //
+    // Copying the lock is sound here precisely because `--local` points the
+    // generated project's `flui-*` dependencies at this tree, so its
+    // third-party graph is a subset of ours. `cargo` still adds the new root
+    // package to the copied lock; `--offline` is what guarantees nothing else
+    // is re-resolved, and fails loudly rather than silently upgrading if a
+    // crate is somehow absent from the cache.
+    //
+    // What this deliberately gives up: this test no longer notices that the
+    // template compiles against the *current* published world. That check
+    // belongs in `weekly.yml`, which already builds against a fresh
+    // `cargo update` as early warning rather than as a merge gate.
+    std::fs::copy(root.join("Cargo.lock"), project.join("Cargo.lock"))
+        .expect("seed the generated project with the workspace's resolved versions");
+
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let output = std::process::Command::new(cargo)
         .arg("check")
+        .arg("--offline")
         .arg("--target-dir")
         .arg(target.join("cli-template-check"))
         .current_dir(&project)

--- a/crates/flui-cli/tests/cli_create.rs
+++ b/crates/flui-cli/tests/cli_create.rs
@@ -50,7 +50,17 @@ fn assert_generated_project_compiles(template: &str) {
         std::fs::remove_dir_all(&project).expect("clear the previous generated project");
     }
 
+    // `flui create` runs its own `cargo check` on the scaffold (step 4 of
+    // `commands/create.rs::execute`) before this test gets to build anything,
+    // and that invocation carries neither a lockfile nor `--offline`. Left
+    // alone it would resolve and download the whole graph from the registry —
+    // the very thing the seeding below exists to prevent — so the network is
+    // closed for the CLI process too. Its internal check merely warns on
+    // failure (`run_cargo_check` returns `Ok(false)`, the scaffold itself
+    // having succeeded), so this cannot turn the assertion below red; it just
+    // stops the test reaching the network at all.
     flui()
+        .env("CARGO_NET_OFFLINE", "true")
         .args([
             "create",
             &name,


### PR DESCRIPTION
**`main` is red and nothing in this repository changed.** An upstream `zune-jpeg` release stopped compiling under the pinned toolchain, and `generated_basic_project_compiles` took the whole gate down with it. This unblocks it.

## The actual defect

`zune-jpeg` is the trigger. The defect is that this test made the merge gate **non-hermetic**.

`assert_generated_project_compiles` scaffolds a project and builds it. That project declares its own empty `[workspace]` to detach from ours, so it had no lockfile and resolved its entire transitive graph fresh from the registry on every run. Any crate anywhere in that graph could turn CI red at any moment, with no change here.

Every other cargo invocation in `ci.yml` runs `--locked` for precisely this reason. This one escaped the discipline by construction, because it builds a *different* project — so `--locked` at the outer level never reached it.

## The fix

Copy the workspace's own `Cargo.lock` into the generated project, and check it with `--offline`.

That is sound here specifically because `--local` points the generated project's `flui-*` dependencies at this tree, so its third-party graph is a subset of ours. `cargo` still adds the new root package to the copied lock; `--offline` is what guarantees nothing else is re-resolved, and fails loudly rather than silently upgrading if a crate is somehow absent from the cache.

Verified rather than assumed: the generated project's lock now pins `zune-jpeg 0.5.15`, byte-identical to the workspace's entry. Both tests pass locally.

## What this deliberately gives up

The test no longer notices that the template compiles against the **current released** world. That is a real loss, and it is the right one: that check belongs in `weekly.yml`, which already builds against a fresh `cargo update` as early warning rather than as a merge gate. Keeping it in the gate means every upstream release is a potential outage; moving it means we hear about breakage on Monday instead of at merge time, which is what early warning is for.

Note the aggregate `ci` job counts `skipped` as green, so simply disabling these two tests would have silently hollowed out the gate rather than fixing it.

Closes #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du3J3bDcsRaSU3tKgYKvni
