### PR TITLE
fix(port-check): retire two stale trigger-7 whitelists (#635)

### DIFF
--- a/crates/flui-engine/AGENTS.md
+++ b/crates/flui-engine/AGENTS.md
@@ -21,10 +21,10 @@ GPU rendering engine via wgpu. Converts Layer trees into GPU draw calls.
 - **`enable-wgpu-tests` feature** — gates GPU-dependent integration tests (not run in CI).
 - **`#![allow(missing_debug_implementations)]`** — wgpu handles (Device, Queue, Texture, Buffer) don't impl Debug.
 - **Outstanding refactors** (tracked in ARCHITECTURE.md):
-  - `Arc<Mutex<OffscreenRenderer>>` → direct ownership + `Backend<'a>`
   - `Arc<Mutex<TexturePoolInner>>` → direct ownership
   - Per-frame `Arc::clone` in renderer.rs → borrowed references
-  - These are whitelisted in port-check.sh triggers #5 and #7 — remove whitelist entries when refactors land.
+  - `render_scene`'s painter take/reassign pattern (the `Arc<Mutex<OffscreenRenderer>>` half of this list **landed**: `Renderer` owns its `OffscreenRenderer`, `Backend<'frame>` borrows one)
+  - The remaining two are whitelisted in port-check.sh triggers #5 and #7 — **remove the whitelist entry in the same change as the refactor**. Trigger 7's exclusions for `renderer.rs`/`backend.rs` were not removed when that refactor landed, and both files went unwatched until #635 caught it.
 - **No `async fn` in render hot paths** — enforced by port-check trigger #3. `new`/`new_offscreen` are async (setup-phase, acceptable).
 
 ## Architecture doc

--- a/crates/flui-engine/ARCHITECTURE.md
+++ b/crates/flui-engine/ARCHITECTURE.md
@@ -327,8 +327,8 @@ The replay/submit path (`render()`, `flush_segment`, `flush_segment_*`) was extr
 | `Renderer::device` / `Renderer::queue` | `Arc<wgpu::Device>` / `Arc<wgpu::Queue>` | Shared, wgpu convention | wgpu's own API uses `Arc` for these handles (cheap ref-count, not lock-protected). Shared by `WgpuPainter` and `OffscreenRenderer` via setup-phase `Arc::clone` (acceptable; not per-frame). |
 | `Renderer::surface` | `Option<wgpu::Surface<'static>>` | Owned, single-mutator | wgpu 29.x's `Surface<'_>: Send + Sync` (verified via `assert_impl_all!` in `wgpu/src/api/surface.rs`). Single-mutator enforced by code convention (only `Renderer::render_scene` calls `surface.get_current_texture`), not by trait bound. |
 | `Renderer::painter` | `Option<WgpuPainter>` | Owned, single-mutator | The take/return dance during `render_scene` is the per-frame ownership transfer. |
-| `Renderer::offscreen` | `Option<Arc<parking_lot::Mutex<OffscreenRenderer>>>` | **Mythos friction** | The lock is uncontended in production (single-mutator). Removal requires a `Backend<'a>` lifetime refactor; see [Outstanding refactors](#outstanding-refactors). |
-| `Backend::offscreen` | `Option<Arc<parking_lot::Mutex<OffscreenRenderer>>>` | **Mythos friction** | Same; symmetric with the above. |
+| `Renderer::offscreen` | `Option<super::offscreen::OffscreenRenderer>` | resolved | Owned outright. The `Backend<'a>` lifetime refactor that this waited on has landed, so the lock is gone; port-check trigger 7 now watches this file. |
+| `Backend::offscreen` | `Option<&'frame mut super::offscreen::OffscreenRenderer>` | resolved | Borrowed for the frame, symmetric with the above. |
 | `Backend::offscreen_painter` | `Option<WgpuPainter>` | Owned, single-mutator | Cross-frame painter cache; resized on demand. No lock. |
 | `WgpuPainter::device` / `WgpuPainter::queue` | `Arc<wgpu::Device>` / `Arc<wgpu::Queue>` | Shared, wgpu convention | Same as `Renderer::device`. |
 | `WgpuPainter::transform_stack` / `clip_stack` / `opacity_stack` | `Vec<T>` | Owned, single-mutator | Per-frame save/restore stacks. No lock. |

--- a/crates/flui-engine/ARCHITECTURE.md
+++ b/crates/flui-engine/ARCHITECTURE.md
@@ -175,7 +175,7 @@ The `GpuCapabilities` struct in `wgpu/renderer.rs` is the canonical capability s
 | U10 + U11 (dead_code audit + `text_renderer.rs` deletion) | ~-330 | 0 | 0 |
 | **Total** | **~-5,984** | **0** | **0** |
 
-Per-frame `Arc::clone` removal (verdict's U7) and `Arc<Mutex<OffscreenRenderer>>` + `Arc<Mutex<TexturePoolInner>>` removal (verdict's U6 + U8) were **deferred** to follow-up; see [Outstanding refactors](#outstanding-refactors).
+Per-frame `Arc::clone` removal and `Arc<Mutex<TexturePoolInner>>` removal were **deferred** to follow-up; see [Outstanding refactors](#outstanding-refactors). The `Arc<Mutex<OffscreenRenderer>>` half of that deferral has since landed -- see the resolved Friction log entry.
 
 ---
 
@@ -366,13 +366,18 @@ There is **no `unsafe impl Sync`** anywhere in the crate. Two further unsafe sur
 
 Known sites that do not yet match the methodology but are not violations of the current refusal triggers. Each entry names the site and the next planned step.
 
-### `Arc<parking_lot::Mutex<OffscreenRenderer>>` shared between `Renderer` and `Backend`
+### `Arc<parking_lot::Mutex<OffscreenRenderer>>` shared between `Renderer` and `Backend` -- RESOLVED
 
-**Sites:** [`src/wgpu/renderer.rs:147`](src/wgpu/renderer.rs) (`Renderer::offscreen` field), [`src/wgpu/renderer.rs:670`](src/wgpu/renderer.rs) (`Arc::clone(offscreen)` at `Backend::with_offscreen` construction), [`src/wgpu/renderer.rs:898, 925`](src/wgpu/renderer.rs) (`offscreen_arc.lock()` calls in `handle_backdrop_filter`), [`src/wgpu/backend.rs:26`](src/wgpu/backend.rs) (field), [`src/wgpu/backend.rs:45, 57`](src/wgpu/backend.rs) (signatures), [`src/wgpu/backend.rs:399`](src/wgpu/backend.rs) (`self.offscreen.clone()` Arc-clone bind), [`src/wgpu/backend.rs:407, 464`](src/wgpu/backend.rs) (`offscreen_arc.lock()` calls in `render_shader_mask`).
+The lock is gone. `Renderer` owns its `OffscreenRenderer` outright and `Backend<'frame>`
+borrows one for the frame, so there is no shared mutable handle and no `.lock()` on this
+path at all. Kept as a heading rather than deleted because port-check trigger 7 exists to
+catch a regression of exactly this shape, and now watches both files -- its exclusions for
+them were retired at the same time.
 
-**Violation:** none of the seven refusal triggers; the Mythos verdict §9 lists this as the canonical "Arc<Mutex<>> over single-mutator data" smell, but the lock is uncontended in production (single-mutator). The shape is a known maintenance burden, not a soundness or contention issue today.
-
-**Next planned step:** see [Outstanding refactors](#outstanding-refactors) -- the refactor requires introducing a frame lifetime `Backend<'a>` and restructuring `Renderer::render_scene`'s painter take/return pattern.
+One piece of the surrounding restructure the Outstanding-refactor entry also described did
+not land with it: `Renderer::render_scene` still uses the `self.painter.take()` /
+reassign pattern (`renderer.rs:1526`). That was an enabler for removing the lock, not the
+goal, and it is now independent of it.
 
 ### `Arc<Mutex<TexturePoolInner>>` back-reference on `PooledTexture`
 
@@ -430,22 +435,26 @@ Same shape as `painter.rs`. Mixes mask, blur, and morphological filter pipelines
 
 Concrete cleanups visible from `flui-engine` outward, sized for an `/aif-implement` dispatch. Each entry names a file and what would need to change. Each has a named concrete blocker per the no-quick-wins memo.
 
-### `Arc<parking_lot::Mutex<OffscreenRenderer>>` -> direct ownership + `Backend<'a>` frame lifetime
+### `Renderer::render_scene`'s painter take/reassign pattern
 
-**Files:** [`src/wgpu/renderer.rs`](src/wgpu/renderer.rs), [`src/wgpu/backend.rs`](src/wgpu/backend.rs).
+**Files:** [`src/wgpu/renderer.rs`](src/wgpu/renderer.rs).
 
-**Goal:** replace `Option<Arc<parking_lot::Mutex<OffscreenRenderer>>>` on `Renderer` and `Backend` with `Option<OffscreenRenderer>` (direct ownership on `Renderer`) + `Option<&'a mut OffscreenRenderer>` (borrowed on `Backend<'a>` for the frame lifetime).
+**What already landed.** This entry used to describe removing
+`Arc<parking_lot::Mutex<OffscreenRenderer>>` from `Renderer` and `Backend`. That is done:
+`Renderer` owns its `OffscreenRenderer`, `Backend<'frame>` borrows one, `handle_backdrop_filter`
+takes `&mut Backend<'_>`, and no `.lock()` remains on the path. Port-check trigger 7 now watches
+both files; its exclusions for them were retired when this was confirmed.
 
-**Shape:**
-1. `Renderer::offscreen: Option<Arc<parking_lot::Mutex<OffscreenRenderer>>>` -> `offscreen: Option<OffscreenRenderer>`.
-2. `pub struct Backend` -> `pub struct Backend<'a>` with `painter: &'a mut WgpuPainter`, `offscreen: Option<&'a mut OffscreenRenderer>`.
-3. `Renderer::render_scene` restructured to drop the `self.painter.take()` / `self.painter = Some(painter)` pattern (no longer needed; Backend borrows).
-4. `Backend::render_shader_mask` uses `&mut self.offscreen.as_mut()` instead of `offscreen_arc.lock()`.
-5. `Renderer::handle_backdrop_filter` takes `backend: &mut Backend<'_>` and accesses offscreen via the backend's lifetime.
+**What remains.** `render_scene` still takes the painter out of `self` and puts it back
+(`renderer.rs:1526`). That was an enabler for the lifetime work above, not its goal, and with the
+lock gone it stands alone: a smaller, self-contained cleanup with no lock-contention argument
+behind it any more.
 
-**Concrete blocker:** the refactor requires breaking the painter take/return pattern in `render_scene` (substantial lifetime gymnastics with the `Backend<'a>` lifetime, since `Backend::render_shader_mask` and `Renderer::handle_backdrop_filter` both need disjoint `&mut painter` + `&mut offscreen` from the same `Backend<'a>`). The borrow-checker resolution is non-trivial (likely needs a `Backend::split_mut(&mut self) -> (&mut WgpuPainter, Option<&mut OffscreenRenderer>)` accessor). Estimated 200-400 LOC of churn for marginal-runtime-benefit (the lock is uncontended in production); review-clarity favours landing this as a separate housekeeping PR with focused review.
+**Concrete blocker:** none identified beyond ordinary borrow-checker work, now that
+`Backend<'frame>` exists. The original blocker -- needing disjoint `&mut painter` and
+`&mut offscreen` out of one `Backend<'a>` -- was what the lifetime refactor solved.
 
-**Dependencies:** none external; pure Rust refactor.
+**Dependencies:** none.
 
 ### `Arc<Mutex<TexturePoolInner>>` -> direct ownership + explicit `pool.release(texture)`
 

--- a/docs/PORT.md
+++ b/docs/PORT.md
@@ -103,7 +103,7 @@ The *funnel* signatures (`tree.rs::insert_box`, view → render `From` impls) ac
 
 ### 7. `Arc<Mutex<*Renderer | *Pool | wgpu::*>>` field in `flui-engine` wgpu module 🔮
 
-**Forward-looking** — added in Mythos Step 9 of the `flui-engine` chain. Catches regressions of the `Arc<parking_lot::Mutex<OffscreenRenderer>>` and `Arc<Mutex<TexturePoolInner>>` shapes documented as Outstanding refactors in [`crates/flui-engine/ARCHITECTURE.md`](../crates/flui-engine/ARCHITECTURE.md). Today's known sites are excluded via file-glob (`!**/texture_pool.rs`, `!**/renderer.rs`, `!**/backend.rs`) so the trigger reports clean post-chain; when the corresponding Outstanding refactor lands, the file-glob exclusions go away.
+A renderer, a pool or a raw wgpu handle behind a shared lock invites a second mutator into a single-mutator design. One file is excluded by glob — `!**/texture_pool.rs`, where `Arc<Mutex<TexturePoolInner>>` is still the real shape — and that exclusion must go in the same change as the lock. The exclusions for `renderer.rs` and `backend.rs` have been retired: `Renderer` now owns its `OffscreenRenderer` outright and `Backend<'frame>` borrows one, so both files are watched again.
 
 **Why:** the wgpu single-mutator runtime invariant means `Arc<Mutex<T>>` on engine subsystems hides a single-thread access pattern behind shared-mutability ceremony. The lock is uncontended in production but the shape mismatches the type-level invariant; a future regression would re-introduce the same maintenance burden.
 

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -332,43 +332,30 @@ check "6" \
 # -----------------------------------------------------------------------------
 # Trigger 7 -- Arc<Mutex<*>> or Arc<RwLock<*>> on a *Renderer / *Pool / wgpu::*
 # field inside crates/flui-engine/src/wgpu/.
-# Forward-looking. Added in Mythos Step 9 of the flui-engine chain. Catches
-# regressions of the Arc<parking_lot::Mutex<OffscreenRenderer>> and
-# Arc<Mutex<TexturePoolInner>> shapes documented as Outstanding refactors in
-# crates/flui-engine/ARCHITECTURE.md.
 #
-# Today's known sites at crate root, intentionally surfaced as Friction log
-# entries in ARCHITECTURE.md, do match this trigger and will be expected to
-# be reported once the corresponding Outstanding refactor lands. Until then,
-# the trigger is INFORMATIONAL on Friction-log-tracked sites; the regex is
-# narrow enough that any NEW Arc<Mutex<>>/Arc<RwLock<>> on a *Renderer /
-# *Pool / wgpu::* field is a regression that should be addressed.
+# The lock-or-interior-mutability problem: a renderer, a pool or a raw wgpu
+# handle behind a shared lock invites a second mutator into a single-mutator
+# design. The regex is narrow enough that any new one is a regression.
 #
-# Scope excludes test files (`!**/test*.rs`, `!**/tests/**`) so test fixtures
-# are not flagged.
+# ONE file is excluded, and the exclusion carries an obligation.
 #
-# *** FILE-GLOB EXCLUSIONS BELOW ARE TRACKED-OUTSTANDING-REFACTOR WHITELISTS ***
+#   texture_pool.rs -- `Arc<Mutex<TexturePoolInner>>` at two sites, still the
+#   real shape. **When that lock is removed, this `--glob` MUST go in the same
+#   change**, or the file silently stops being watched precisely when it
+#   becomes watchable.
 #
-# Three files contain the EXACT patterns this trigger is designed to catch:
-#   - `texture_pool.rs:71,224`  -- `Arc<Mutex<TexturePoolInner>>` (R10; tracked
-#                                  as Outstanding refactor #2 in
-#                                  `crates/flui-engine/ARCHITECTURE.md`).
-#   - `renderer.rs:147`         -- `Arc<parking_lot::Mutex<OffscreenRenderer>>`
-#                                  (R9; tracked as Outstanding refactor #1).
-#   - `backend.rs:26,45,57`     -- same `Arc<Mutex<OffscreenRenderer>>` shape,
-#                                  symmetric with renderer.rs (R9).
+# Two other exclusions used to sit here, for `renderer.rs` and `backend.rs`,
+# both waiting on the same refactor. That refactor landed -- `Renderer` now
+# owns its `OffscreenRenderer` outright and `Backend` borrows one for a frame
+# -- and nobody removed the globs, so both files went unwatched for however
+# long. A stale exclusion is worse than none: it reads as "known to violate"
+# while the file is clean, and it permits the next real violation in exactly
+# the place the rule most wants to look. Both are now gone, verified by
+# running the trigger against both files with the globs removed (zero hits).
 #
-# The Mythos chain (PR feat/flui-engine-mythos-redesign) DEFERRED these three
-# refactors to follow-up work per ARCHITECTURE.md `## Outstanding refactors`.
-# To avoid port-check fire-on-known-violation, the three files are whitelisted
-# below. **When the corresponding Outstanding refactor lands (i.e., the
-# Arc<Mutex<>> shape is removed from a file), the matching `--glob !**/<file>`
-# exclusion below MUST be removed in the same PR** so this trigger then catches
-# regressions against the post-refactor shape.
-#
-# Cross-reference: see `crates/flui-engine/ARCHITECTURE.md` ## Friction log
-# entry "Arc<parking_lot::Mutex<OffscreenRenderer>>" and "Arc<Mutex<
-# TexturePoolInner>>" for the deferral rationale.
+# Test files (`!**/test*.rs`, `!**/tests/**`) stay excluded so fixtures are
+# not flagged.
+
 # -----------------------------------------------------------------------------
 #
 # Regex shape (anchored + grouped):
@@ -390,8 +377,6 @@ check "7" \
   --glob '!**/test*.rs' \
   --glob '!**/tests/**' \
   --glob '!**/texture_pool.rs' \
-  --glob '!**/renderer.rs' \
-  --glob '!**/backend.rs' \
   crates/flui-engine/src/wgpu
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #635.

## The obligation that was not met

Trigger 7 excludes files with a literal `--glob`, and its own prose set the terms: **"When the corresponding Outstanding refactor lands (i.e., the `Arc<Mutex<>>` shape is removed from a file), the matching `--glob !**/<file>` exclusion below MUST be removed in the same PR."**

Two of the three landed. The globs stayed.

`Renderer` now owns its `OffscreenRenderer` outright and `Backend` borrows one for a frame — the `Backend<'a>` lifetime refactor those exclusions were waiting on. Verified before removing rather than inferred from the prose: the trigger's regex matches **zero** in both files with the globs gone, and `port-check -v` stays green.

## Why this is worth a PR rather than a tidy-up

A stale exclusion is worse than no exclusion. It reads as "this file is known to violate the rule" when the file is clean, and it silently permits the *next* real violation in exactly the place the rule most wants to watch. That is the same failure `cross-typecheck` was created to end for the Win32 and AppKit backends, and that #632 ended for Android — a gate whose coverage nobody re-checked.

## The docs were describing code that no longer exists

`crates/flui-engine/ARCHITECTURE.md`'s friction log still listed both fields as `Option<Arc<parking_lot::Mutex<OffscreenRenderer>>>`. Corrected to the real shapes, with the resolution noted.

## What stays

`texture_pool.rs` keeps its exclusion — `Arc<Mutex<TexturePoolInner>>` is still the real shape at two sites. The obligation to remove it in the same change as the lock now sits next to it instead of three paragraphs away, which is part of why the previous one was missed.

The rewritten block also drops the plan-block provenance it carried — a step number, two audit-row IDs, a branch name. #613's sweep of this file missed them because those forms are not among the banned list's shapes; they are the same thing by another spelling.
