### PR TITLE
build(deps): bump console from 0.15 to 0.16 in flui-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1493,7 +1493,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "cliclack",
- "console 0.15.11",
+ "console 0.16.3",
  "dirs",
  "flui-build",
  "flui-devtools",
@@ -6084,7 +6084,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/flui-cli/Cargo.toml
+++ b/crates/flui-cli/Cargo.toml
@@ -51,7 +51,7 @@ toml = "1.1"
 # Utilities
 which = "8.0"
 cliclack = "0.3.6"
-console = "0.15"
+console = "0.16"
 dirs = "6.0"
 
 # Async runtime (for flui-build async builders)


### PR DESCRIPTION
Dependabot's #583 could not be rebased cleanly after five sibling bumps landed ahead of it, so this applies the same change directly. Closes #583.

## What the graph actually looks like

The naive reading of a major bump here is wrong. `console` **0.16 is already in the tree**, pulled by `indicatif` 0.18 and `insta`; **0.15 is also already there**, pulled by `cliclack` and `indicatif` 0.17. Both versions coexist on `main` today.

So moving `flui-cli` onto 0.16 does not introduce a duplicate — it removes one consumer from the older of two versions that are already present. The duplicate persists until `cliclack` moves, and `deny.toml` sets `multiple-versions = "warn"` rather than banning it.

I checked this before merging rather than after, because the obvious worry with a major bump on a tooling crate is exactly the opposite conclusion: that it forks the graph. Here it de-forks it slightly.

## Risk surface

Our entire use of the crate is `console::style`. One function.

`cargo nextest run -p flui-cli` (70/70) and `cargo clippy -p flui-cli --all-targets --all-features -- -D warnings` both clean locally.
