### PR TITLE
docs(adr): ADR-0045 gave ReplaceServices two different shapes

### DIFF
--- a/docs/adr/ADR-0045-raster-lane.md
+++ b/docs/adr/ADR-0045-raster-lane.md
@@ -112,7 +112,7 @@ This record does not paper over that. The scope **is** per owner thread, and it 
 
 **And recovery must reach every lane, not just the one that observed the loss.** The device is shared per owner thread, so its loss is a property of the *thread*, not of one surface. A second lane's `Renderer` still holds an `Arc<Device>` from the pre-recovery services and would render into a dead device forever — the third of the three hazards named at the top of this decision. `ResourceGeneration` gating rejects that lane's *frames*, which prevents corruption but does not by itself re-point the lane at the new device; without the step below, gating alone would leave the second lane permanently starved rather than recovered.
 
-> **Recovery is a whole-owner-thread event.** `AppRuntime::recreate_gpu(observed)` mints **one** new `GpuServices` on the owner thread, then sends **every** lane on that thread a `ReplaceServices { services, generation }` command on the same ordered, coalesced command path as resize and attach/detach — not a broadcast on the lossy ack lane.
+> **Recovery is a whole-owner-thread event.** `AppRuntime::recreate_gpu(observed)` mints **one** new `GpuServices` on the owner thread, then sends **every** lane on that thread a `ReplaceServices` command on the same ordered, coalesced command path as resize and attach/detach — not a broadcast on the lossy ack lane. Its full shape, including the replacement surface the owner thread builds because the lane may not, is given below.
 
 Each lane applies it at its next command drain, which happens at the top of `pump` **before** the generation compare, so no frame is ever rendered against a replaced device:
 


### PR DESCRIPTION
Decision 2 introduces the command as `ReplaceServices { services, generation }`; the surface-lifecycle amendment (#641) later defines it as `{ services, surface, generation }`, because the owner thread builds the replacement surface — the lane may not create one — and did not correct the introduction.

A record that states two shapes for one command is a record whoever implements it will pick from, and this one lands several slices after the point where it is first read.

The introduction now names the command without a field list and points at the definition, so there is one place to change if the shape moves again.

Found while briefing #559's third slice against the amended ADR.