### PR TITLE
fix(deps): repair a dangling windows-sys reference in Cargo.lock (unblocks CI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6084,7 +6084,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
**`main` is red on every job** and has been since the dependency series merged. All twelve fail the same way:

```
error: cannot update the lock file /home/runner/work/flui/flui/Cargo.lock because --locked was passed to prevent this
```

Every cargo invocation in `ci.yml` uses `--locked`, so one broken lock takes the whole pipeline down at once.

## What is broken

`Cargo.lock` is internally inconsistent. It carries four `windows-sys` package entries — `0.52.0`, `0.59.0`, `0.60.2`, `0.61.2` — and **no `0.48.0`**, while `which` and `winapi-util` both still list `"windows-sys 0.48.0"` in their dependency lists. A name pointing at a version the file does not contain.

Two lines. `cargo` repairs them to `0.52.0` and nothing else in the file moves — the diff is exactly those two lines.

## How it happened, and what to do differently

Six dependabot PRs merged in sequence. Each was green against a lock that no longer existed by the time the next one landed; the `which` 7→8 bump is what dropped the `0.48.0` entry that two other packages still referenced. Squash-merging a series does not re-resolve the lock, so the inconsistency was assembled rather than introduced by any one PR.

`.gitattributes` marks `Cargo.lock` as `-diff linguist-generated=true`, so the conflict was invisible in review. That is the right setting for a generated file, and it is also exactly why nobody saw this.

Worth naming rather than filing away: **a lock repaired by regeneration is not the same as a lock that never broke.** Merging a dependency series one PR at a time and letting each rebase onto the previous is slower and does not produce this. I merged five in a row because they were individually green — which is the trap: individually green says nothing about the lock they collectively produce.

Verified: `cargo check --workspace --locked --all-targets` fails on `main` and passes here.
