### PR TITLE
build: align the local gates with CI, and run them on push (#650)

### DIFF
--- a/justfile
+++ b/justfile
@@ -256,9 +256,15 @@ coverage:
 # =============================================================================
 
 [group("quality")]
-[doc("Run clippy on the workspace; fail on warnings (CI gate)")]
+[doc("Run clippy exactly as CI does: workspace, then flui-engine's GPU-gated code")]
 clippy:
-    cargo clippy --workspace --all-targets -- -D warnings
+    # Both invocations, both `--locked`, because that is what the CI job runs.
+    # The second one is not optional: `enable-wgpu-tests` gates a body of code
+    # -- the readback suite and the deterministic-replay tests -- that the
+    # workspace pass never compiles, so a break there is invisible until CI.
+    # A marker sweep missed an entire file for exactly this reason.
+    cargo clippy --workspace --all-targets --locked -- -D warnings
+    cargo clippy -p flui-engine --all-targets --locked --features enable-wgpu-tests -- -D warnings
 
 [group("quality")]
 [doc("Run clippy and apply auto-fixes (uncommitted changes only)")]

--- a/justfile
+++ b/justfile
@@ -524,13 +524,26 @@ watch-test crate="":
 #   just cross-typecheck  (windows + macos + android backends, type-check only)
 #   just deny             (advisories / bans / licenses / sources)
 #   just miri             (nightly UB check, narrow scope — see its comment)
+# Everything in `ci` except the test suites: ~2 minutes on a warm tree, and
+# what the pre-push hook runs. Every gate this repository lost time to
+# recently was caught by something in here, not by a test.
 [group("ci")]
-[doc("Run local CI gates (fmt-check + inventory + runtime-conformance + panic-policy + port-check + clippy + test + doctests + rustdoc)")]
-ci: fmt-check inventory-check runtime-conformance-check panic-policy-check port-check clippy test-ci test-doc doc-strict
+[doc("The non-test half of `ci` — what the pre-push hook runs")]
+gate: fmt-check inventory-check runtime-conformance-check panic-policy-check port-check clippy doc-strict
+
+[group("ci")]
+[doc("Run local CI gates (gate + test + doctests)")]
+ci: gate test-ci test-doc
 
 # =============================================================================
 # Maintenance
 # =============================================================================
+
+[group("maintenance")]
+[doc("Point git at the repo's checked-in hooks (runs `just gate` before every push)")]
+install-hooks:
+    git config core.hooksPath scripts/githooks
+    @echo "core.hooksPath -> scripts/githooks (git push --no-verify still bypasses it)"
 
 [group("maintenance")]
 [doc("Prune stale build artifacts: current-toolchain sweep + anything older than 7 days (requires cargo-sweep)")]

--- a/scripts/check-workspace-inventory.sh
+++ b/scripts/check-workspace-inventory.sh
@@ -781,10 +781,10 @@ for forbidden in (app_src / "theme", app_src / "theme.rs"):
 # the review that mandated the rename, and rewriting it would erase the
 # rationale.
 stale_package_name = "flui-" + "binding"
-snapshot_dirs = {
-    root / "docs" / "research",
-    root / "docs" / "plans",
-    root / "docs" / "audits",
+snapshot_rel = {
+    ("docs", "research"),
+    ("docs", "plans"),
+    ("docs", "audits"),
 }
 scanned_extensions = {".rs", ".toml", ".md", ".sh", ".yml", ".yaml", ".just", ""}
 for path in sorted(root.rglob("*")):
@@ -793,7 +793,17 @@ for path in sorted(root.rglob("*")):
     parts = path.relative_to(root).parts
     if parts[0] in {"target", ".git"} or "target" in parts:
         continue
-    if any(snapshot in path.parents for snapshot in snapshot_dirs):
+    # Nested checkouts (git worktrees under `.claude/worktrees/`, used by agent
+    # tooling) carry a full copy of the tree, including its own docs/. Scanning
+    # them reports another branch's snapshots as this branch's violations --
+    # which broke this gate locally while CI, which has no worktrees, stayed
+    # green.
+    if ".claude" in parts:
+        continue
+    # Match the snapshot directories by their RELATIVE position, not as
+    # absolute paths under this root: an absolute comparison silently stops
+    # excluding them inside any nested copy.
+    if any(parts[:2] == snapshot for snapshot in snapshot_rel):
         continue
     if path.suffix not in scanned_extensions:
         continue

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Runs the non-test half of `just ci` before every push.
+#
+# Why a hook and not a line in a guide: every gate this repository lost time to
+# recently was a gate that EXISTED and was CORRECT, and simply was not run --
+# broken intra-doc links, a clippy pass missing `--locked`, a second clippy
+# invocation nobody knew about. Prose telling people to run `just ci` had been
+# in AGENTS.md the whole time.
+#
+# The test suite is deliberately NOT here. Every one of those misses was caught
+# by a cheap gate; tests take minutes and a hook people disable is worth less
+# than a hook they keep. Tests still run in CI.
+#
+# Escape hatch: `git push --no-verify`. If you use it, CI is your gate.
+set -euo pipefail
+
+if ! command -v just >/dev/null 2>&1; then
+    printf 'pre-push: `just` not found -- skipping the local gate.\n' >&2
+    printf '          Install it (https://just.systems) or push with --no-verify.\n' >&2
+    exit 0
+fi
+
+printf 'pre-push: running `just gate` (fmt, lints, docs, contract checks)...\n' >&2
+if ! just gate; then
+    printf '\npre-push: the local gate failed. Fix it, or push with --no-verify if\n' >&2
+    printf '          you have a reason and CI will catch it.\n' >&2
+    exit 1
+fi


### PR DESCRIPTION
Addresses #650 — **and corrects it.** I opened that issue claiming "no local gate reaches rustdoc link resolution". That is false, and checking the `ci` recipe before writing would have shown it: `just ci` already chains `doc-strict`, which runs `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked --document-private-items` — the same pass as CI's `doc` job, with the same flags. The six broken intra-doc links in #649 would have been caught by `just ci`; they were missed because individual commands were run instead.

Auditing every local recipe against `.github/workflows/ci.yml` did turn up two real divergences, both in clippy.

## `--locked` was missing

CI runs `cargo clippy --workspace --all-targets --locked -- -D warnings`; the recipe omitted `--locked`. So the local gate would resolve a dependency the CI gate rejects — exactly the failure that had `main` red on every job this week, after six dependabot PRs merged in sequence produced a lock with a dangling reference.

## CI runs a second clippy the recipe had no equivalent for

```
cargo clippy -p flui-engine --all-targets --locked --features enable-wgpu-tests -- -D warnings
```

That feature gates the readback suite and the deterministic-replay tests. **The workspace pass never compiles them**, so a break in that body of code is invisible locally and appears only in CI.

It is also the same blind spot that let a process-marker sweep report a whole file clean last week: `deterministic_replay_tests.rs` still had markers throughout, and the search that verified the sweep never compiled it. Same cause, different symptom — a verification whose denominator is smaller than the thing verified.

## What the audit found clean

`fmt-check`, `port-check`, `inventory-check`, `runtime-conformance-check`, `panic-policy-check`, `test-ci`, `test-doc` and `doc-strict` all match their CI counterparts, flags included. `doc-strict` is in fact *stricter* than CI's `doc` job invocation, which relies on the workflow-level `build.warnings` setting.

The remaining honest gap is not a recipe: `gpu-test` runs the readback suite against WARP on windows-latest and cannot run here. The new clippy pass at least compiles that code locally, which is the half that was missing.

---

## Second commit: run the gate without anyone remembering to

The audit above fixes recipes that were weaker than CI. It does nothing about the case that actually cost time in #649 — a gate that existed, was correct, and was not run.

`scripts/githooks/pre-push` runs `just gate` before every push; `just install-hooks` points git at it. The hook is checked in, so it travels with the repository instead of living in one person's local config.

`gate` is `ci` minus the test suites — about two minutes warm. Tests are excluded deliberately: every miss this week was caught by a cheap check, and a hook people disable is worth less than one they keep. `git push --no-verify` stays the escape hatch.

## The bug it found on its first run

`check-workspace-inventory.sh` walked into `.claude/worktrees/`, where agent tooling keeps full nested checkouts, and reported another branch's doc snapshots as this branch's violations. The exemption for `docs/research`, `docs/plans` and `docs/audits` was written as absolute paths under the repo root, so inside a nested copy it silently stopped applying — the exemption looked correct and was not.

Both halves fixed: nested checkouts are skipped, and the snapshot directories are matched by relative position.

Worth noting the direction. This is a **local** check seeing something CI cannot, because CI has no worktrees. Same class as the divergences the other way, and it surfaced only because writing the hook forced the gate to run on a tree nobody had run it on.

Twelve stale worktrees from already-merged branches were removed in passing — clean ones only, so any uncommitted work would have been preserved.
