### PR TITLE
fix(platform): make Win32 userdata lifetime reentrant-safe (#597)

### DIFF
--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -894,7 +894,7 @@ impl WindowsPlatform {
                         // the current live HWND; Win32 does not retain it.
                         let _ = unsafe { TrackMouseEvent(&raw mut tme) };
 
-                        // Track hover state (T034)
+                        // Track hover state so WM_MOUSELEAVE can fire an exit exactly once.
                         let scale_factor = {
                             let mut state = ctx.state.lock();
                             state.is_hovered = true;
@@ -1054,7 +1054,7 @@ impl WindowsPlatform {
                             WindowsWindow::set_fullscreen_for_context(hwnd, ctx, enter_fullscreen);
                         }
 
-                        // Track modifiers (T035)
+                        // Mirror the modifier state the next key/pointer event will carry.
                         ctx.state.lock().modifiers = current_modifiers();
 
                         // Dispatch keyboard event via per-window callback
@@ -1068,7 +1068,7 @@ impl WindowsPlatform {
 
                 WM_KEYUP | WM_SYSKEYUP => {
                     if let Some(ctx) = ctx.as_deref() {
-                        // Track modifiers (T035)
+                        // Mirror the modifier state the next key/pointer event will carry.
                         ctx.state.lock().modifiers = current_modifiers();
 
                         use super::events::key_up_event;
@@ -1120,10 +1120,10 @@ impl WindowsPlatform {
                     LRESULT(0)
                 }
 
-                // T025: Mouse hover tracking — WM_MOUSELEAVE (0x02A3)
+                // Mouse hover tracking — WM_MOUSELEAVE (0x02A3)
                 0x02A3 => {
                     if let Some(ctx) = ctx.as_deref() {
-                        // Track hover state (T034)
+                        // Track hover state so WM_MOUSELEAVE can fire an exit exactly once.
                         ctx.state.lock().is_hovered = false;
 
                         ctx.callbacks.dispatch_hover_status_change(false);
@@ -1131,7 +1131,7 @@ impl WindowsPlatform {
                     LRESULT(0)
                 }
 
-                // T026: System theme/appearance change
+                // System theme/appearance change
                 WM_SETTINGCHANGE => {
                     if let Some(ctx) = ctx.as_deref() {
                         ctx.callbacks.dispatch_appearance_changed();
@@ -1139,7 +1139,7 @@ impl WindowsPlatform {
                     default_window_proc(hwnd, msg, wparam, lparam)
                 }
 
-                // T046: Keyboard layout change
+                // Keyboard layout change
                 WM_INPUTLANGCHANGE => {
                     if let Some(ctx) = ctx.as_deref() {
                         // Dispatch keyboard layout change via take/restore pattern
@@ -1312,7 +1312,7 @@ impl Platform for WindowsPlatform {
         self.handlers.lock().keyboard_layout_changed = Some(callback);
     }
 
-    // ==================== App Activation (US3 T038) ====================
+    // ==================== App Activation ====================
 
     fn activate(&self, _ignoring_other_apps: bool) {
         // SAFETY: `GetForegroundWindow`/`SetForegroundWindow` take no
@@ -1332,7 +1332,7 @@ impl Platform for WindowsPlatform {
         }
     }
 
-    // ==================== Appearance (US3 T040) ====================
+    // ==================== Appearance ====================
 
     fn window_appearance(&self) -> WindowAppearance {
         // Read system theme from registry: AppsUseLightTheme
@@ -1393,7 +1393,7 @@ impl Platform for WindowsPlatform {
         }
     }
 
-    // ==================== File Operations (US3 T041) ====================
+    // ==================== File Operations ====================
 
     fn open_url(&self, url: &str) {
         use windows::Win32::UI::Shell::ShellExecuteW;
@@ -1456,7 +1456,7 @@ impl Platform for WindowsPlatform {
         }
     }
 
-    // ==================== File Dialogs (US3 T042-T043) ====================
+    // ==================== File Dialogs ====================
 
     fn prompt_for_paths(
         &self,
@@ -1618,7 +1618,7 @@ impl Platform for WindowsPlatform {
         })
     }
 
-    // ==================== Keyboard (US3 T045) ====================
+    // ==================== Keyboard ====================
 
     fn keyboard_layout(&self) -> String {
         use windows::Win32::UI::Input::KeyboardAndMouse::GetKeyboardLayoutNameW;
@@ -1709,7 +1709,7 @@ impl Drop for WindowsPlatform {
 
 // ==================== Helper Functions ====================
 
-/// Read current keyboard modifier state from Win32 (T035)
+/// Read current keyboard modifier state from Win32.
 fn current_modifiers() -> keyboard_types::Modifiers {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         GetKeyState, VK_CONTROL, VK_LWIN, VK_MENU, VK_RWIN, VK_SHIFT,

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -1,14 +1,19 @@
 //! Windows platform implementation
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Weak},
+};
 
 use anyhow::{Context, Result};
-use cursor_icon::CursorIcon;
-use flui_types::geometry::{Bounds, DevicePixels, Point, Size};
+use flui_types::geometry::{Bounds, Point, Size};
 use parking_lot::Mutex;
 use windows::{
     Win32::{
-        Foundation::{ERROR_CANCELLED, HWND, LPARAM, LRESULT, RECT, WPARAM},
+        Foundation::{
+            ERROR_CANCELLED, ERROR_SUCCESS, GetLastError, HWND, LPARAM, LRESULT, RECT,
+            SetLastError, WPARAM,
+        },
         Graphics::Gdi::{BeginPaint, EndPaint, HBRUSH, PAINTSTRUCT},
         System::LibraryLoader::{GetModuleFileNameW, GetModuleHandleW},
         UI::{
@@ -34,7 +39,7 @@ use windows::{
 use super::{
     display::enumerate_displays,
     util::{WINDOW_CLASS_NAME, get_x_lparam, get_y_lparam, hiword, load_cursor_style},
-    window::WindowsWindow,
+    window::{WindowCommand, WindowState, WindowsWindow},
 };
 use crate::{
     config::WindowConfiguration,
@@ -56,38 +61,20 @@ static REGISTER_WINDOW_CLASS: std::sync::Once = std::sync::Once::new();
 /// Context data stored per window for event dispatch
 pub(super) struct WindowContext {
     /// Window ID for event dispatch
-    pub window_id: WindowId,
+    pub(super) window_id: WindowId,
     /// Reference to platform handlers (global)
-    pub handlers: Arc<Mutex<PlatformHandlers>>, // PORT-CHECK-OK-SP6: WindowsPlatform handlers Arc<Mutex<>>; mirrors PlatformHandlers callback storage; pre-existing SP-6
+    pub(super) handlers: Arc<Mutex<PlatformHandlers>>, // PORT-CHECK-OK-SP6: WindowsPlatform handlers Arc<Mutex<>>; mirrors PlatformHandlers callback storage; pre-existing SP-6
     /// Per-window callbacks for event delivery
-    pub callbacks: Arc<WindowCallbacks>,
-    /// Scale factor for coordinate conversion.
-    ///
-    /// `Cell`, not a plain `f32`: `window_proc` only ever holds a shared
-    /// `&WindowContext` (see its `# Safety` section), and `WM_DPICHANGED` is
-    /// the one message that updates this field — `Cell::set` lets it do so
-    /// through that shared reference instead of forging a second, aliasing
-    /// `&mut WindowContext` from the raw `GWLP_USERDATA` pointer while the
-    /// shared one is still live.
-    pub scale_factor: std::cell::Cell<f32>,
-    /// Current window mode (replaces display_state + saved bounds)
-    pub mode: std::cell::Cell<WindowMode>,
-    /// Last known size (before minimization) for restore detection
-    pub last_size: std::cell::Cell<Size<DevicePixels>>,
+    pub(super) callbacks: Arc<WindowCallbacks>,
+    /// State shared with `WindowsWindow`; locks are released before callbacks.
+    pub(super) state: Arc<Mutex<WindowState>>,
     /// Window configuration (hotkeys, debouncing, etc.)
-    pub config: WindowConfiguration,
-    /// Is mouse hovering over this window? (T034)
-    pub is_hovered: std::cell::Cell<bool>,
-    /// Current keyboard modifiers (T035)
-    pub modifiers: std::cell::Cell<keyboard_types::Modifiers>,
-    /// Cursor selected by this exact window's presentation.
-    pub cursor: std::cell::Cell<CursorIcon>,
-    /// Window style bits before fullscreen (Windows-specific: WS_OVERLAPPEDWINDOW, etc.)
-    ///
-    /// Stored here instead of in `WindowMode` to keep the cross-platform enum
-    /// free of platform-specific fields.
-    pub restore_style: std::cell::Cell<u32>,
+    pub(super) config: WindowConfiguration,
+    /// Non-owning access to the platform registry for owner-thread teardown.
+    pub(super) windows: Weak<Mutex<HashMap<isize, Arc<WindowsWindow>>>>,
 }
+
+static_assertions::assert_impl_all!(WindowContext: Send, Sync);
 
 impl WindowContext {
     /// Dispatch a window event safely without holding locks
@@ -108,6 +95,136 @@ impl WindowContext {
             self.handlers.lock().window_event = Some(handler);
         }
     }
+}
+
+/// Installs the raw strong reference owned by an HWND's userdata slot.
+pub(super) fn install_window_context(hwnd: HWND, context: Arc<WindowContext>) -> Result<()> {
+    // Win32 initializes a fresh HWND's userdata to zero, and this runs
+    // on its owner thread before the window is published. Preflighting before
+    // `Arc::into_raw` means an unexpected occupied slot is never overwritten
+    // or later mistaken for FLUI's Arc. After the conversion, a successful
+    // write transfers that one strong reference to the slot; its address is
+    // obtained with `expose_provenance` because Win32 stores only an integer.
+    // A failed write reconstructs and drops the original pointer directly.
+    // SAFETY: these inseparable calls inspect only `hwnd`'s pointer-sized
+    // userdata value. `SetLastError` disambiguates a successful zero read.
+    let (existing, preflight_error) = unsafe {
+        SetLastError(ERROR_SUCCESS);
+        let existing = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+        (existing, GetLastError())
+    };
+    if existing != 0 {
+        anyhow::bail!("refusing to overwrite occupied Win32 userdata slot");
+    }
+    if preflight_error != ERROR_SUCCESS {
+        anyhow::bail!(
+            "failed to inspect Win32 userdata slot: error={}",
+            preflight_error.0
+        );
+    }
+
+    let context_ptr = Arc::into_raw(context);
+    let context_address = context_ptr.expose_provenance().cast_signed();
+    // SAFETY: `context_address` is the exposed address of the raw Arc strong
+    // reference above. These calls atomically install that integer value and
+    // immediately capture the thread-local error needed to interpret zero.
+    let (previous, install_error) = unsafe {
+        SetLastError(ERROR_SUCCESS);
+        let previous = SetWindowLongPtrW(hwnd, GWLP_USERDATA, context_address);
+        (previous, GetLastError())
+    };
+    if previous != 0 {
+        // A nonzero previous value means the write succeeded despite the
+        // owner-serialized empty preflight. The slot now owns our Arc;
+        // the caller's error cleanup destroys the HWND and consumes it.
+        anyhow::bail!("Win32 userdata slot changed after empty preflight: previous={previous}");
+    }
+    if install_error != ERROR_SUCCESS {
+        // SAFETY: the failed slot write did not consume the raw strong
+        // reference produced immediately above.
+        drop(unsafe { Arc::from_raw(context_ptr) });
+        anyhow::bail!(
+            "failed to install Win32 window context: error={}",
+            install_error.0
+        );
+    }
+    Ok(())
+}
+
+/// Pins the context for one WNDPROC invocation.
+///
+/// # Safety
+///
+/// The caller must be executing serialized WNDPROC dispatch on `hwnd`'s owner
+/// thread. Every nonzero userdata value must be the exposed address of the raw
+/// `Arc<WindowContext>` strong reference installed by `install_window_context`,
+/// and no other thread may clear or replace the slot during this call.
+unsafe fn acquire_window_context(hwnd: HWND) -> Option<Arc<WindowContext>> {
+    // Only this module reads or clears this slot, and Win32 serializes
+    // WNDPROC dispatch for an HWND on its owner thread. A non-null pointer is
+    // the raw strong reference installed by `install_window_context`; it
+    // remains owned by the slot while the increment is performed. The address
+    // is reconstituted with `with_exposed_provenance` before any Arc operation.
+    // The new strong reference pins the allocation across reentrant callbacks,
+    // including a nested `WM_DESTROY` that clears the slot.
+    // SAFETY: the caller's contract guarantees owner-thread serialization;
+    // this reads the pointer-sized userdata value without dereferencing it.
+    let context_address = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) };
+    if context_address == 0 {
+        return None;
+    }
+    let context_ptr =
+        std::ptr::with_exposed_provenance::<WindowContext>(context_address.cast_unsigned());
+    // SAFETY: the nonzero address is the slot-owned raw Arc strong reference.
+    // The increment happens while that reference is still slot-owned, and
+    // `from_raw` consumes exactly the newly added invocation-local reference.
+    unsafe {
+        Arc::increment_strong_count(context_ptr);
+        Some(Arc::from_raw(context_ptr))
+    }
+}
+
+/// Clears userdata and consumes the strong reference formerly owned by it.
+///
+/// # Safety
+///
+/// The caller must be executing serialized WNDPROC dispatch on `hwnd`'s owner
+/// thread, and must be the sole code allowed to clear the slot. Every nonzero
+/// value must be the exposed address installed by `install_window_context` and
+/// must not have been previously consumed with `Arc::from_raw`.
+unsafe fn take_window_context(hwnd: HWND) -> Result<Option<Arc<WindowContext>>> {
+    // Owner-thread WNDPROC dispatch is the sole clearer of this slot.
+    // A nonzero return is exactly the raw strong reference installed by
+    // `install_window_context`; `with_exposed_provenance` reconstitutes the
+    // pointer before `Arc::from_raw` consumes it once. On a failed zero return
+    // the slot may still own the reference, so it is left untouched and
+    // reported rather than guessed-at or double-consumed.
+    // SAFETY: the caller's contract grants sole owner-thread clearing access.
+    // These inseparable calls clear the pointer-sized value and immediately
+    // capture the thread-local error needed to interpret a zero return.
+    let (context_address, error) = unsafe {
+        SetLastError(ERROR_SUCCESS);
+        let context_address = SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
+        (context_address, GetLastError())
+    };
+    if context_address != 0 {
+        let context_ptr =
+            std::ptr::with_exposed_provenance::<WindowContext>(context_address.cast_unsigned());
+        // SAFETY: by contract this is the unique raw strong reference just
+        // removed from the slot, reconstructed with exposed provenance.
+        return Ok(Some(unsafe { Arc::from_raw(context_ptr) }));
+    }
+    if error == ERROR_SUCCESS {
+        Ok(None)
+    } else {
+        anyhow::bail!("failed to clear Win32 window context: error={}", error.0)
+    }
+}
+
+fn default_window_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    // SAFETY: this forwards the exact HWND and message parameters supplied by
+    // Win32 to the registered WNDPROC; no Rust reference is derived from them.
+    unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
 }
 
 /// Windows platform state
@@ -356,9 +473,9 @@ impl WindowsPlatform {
     /// registered as this exact function in `register_window_class`. Win32
     /// guarantees `hwnd`/`msg`/`wparam`/`lparam` are well-formed for the
     /// message being delivered, and always dispatches on the thread that
-    /// owns the window's message queue — the `GWLP_USERDATA` read below does
-    /// not race `WM_DESTROY`'s clear+free precisely because both run here,
-    /// serialized by that same-thread dispatch guarantee.
+    /// owns the window's message queue. `acquire_window_context` turns the
+    /// slot-owned raw Arc reference into an invocation-local strong reference
+    /// before any callback can reentrantly destroy the HWND.
     ///
     /// Known gap (not fixed by this comment, not UB — flagged for the
     /// audit): none of the callback dispatches below (`ctx.callbacks.*`,
@@ -375,25 +492,20 @@ impl WindowsPlatform {
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> LRESULT {
-        // SAFETY: see the `# Safety` section above for the `GWLP_USERDATA`
-        // contract this read relies on. The rest of this single `unsafe`
-        // block covers every Win32 call in the `match` below: `GetWindowLongPtrW`/
-        // `SetWindowLongPtrW` take `hwnd` and plain integers, no pointers;
-        // `TrackMouseEvent` (`WM_MOUSEMOVE`) and `BeginPaint`/`EndPaint`
-        // (`WM_PAINT`, its own SAFETY note below) take `&raw` pointers to
-        // stack-local, correctly-sized structs; `DestroyWindow` calls are
-        // individually commented where they appear; `Box::from_raw(ctx_ptr)`
-        // (`WM_DESTROY`) has its own SAFETY note where it appears;
-        // `DefWindowProcW` forwards unhandled messages verbatim with no
-        // pointer arguments of its own.
-        unsafe {
-            // Get window context from GWLP_USERDATA
-            let ctx_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut WindowContext;
-            let ctx = if ctx_ptr.is_null() {
-                None
-            } else {
-                Some(&*ctx_ptr)
-            };
+        // Ordinary scope only: unsafe authority is granted separately at each
+        // FFI/raw-Arc operation below, never to the dispatch state machine.
+        {
+            // SAFETY: WNDPROC runs on the HWND owner thread. The slot-owned Arc is
+            // live until the only clearing path, WM_DESTROY, so the helper can pin
+            // an invocation-local reference before any callback runs.
+            let ctx = unsafe { acquire_window_context(hwnd) };
+
+            if let Some(command) = WindowCommand::from_message(msg) {
+                if let Some(ctx) = ctx.as_deref() {
+                    WindowsWindow::execute_window_command(hwnd, ctx, command);
+                }
+                return LRESULT(0);
+            }
 
             match msg {
                 WM_CREATE => {
@@ -404,7 +516,7 @@ impl WindowsPlatform {
                 WM_CLOSE => {
                     tracing::debug!("WM_CLOSE for HWND {:?}", hwnd);
 
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         // Ask per-window callback if close should proceed
                         let should_close = ctx.callbacks.dispatch_should_close();
 
@@ -413,17 +525,22 @@ impl WindowsPlatform {
                             ctx.dispatch_event(WindowEvent::CloseRequested {
                                 window_id: ctx.window_id,
                             });
-                            if let Err(error) = DestroyWindow(hwnd) {
+                            // SAFETY: WNDPROC runs on this HWND's owner thread.
+                            if let Err(error) = unsafe { DestroyWindow(hwnd) } {
                                 tracing::warn!(?hwnd, ?error, "DestroyWindow failed on WM_CLOSE");
                             }
                         }
                         // If !should_close, the close is vetoed
-                    } else if let Err(error) = DestroyWindow(hwnd) {
-                        tracing::warn!(
-                            ?hwnd,
-                            ?error,
-                            "DestroyWindow failed on WM_CLOSE (no WindowContext)"
-                        );
+                    } else {
+                        // SAFETY: WNDPROC runs on this HWND's owner thread even
+                        // before or after a context is installed.
+                        if let Err(error) = unsafe { DestroyWindow(hwnd) } {
+                            tracing::warn!(
+                                ?hwnd,
+                                ?error,
+                                "DestroyWindow failed on WM_CLOSE (no WindowContext)"
+                            );
+                        }
                     }
 
                     LRESULT(0)
@@ -432,31 +549,37 @@ impl WindowsPlatform {
                 WM_DESTROY => {
                     tracing::debug!("WM_DESTROY for HWND {:?}", hwnd);
 
-                    if let Some(ctx) = ctx {
-                        // Fire per-window on_close callback (FnOnce)
-                        ctx.callbacks.dispatch_close();
+                    if let Some(ctx) = ctx.as_deref() {
+                        let should_dispatch_close = {
+                            let mut state = ctx.state.lock();
+                            let was_destroyed = state.is_destroyed;
+                            state.is_destroyed = true;
+                            state.visible = false;
+                            state.focused = false;
+                            state.is_hovered = false;
+                            !was_destroyed
+                        };
 
-                        // Dispatch Closed event to global handlers
-                        ctx.dispatch_event(WindowEvent::Closed(ctx.window_id));
+                        if should_dispatch_close {
+                            // Fire per-window on_close callback (FnOnce)
+                            ctx.callbacks.dispatch_close();
 
-                        // Clean up context - IMPORTANT: Clear pointer BEFORE dropping to avoid
-                        // dangling pointer
-                        //
-                        // SAFETY: `ctx_ptr` is the same pointer `WindowsWindow::new`
-                        // produced via `Box::into_raw` and stored in this HWND's
-                        // `GWLP_USERDATA` — `ctx` (the shared reference used just
-                        // above) is derived from that same allocation, and its
-                        // last use is the `dispatch_event` call above, so no
-                        // reference into the box outlives this reclaim. The slot
-                        // is zeroed with `SetWindowLongPtrW` *before* `Box::from_raw`
-                        // runs, so if `dispatch_close`/`dispatch_event` above had
-                        // re-entrantly queried `GWLP_USERDATA` (they don't), they
-                        // would see null rather than a pointer about to be freed.
-                        // `window_proc` never runs concurrently with itself for
-                        // the same `hwnd` (Win32 serializes message dispatch per
-                        // queue), so this is the only path that can free `ctx_ptr`.
-                        SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
-                        drop(Box::from_raw(ctx_ptr));
+                            // Dispatch Closed event to global handlers
+                            ctx.dispatch_event(WindowEvent::Closed(ctx.window_id));
+
+                            if let Some(windows) = ctx.windows.upgrade() {
+                                windows.lock().remove(&(hwnd.0 as isize));
+                            }
+                        }
+                    }
+
+                    // SAFETY: this owner-thread WNDPROC is the only userdata
+                    // clearer. The invocation-local `ctx: Arc<_>` above stays
+                    // alive until this function returns, so consuming the
+                    // slot-owned strong reference cannot invalidate callback
+                    // stack frames, including after reentrant destruction.
+                    if let Err(error) = unsafe { take_window_context(hwnd) } {
+                        tracing::warn!(?hwnd, ?error, "failed to release HWND userdata context");
                     }
 
                     LRESULT(0)
@@ -478,10 +601,12 @@ impl WindowsPlatform {
                     // `BeginPaint`/`EndPaint` exactly once, satisfying
                     // Win32's required pairing.
                     let mut ps = PAINTSTRUCT::default();
-                    let hdc = BeginPaint(hwnd, &raw mut ps);
+                    let hdc = unsafe { BeginPaint(hwnd, &raw mut ps) };
                     if !hdc.is_invalid() {
                         // Skip rendering for minimized windows to save CPU/GPU resources
-                        let should_skip = WindowsWindow::should_skip_render(hwnd);
+                        let should_skip = ctx
+                            .as_deref()
+                            .is_some_and(WindowsWindow::should_skip_render);
                         if should_skip {
                             tracing::trace!("Skipping render for minimized window");
                         } else {
@@ -493,7 +618,7 @@ impl WindowsPlatform {
                             // the window is being live-resized. The background comes from the
                             // wgpu clear pass + the scene, not from a GDI fill (the old
                             // FillRect was overwritten by the present in the same frame).
-                            if let Some(ctx) = ctx {
+                            if let Some(ctx) = ctx.as_deref() {
                                 // Fire per-window on_request_frame callback
                                 ctx.callbacks.dispatch_request_frame();
 
@@ -503,7 +628,7 @@ impl WindowsPlatform {
                                 });
                             }
                         }
-                        let _ = EndPaint(hwnd, &raw const ps);
+                        let _ = unsafe { EndPaint(hwnd, &raw const ps) };
                     }
                     LRESULT(0)
                 }
@@ -515,10 +640,13 @@ impl WindowsPlatform {
                     let height = get_y_lparam(lparam).max(1);
                     let size_type = wparam.0 as u32;
 
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use flui_types::geometry::DevicePixels;
                         let size = Size::new(DevicePixels(width), DevicePixels(height));
-                        let prev_mode = ctx.mode.get();
+                        let (prev_mode, last_size, scale_factor) = {
+                            let state = ctx.state.lock();
+                            (state.mode, state.last_size, state.scale_factor)
+                        };
 
                         // Handle state transition and dispatch appropriate event
                         let (new_mode, event) = match size_type {
@@ -528,14 +656,10 @@ impl WindowsPlatform {
                                 let candidate = WindowMode::Minimized {
                                     previous: Bounds {
                                         origin: Point::new(DevicePixels(0), DevicePixels(0)),
-                                        size: ctx.last_size.get(),
+                                        size: last_size,
                                     },
                                 };
                                 if prev_mode.can_transition_to(&candidate) {
-                                    // Save current size before minimizing
-                                    if !prev_mode.is_minimized() {
-                                        ctx.last_size.set(size);
-                                    }
                                     (
                                         candidate,
                                         Some(WindowEvent::Minimized {
@@ -556,11 +680,10 @@ impl WindowsPlatform {
                                 let candidate = WindowMode::Maximized {
                                     previous: Bounds {
                                         origin: Point::new(DevicePixels(0), DevicePixels(0)),
-                                        size: ctx.last_size.get(),
+                                        size: last_size,
                                     },
                                 };
                                 if prev_mode.can_transition_to(&candidate) {
-                                    ctx.last_size.set(size);
                                     (
                                         candidate,
                                         Some(WindowEvent::Maximized {
@@ -584,7 +707,6 @@ impl WindowsPlatform {
                                 // NOT gate this event: a normal-state resize is always a valid
                                 // `Resized`. Gating on it dropped the event (and the last_size
                                 // update) on every live-resize drag step.
-                                ctx.last_size.set(size);
                                 let event = if prev_mode.is_minimized() || prev_mode.is_maximized()
                                 {
                                     tracing::info!("📐 Window Restored: {}x{}", width, height);
@@ -604,9 +726,6 @@ impl WindowsPlatform {
                             _ => {
                                 // Regular resize while in current state
                                 tracing::info!("📐 Window Resized: {}x{}", width, height);
-                                if prev_mode.is_normal() {
-                                    ctx.last_size.set(size);
-                                }
                                 (
                                     prev_mode,
                                     Some(WindowEvent::Resized {
@@ -617,23 +736,41 @@ impl WindowsPlatform {
                             }
                         };
 
-                        // Update state
-                        ctx.mode.set(new_mode);
+                        // Update cached state under one short lock, then release it before
+                        // any callback can synchronously re-enter WNDPROC.
+                        {
+                            let mut state = ctx.state.lock();
+                            state.mode = new_mode;
+                            if size_type != SIZE_MINIMIZED || !prev_mode.is_minimized() {
+                                state.last_size = size;
+                            }
+                            if size_type != SIZE_MINIMIZED {
+                                state.bounds.size = Size::new(
+                                    flui_types::geometry::px(super::util::device_to_logical(
+                                        width,
+                                        scale_factor,
+                                    )),
+                                    flui_types::geometry::px(super::util::device_to_logical(
+                                        height,
+                                        scale_factor,
+                                    )),
+                                );
+                            }
+                        }
 
                         // Fire per-window on_resize callback (for all size changes except minimize)
                         if size_type != SIZE_MINIMIZED {
                             let logical_size = Size::new(
                                 flui_types::geometry::px(super::util::device_to_logical(
                                     width,
-                                    ctx.scale_factor.get(),
+                                    scale_factor,
                                 )),
                                 flui_types::geometry::px(super::util::device_to_logical(
                                     height,
-                                    ctx.scale_factor.get(),
+                                    scale_factor,
                                 )),
                             );
-                            ctx.callbacks
-                                .dispatch_resize(logical_size, ctx.scale_factor.get());
+                            ctx.callbacks.dispatch_resize(logical_size, scale_factor);
                         }
 
                         // Dispatch event to global handlers if any
@@ -669,16 +806,22 @@ impl WindowsPlatform {
                     let y = get_y_lparam(lparam);
                     tracing::debug!("Window Moved: ({}, {})", x, y);
 
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
+                        let scale_factor = {
+                            let mut state = ctx.state.lock();
+                            state.bounds.origin = Point::new(
+                                flui_types::geometry::px(x as f32 / state.scale_factor),
+                                flui_types::geometry::px(y as f32 / state.scale_factor),
+                            );
+                            state.scale_factor
+                        };
                         // Fire per-window on_moved callback
                         ctx.callbacks.dispatch_moved();
 
                         // Dispatch Moved event to global handlers
                         use flui_types::geometry::{Point, px};
-                        let position = Point::new(
-                            px(x as f32 / ctx.scale_factor.get()),
-                            px(y as f32 / ctx.scale_factor.get()),
-                        );
+                        let position =
+                            Point::new(px(x as f32 / scale_factor), px(y as f32 / scale_factor));
                         ctx.dispatch_event(WindowEvent::Moved {
                             window_id: ctx.window_id,
                             position,
@@ -695,18 +838,12 @@ impl WindowsPlatform {
                     tracing::info!("🔍 DPI Changed: {} (scale: {:.2}x)", new_dpi, new_scale);
 
                     // Dispatch ScaleFactorChanged event
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
+                        ctx.state.lock().scale_factor = new_scale;
                         ctx.dispatch_event(WindowEvent::ScaleFactorChanged {
                             window_id: ctx.window_id,
                             scale_factor: new_scale as f64,
                         });
-
-                        // Update context scale factor through the shared
-                        // reference already held above — see the field doc
-                        // on `WindowContext::scale_factor` for why this must
-                        // not go through a second `&mut` reborrow of
-                        // `ctx_ptr`.
-                        ctx.scale_factor.set(new_scale);
 
                         // Suggested rect for new DPI
                         //
@@ -716,18 +853,22 @@ impl WindowsPlatform {
                         // null-check guards a caller that violates that
                         // documented contract, and `rect` is copied out
                         // (`RECT: Copy`) rather than referenced further.
-                        let suggested_rect = lparam.0 as *const RECT;
+                        let suggested_rect =
+                            std::ptr::with_exposed_provenance::<RECT>(lparam.0.cast_unsigned());
                         if !suggested_rect.is_null() {
-                            let rect = *suggested_rect;
-                            if let Err(error) = SetWindowPos(
-                                hwnd,
-                                None,
-                                rect.left,
-                                rect.top,
-                                rect.right - rect.left,
-                                rect.bottom - rect.top,
-                                SWP_NOZORDER | SWP_NOACTIVATE,
-                            ) {
+                            let rect = unsafe { *suggested_rect };
+                            let reposition_result = unsafe {
+                                SetWindowPos(
+                                    hwnd,
+                                    None,
+                                    rect.left,
+                                    rect.top,
+                                    rect.right - rect.left,
+                                    rect.bottom - rect.top,
+                                    SWP_NOZORDER | SWP_NOACTIVATE,
+                                )
+                            };
+                            if let Err(error) = reposition_result {
                                 tracing::warn!(
                                     ?hwnd,
                                     ?error,
@@ -741,7 +882,7 @@ impl WindowsPlatform {
                 }
 
                 WM_MOUSEMOVE => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         // Request WM_MOUSELEAVE notification for hover tracking
                         let mut tme = TRACKMOUSEEVENT {
                             cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
@@ -749,26 +890,33 @@ impl WindowsPlatform {
                             hwndTrack: hwnd,
                             dwHoverTime: 0,
                         };
-                        let _ = TrackMouseEvent(&raw mut tme);
+                        // SAFETY: `tme` is initialized with its exact size and
+                        // the current live HWND; Win32 does not retain it.
+                        let _ = unsafe { TrackMouseEvent(&raw mut tme) };
 
                         // Track hover state (T034)
-                        ctx.is_hovered.set(true);
+                        let scale_factor = {
+                            let mut state = ctx.state.lock();
+                            state.is_hovered = true;
+                            state.scale_factor
+                        };
 
                         // Dispatch hover enter (will be cleared on WM_MOUSELEAVE)
                         ctx.callbacks.dispatch_hover_status_change(true);
 
                         use super::events::mouse_move_event;
-                        let event = mouse_move_event(lparam, ctx.scale_factor.get());
+                        let event = mouse_move_event(lparam, scale_factor);
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)
                 }
 
                 WM_SETCURSOR => {
-                    if let Some(ctx) = ctx
+                    if let Some(ctx) = ctx.as_deref()
                         && (lparam.0 as u32 & 0xffff) == HTCLIENT
                     {
-                        match WindowsWindow::apply_native_cursor(ctx.cursor.get()) {
+                        let cursor = ctx.state.lock().cursor;
+                        match WindowsWindow::apply_native_cursor(cursor) {
                             Ok(()) => return LRESULT(1),
                             Err(error) => {
                                 tracing::warn!(
@@ -779,11 +927,11 @@ impl WindowsPlatform {
                             }
                         }
                     }
-                    DefWindowProcW(hwnd, msg, wparam, lparam)
+                    default_window_proc(hwnd, msg, wparam, lparam)
                 }
 
                 WM_LBUTTONDOWN => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use ui_events::pointer::PointerButton;
 
                         use super::events::mouse_button_event;
@@ -791,7 +939,7 @@ impl WindowsPlatform {
                             PointerButton::Primary,
                             true,
                             lparam,
-                            ctx.scale_factor.get(),
+                            ctx.state.lock().scale_factor,
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -799,7 +947,7 @@ impl WindowsPlatform {
                 }
 
                 WM_RBUTTONDOWN => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use ui_events::pointer::PointerButton;
 
                         use super::events::mouse_button_event;
@@ -807,7 +955,7 @@ impl WindowsPlatform {
                             PointerButton::Secondary,
                             true,
                             lparam,
-                            ctx.scale_factor.get(),
+                            ctx.state.lock().scale_factor,
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -815,7 +963,7 @@ impl WindowsPlatform {
                 }
 
                 WM_MBUTTONDOWN => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use ui_events::pointer::PointerButton;
 
                         use super::events::mouse_button_event;
@@ -823,7 +971,7 @@ impl WindowsPlatform {
                             PointerButton::Auxiliary,
                             true,
                             lparam,
-                            ctx.scale_factor.get(),
+                            ctx.state.lock().scale_factor,
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -831,7 +979,7 @@ impl WindowsPlatform {
                 }
 
                 WM_LBUTTONUP => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use ui_events::pointer::PointerButton;
 
                         use super::events::mouse_button_event;
@@ -839,7 +987,7 @@ impl WindowsPlatform {
                             PointerButton::Primary,
                             false,
                             lparam,
-                            ctx.scale_factor.get(),
+                            ctx.state.lock().scale_factor,
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -847,7 +995,7 @@ impl WindowsPlatform {
                 }
 
                 WM_RBUTTONUP => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use ui_events::pointer::PointerButton;
 
                         use super::events::mouse_button_event;
@@ -855,7 +1003,7 @@ impl WindowsPlatform {
                             PointerButton::Secondary,
                             false,
                             lparam,
-                            ctx.scale_factor.get(),
+                            ctx.state.lock().scale_factor,
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -863,7 +1011,7 @@ impl WindowsPlatform {
                 }
 
                 WM_MBUTTONUP => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use ui_events::pointer::PointerButton;
 
                         use super::events::mouse_button_event;
@@ -871,7 +1019,7 @@ impl WindowsPlatform {
                             PointerButton::Auxiliary,
                             false,
                             lparam,
-                            ctx.scale_factor.get(),
+                            ctx.state.lock().scale_factor,
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -879,9 +1027,10 @@ impl WindowsPlatform {
                 }
 
                 WM_MOUSEWHEEL => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         use super::events::mouse_wheel_event;
-                        let event = mouse_wheel_event(wparam, lparam, ctx.scale_factor.get());
+                        let event =
+                            mouse_wheel_event(wparam, lparam, ctx.state.lock().scale_factor);
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)
@@ -892,7 +1041,7 @@ impl WindowsPlatform {
                     let is_repeat = (lparam.0 & (1 << 30)) != 0;
 
                     // Check if fullscreen hotkey is pressed (configurable, default F11)
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         if let Some(hotkey) = ctx.config.fullscreen_hotkey
                             && vk == hotkey
                             && !is_repeat
@@ -901,11 +1050,12 @@ impl WindowsPlatform {
                                 "Fullscreen hotkey (VK={:#04x}) pressed - toggling fullscreen",
                                 hotkey
                             );
-                            WindowsWindow::toggle_fullscreen_for_hwnd(hwnd);
+                            let enter_fullscreen = !ctx.state.lock().mode.is_fullscreen();
+                            WindowsWindow::set_fullscreen_for_context(hwnd, ctx, enter_fullscreen);
                         }
 
                         // Track modifiers (T035)
-                        ctx.modifiers.set(current_modifiers());
+                        ctx.state.lock().modifiers = current_modifiers();
 
                         // Dispatch keyboard event via per-window callback
                         use super::events::key_down_event;
@@ -917,9 +1067,9 @@ impl WindowsPlatform {
                 }
 
                 WM_KEYUP | WM_SYSKEYUP => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         // Track modifiers (T035)
-                        ctx.modifiers.set(current_modifiers());
+                        ctx.state.lock().modifiers = current_modifiers();
 
                         use super::events::key_up_event;
                         let event = key_up_event(wparam, lparam);
@@ -937,7 +1087,8 @@ impl WindowsPlatform {
                 WM_SETFOCUS => {
                     tracing::debug!("Window Focused");
 
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
+                        ctx.state.lock().focused = true;
                         // Fire per-window on_active_status_change callback
                         ctx.callbacks.dispatch_active_status_change(true);
 
@@ -954,7 +1105,8 @@ impl WindowsPlatform {
                 WM_KILLFOCUS => {
                     tracing::debug!("Window Unfocused");
 
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
+                        ctx.state.lock().focused = false;
                         // Fire per-window on_active_status_change callback
                         ctx.callbacks.dispatch_active_status_change(false);
 
@@ -970,9 +1122,9 @@ impl WindowsPlatform {
 
                 // T025: Mouse hover tracking — WM_MOUSELEAVE (0x02A3)
                 0x02A3 => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         // Track hover state (T034)
-                        ctx.is_hovered.set(false);
+                        ctx.state.lock().is_hovered = false;
 
                         ctx.callbacks.dispatch_hover_status_change(false);
                     }
@@ -981,15 +1133,15 @@ impl WindowsPlatform {
 
                 // T026: System theme/appearance change
                 WM_SETTINGCHANGE => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         ctx.callbacks.dispatch_appearance_changed();
                     }
-                    DefWindowProcW(hwnd, msg, wparam, lparam)
+                    default_window_proc(hwnd, msg, wparam, lparam)
                 }
 
                 // T046: Keyboard layout change
                 WM_INPUTLANGCHANGE => {
-                    if let Some(ctx) = ctx {
+                    if let Some(ctx) = ctx.as_deref() {
                         // Dispatch keyboard layout change via take/restore pattern
                         let handler = ctx.handlers.lock().keyboard_layout_changed.take();
                         if let Some(mut handler) = handler {
@@ -997,10 +1149,10 @@ impl WindowsPlatform {
                             ctx.handlers.lock().keyboard_layout_changed = Some(handler);
                         }
                     }
-                    DefWindowProcW(hwnd, msg, wparam, lparam)
+                    default_window_proc(hwnd, msg, wparam, lparam)
                 }
 
-                _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+                _ => default_window_proc(hwnd, msg, wparam, lparam),
             }
         }
     }

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -1,6 +1,10 @@
 //! Windows window implementation
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    thread::{self, ThreadId},
+};
 
 use anyhow::{Context, Result};
 use cursor_icon::CursorIcon;
@@ -12,7 +16,7 @@ use raw_window_handle::{
 };
 use windows::{
     Win32::{
-        Foundation::{FALSE, HWND, POINT, RECT, TRUE},
+        Foundation::{FALSE, HWND, LPARAM, POINT, RECT, TRUE, WPARAM},
         Graphics::Gdi::{
             HRGN, InvalidateRect, MONITOR_DEFAULTTOPRIMARY, MonitorFromWindow, ScreenToClient,
             UpdateWindow,
@@ -22,15 +26,14 @@ use windows::{
             HiDpi::{GetDpiForSystem, GetDpiForWindow},
             WindowsAndMessaging::{
                 CW_USEDEFAULT, CreateWindowExW, DestroyWindow, GCLP_HBRBACKGROUND, GWL_STYLE,
-                GWLP_USERDATA, GetClientRect, GetCursorPos, GetForegroundWindow, GetWindowLongPtrW,
-                GetWindowPlacement, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_IBEAM,
-                IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
-                IsZoomed, LoadCursorW, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW,
+                GetClientRect, GetCursorPos, GetForegroundWindow, GetWindowLongPtrW,
+                IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_IBEAM, IDC_NO, IDC_SIZEALL,
+                IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT, LoadCursorW,
+                PostMessageW, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW,
                 SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
                 SetClassLongPtrW, SetCursor, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
-                SetWindowTextW, ShowWindow, WINDOWPLACEMENT, WS_EX_APPWINDOW, WS_MAXIMIZEBOX,
-                WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SYSMENU, WS_THICKFRAME,
-                WS_VISIBLE,
+                SetWindowTextW, ShowWindow, WS_EX_APPWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX,
+                WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SYSMENU, WS_THICKFRAME, WS_VISIBLE,
             },
         },
     },
@@ -55,48 +58,83 @@ pub struct WindowsWindow {
     /// Window state
     state: Arc<Mutex<WindowState>>,
 
-    /// Per-window callbacks for event delivery
-    callbacks: Arc<WindowCallbacks>,
-
-    /// Reference to platform's window map (for cleanup)
-    windows_map: Arc<Mutex<HashMap<isize, Arc<WindowsWindow>>>>,
+    /// Context shared with the WNDPROC invocation pin.
+    context: Arc<super::platform::WindowContext>,
 }
 
-// SAFETY, per field: `state` and `callbacks` are `Arc<Mutex<..>>`/`Arc<..>`
-// with their own synchronization; `windows_map` is likewise an
-// `Arc<Mutex<..>>`. The only non-`Sync` member is `hwnd: HWND`, a bare
+// SAFETY, per field: `state` is synchronized and `context` is compile-time
+// asserted `Send + Sync`. The only non-`Sync` member is `hwnd: HWND`, a bare
 // address — sending or sharing the address itself aliases nothing, so `Send`
 // and `Sync` are sound for the struct.
 //
 // NOT claimed — an HWND is thread-AFFINE, not "thread-safe by design": its
 // message queue belongs to the thread that created it, and Win32 requires
-// several of the calls below (`DestroyWindow`, `SetWindowLongPtrW` on
-// `GWLP_USERDATA`, anything touching the `WindowContext` stashed there) to
-// run on that owning thread to stay race-free against `window_proc`'s
-// `WM_DESTROY` handler freeing the same context. These impls only make it
-// legal to move/share the `Arc<WindowsWindow>` across threads; they do not
-// themselves discharge that thread-affinity obligation — see the per-call
-// SAFETY comments below and the same gap already documented on
-// `WindowsPlatform`'s `Send`/`Sync` impls in `platform.rs`.
+// several mutations below to run on that owning thread. The public fullscreen,
+// cursor, and close paths either execute on the recorded owner or post a
+// private command to its WNDPROC; synchronized queries never dereference the
+// raw userdata slot.
 unsafe impl Send for WindowsWindow {}
 unsafe impl Sync for WindowsWindow {}
 
 /// Mutable window state
-struct WindowState {
+pub(super) struct WindowState {
     /// Current window bounds (logical pixels)
-    bounds: Bounds<Pixels>,
+    pub(super) bounds: Bounds<Pixels>,
 
     /// Current scale factor (DPI / 96)
-    scale_factor: f32,
+    pub(super) scale_factor: f32,
 
     /// Is window visible?
-    visible: bool,
+    pub(super) visible: bool,
 
     /// Is window focused?
-    focused: bool,
+    pub(super) focused: bool,
 
     /// Window title
-    title: String,
+    pub(super) title: String,
+
+    pub(super) mode: WindowMode,
+    pub(super) last_size: Size<DevicePixels>,
+    pub(super) is_hovered: bool,
+    pub(super) modifiers: keyboard_types::Modifiers,
+    pub(super) cursor: CursorIcon,
+    pub(super) restore_style: u32,
+    pub(super) is_destroyed: bool,
+    owner_thread: ThreadId,
+}
+
+const WM_FLUI_ENTER_FULLSCREEN: u32 = windows::Win32::UI::WindowsAndMessaging::WM_APP + 1;
+const WM_FLUI_EXIT_FULLSCREEN: u32 = windows::Win32::UI::WindowsAndMessaging::WM_APP + 2;
+const WM_FLUI_APPLY_CURSOR: u32 = windows::Win32::UI::WindowsAndMessaging::WM_APP + 3;
+const WM_FLUI_CLOSE: u32 = windows::Win32::UI::WindowsAndMessaging::WM_APP + 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WindowCommand {
+    EnterFullscreen,
+    ExitFullscreen,
+    ApplyCursor,
+    Close,
+}
+
+impl WindowCommand {
+    pub(super) const fn from_message(message: u32) -> Option<Self> {
+        match message {
+            WM_FLUI_ENTER_FULLSCREEN => Some(Self::EnterFullscreen),
+            WM_FLUI_EXIT_FULLSCREEN => Some(Self::ExitFullscreen),
+            WM_FLUI_APPLY_CURSOR => Some(Self::ApplyCursor),
+            WM_FLUI_CLOSE => Some(Self::Close),
+            _ => None,
+        }
+    }
+
+    const fn message(self) -> u32 {
+        match self {
+            Self::EnterFullscreen => WM_FLUI_ENTER_FULLSCREEN,
+            Self::ExitFullscreen => WM_FLUI_EXIT_FULLSCREEN,
+            Self::ApplyCursor => WM_FLUI_APPLY_CURSOR,
+            Self::Close => WM_FLUI_CLOSE,
+        }
+    }
 }
 
 impl std::fmt::Debug for WindowsWindow {
@@ -117,28 +155,17 @@ impl WindowsWindow {
         handlers: Arc<Mutex<PlatformHandlers>>,
         config: crate::config::WindowConfiguration,
     ) -> Result<Arc<Self>> {
-        // SAFETY: `GetModuleHandleW(None)` queries the current process image
-        // and takes no pointer arguments — always sound. `GetDpiForSystem`
-        // reads global state, no preconditions. `CreateWindowExW` requires
-        // `WINDOW_CLASS_NAME` to already be registered, which
-        // `WindowsPlatform::with_config` guarantees before any `open_window`
-        // call can reach here; `&title` is a live `HSTRING` owned by this
-        // frame. `hwnd.is_invalid()` is checked immediately after, so every
-        // Win32 call below it only runs against a handle the OS just
-        // returned as valid. `SetClassLongPtrW` and `apply_windows_features`
-        // operate on that same freshly created, still-valid `hwnd`.
-        // `Box::into_raw(context)` intentionally leaks the allocation into
-        // the `GWLP_USERDATA` slot — ownership transfers to the window and is
-        // reclaimed by `WindowsPlatform::window_proc`'s `WM_DESTROY` arm
-        // (`platform.rs`, `Box::from_raw`); a window destroyed by any path
-        // that skips `WM_DESTROY` (process-exit teardown) leaks the
-        // allocation rather than double-frees or dangles it. `ShowWindow`/
-        // `UpdateWindow` again only need a valid `hwnd`, which holds here.
-        unsafe {
-            let hinstance = GetModuleHandleW(None).context("Failed to get module handle")?;
+        // Ordinary scope only: construction stays one expression while each
+        // Win32 operation receives its own narrow unsafe justification.
+        {
+            // SAFETY: `GetModuleHandleW(None)` queries the current process image
+            // and takes no pointer arguments.
+            let hinstance =
+                unsafe { GetModuleHandleW(None) }.context("Failed to get module handle")?;
 
-            // Get DPI for initial size calculation
-            let dpi = GetDpiForSystem();
+            // SAFETY: `GetDpiForSystem` takes no arguments and returns process DPI
+            // state by value.
+            let dpi = unsafe { GetDpiForSystem() };
             let scale_factor = dpi as f32 / USER_DEFAULT_SCREEN_DPI as f32;
 
             // Convert logical size to device pixels
@@ -160,20 +187,24 @@ impl WindowsWindow {
 
             // Create the window
             let title = HSTRING::from(&options.title);
-            let hwnd = CreateWindowExW(
-                ex_style,
-                WINDOW_CLASS_NAME,
-                &title,
-                style,
-                x,
-                y,
-                width,
-                height,
-                None, // parent
-                None, // menu
-                Some(hinstance.into()),
-                None, // lpParam
-            )
+            // SAFETY: the class is registered before `open_window`; `title` is a
+            // live HSTRING for the call and no pointer argument is retained.
+            let hwnd = unsafe {
+                CreateWindowExW(
+                    ex_style,
+                    WINDOW_CLASS_NAME,
+                    &title,
+                    style,
+                    x,
+                    y,
+                    width,
+                    height,
+                    None,
+                    None,
+                    Some(hinstance.into()),
+                    None,
+                )
+            }
             .context("Failed to create window")?;
 
             if hwnd.is_invalid() {
@@ -181,7 +212,9 @@ impl WindowsWindow {
             }
 
             // Remove background brush to allow Mica backdrop
-            SetClassLongPtrW(hwnd, GCLP_HBRBACKGROUND, 0);
+            // SAFETY: `hwnd` was just created successfully; this writes a plain
+            // zero brush-handle value to the registered class slot.
+            unsafe { SetClassLongPtrW(hwnd, GCLP_HBRBACKGROUND, 0) };
 
             // Apply Windows 11 features automatically
             Self::apply_windows_features(hwnd);
@@ -209,39 +242,49 @@ impl WindowsWindow {
                 visible: false,
                 focused: false,
                 title: options.title.clone(),
+                mode: WindowMode::Normal,
+                last_size: Size::new(
+                    DevicePixels(logical_to_device(width as f32, scale_factor)),
+                    DevicePixels(logical_to_device(height as f32, scale_factor)),
+                ),
+                is_hovered: false,
+                modifiers: keyboard_types::Modifiers::empty(),
+                cursor: CursorIcon::default(),
+                restore_style: 0,
+                is_destroyed: false,
+                owner_thread: thread::current().id(),
             }));
 
-            let window = Arc::new(Self {
-                hwnd,
-                state,
-                callbacks: Arc::clone(&callbacks),
-                windows_map,
-            });
-
             // Create and store WindowContext for event dispatch
-            use flui_types::geometry::{DevicePixels, Size};
-
             use super::platform::WindowContext;
 
             let window_id = WindowId(hwnd.0 as u64);
-            let device_width = logical_to_device(width as f32, scale_factor);
-            let device_height = logical_to_device(height as f32, scale_factor);
-            let initial_size = Size::new(DevicePixels(device_width), DevicePixels(device_height));
-            let context = Box::new(WindowContext {
+            let context = Arc::new(WindowContext {
                 window_id,
                 handlers: handlers.clone(),
                 callbacks,
-                scale_factor: std::cell::Cell::new(scale_factor),
-                mode: std::cell::Cell::new(WindowMode::Normal),
-                last_size: std::cell::Cell::new(initial_size),
+                state: Arc::clone(&state),
                 config,
-                is_hovered: std::cell::Cell::new(false),
-                modifiers: std::cell::Cell::new(keyboard_types::Modifiers::empty()),
-                cursor: std::cell::Cell::new(CursorIcon::default()),
-                restore_style: std::cell::Cell::new(0),
+                windows: Arc::downgrade(&windows_map),
             });
-            let context_ptr = Box::into_raw(context);
-            SetWindowLongPtrW(hwnd, GWLP_USERDATA, context_ptr as isize);
+            let window = Arc::new(Self {
+                hwnd,
+                state,
+                context: Arc::clone(&context),
+            });
+            if let Err(error) = super::platform::install_window_context(hwnd, context) {
+                window.state.lock().is_destroyed = true;
+                // SAFETY: creation succeeded on this owner thread; error
+                // cleanup destroys the unpublished HWND here.
+                if let Err(destroy_error) = unsafe { DestroyWindow(hwnd) } {
+                    tracing::warn!(
+                        ?hwnd,
+                        ?destroy_error,
+                        "DestroyWindow failed after userdata installation failure"
+                    );
+                }
+                return Err(error);
+            }
 
             // Show window if requested
             if options.visible {
@@ -252,8 +295,10 @@ impl WindowsWindow {
                 // warn on every visible window creation. Nothing meaningful
                 // to check here; UpdateWindow below does return a genuine
                 // success/failure BOOL.
-                let _ = ShowWindow(hwnd, SW_SHOW);
-                if let Err(error) = UpdateWindow(hwnd).ok() {
+                // SAFETY: `hwnd` is live and owner-affine here. ShowWindow's
+                // result is prior visibility; UpdateWindow reports failure.
+                let _ = unsafe { ShowWindow(hwnd, SW_SHOW) };
+                if let Err(error) = unsafe { UpdateWindow(hwnd) }.ok() {
                     tracing::warn!(?hwnd, ?error, "UpdateWindow failed in WindowsWindow::new");
                 }
                 window.state.lock().visible = true;
@@ -352,8 +397,7 @@ impl WindowsWindow {
         self.state.lock().scale_factor
     }
 
-    /// Toggle fullscreen mode for a window by HWND (static method for use from
-    /// window_proc)
+    /// Applies a fullscreen request on the HWND owner thread.
     ///
     /// This method implements borderless fullscreen by:
     /// 1. **Entering fullscreen**: Saves current window style and bounds,
@@ -370,42 +414,26 @@ impl WindowsWindow {
     /// - Dispatches `WindowEvent::Fullscreen` and `WindowEvent::ExitFullscreen`
     ///   events
     ///
-    /// # Thread Safety
-    /// This method is unsafe because it accesses raw window context via
-    /// GWLP_USERDATA. It should only be called from the window's message
-    /// loop thread or with proper synchronization.
-    ///
-    /// # Example
-    /// ```ignore
-    /// // Toggle fullscreen on F11 key press (from WM_KEYDOWN handler)
-    /// WindowsWindow::toggle_fullscreen_for_hwnd(hwnd);
-    /// ```
-    pub fn toggle_fullscreen_for_hwnd(hwnd: HWND) {
+    pub(super) fn set_fullscreen_for_context(
+        hwnd: HWND,
+        context: &super::platform::WindowContext,
+        fullscreen: bool,
+    ) {
         use windows::Win32::{
             Graphics::Gdi::{
                 GetMonitorInfoW, MONITOR_DEFAULTTOPRIMARY, MONITORINFO, MonitorFromWindow,
             },
             UI::WindowsAndMessaging::{
-                GWL_STYLE, GWLP_USERDATA, GetWindowLongPtrW, GetWindowRect, HWND_TOP,
-                SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SetWindowLongPtrW, SetWindowPos,
-                WS_POPUP, WS_VISIBLE,
+                GWL_STYLE, GetWindowLongPtrW, GetWindowRect, HWND_TOP, SWP_FRAMECHANGED,
+                SWP_NOACTIVATE, SWP_NOZORDER, SetWindowLongPtrW, SetWindowPos, WS_POPUP,
+                WS_VISIBLE,
             },
         };
 
-        // SAFETY: `ctx_ptr` is whatever `isize` is currently stored in
-        // `hwnd`'s `GWLP_USERDATA` slot. A non-null value was written by
-        // `WindowsWindow::new` (`Box::into_raw`) and is only cleared+freed by
-        // `WindowsPlatform::window_proc`'s `WM_DESTROY` arm, on this window's
-        // owning thread. The null check covers a window not yet initialized
-        // or already destroyed by the time this call reads the slot.
-        //
-        // Known gap (not fixed by this comment): this function is reachable
-        // both from `window_proc` (always on the owning thread, per the
-        // `# Thread Safety` doc above) and from `WindowsWindow::toggle_fullscreen`
-        // on `&self`, which carries no thread-affinity check — a caller on a
-        // different thread than the one servicing this HWND's message queue
-        // races the `WM_DESTROY` free with no synchronization discharging
-        // that race. `GetWindowRect`/`GetWindowLongPtrW`/`SetWindowLongPtrW`/
+        // SAFETY: the caller is either the HWND's WNDPROC or a public method
+        // after checking the owner thread recorded at creation. `context` is
+        // already Arc-pinned by that caller, so no userdata lookup or raw
+        // dereference occurs here. `GetWindowRect`/`GetWindowLongPtrW`/`SetWindowLongPtrW`/
         // `SetWindowPos`/`MonitorFromWindow`/`GetMonitorInfoW` below all take
         // `hwnd` or a `&raw mut` to a stack-local out-parameter whose size
         // matches what each call expects, and are otherwise ordinary Win32
@@ -413,16 +441,13 @@ impl WindowsWindow {
         // window, which the OS itself would report via a failed return
         // rather than UB if it did not.
         unsafe {
-            // Get WindowContext from GWLP_USERDATA
-            let ctx_ptr =
-                GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                tracing::warn!("Cannot toggle fullscreen: no WindowContext");
+            let (current_mode, restore_style, is_destroyed) = {
+                let state = context.state.lock();
+                (state.mode, state.restore_style, state.is_destroyed)
+            };
+            if is_destroyed || current_mode.is_fullscreen() == fullscreen {
                 return;
             }
-            let ctx = &*ctx_ptr;
-
-            let current_mode = ctx.mode.get();
 
             if let WindowMode::Fullscreen { restore_bounds } = current_mode {
                 // Exit fullscreen - restore previous style and bounds
@@ -436,7 +461,6 @@ impl WindowsWindow {
                 }
 
                 // Restore window style from WindowContext
-                let restore_style = ctx.restore_style.get();
                 SetWindowLongPtrW(hwnd, GWL_STYLE, restore_style as isize);
 
                 // Restore window position and size
@@ -457,11 +481,11 @@ impl WindowsWindow {
                 }
 
                 // Update state
-                ctx.mode.set(WindowMode::Normal);
+                context.state.lock().mode = WindowMode::Normal;
 
                 // Dispatch ExitFullscreen event
-                ctx.dispatch_event(crate::traits::WindowEvent::ExitFullscreen {
-                    window_id: ctx.window_id,
+                context.dispatch_event(crate::traits::WindowEvent::ExitFullscreen {
+                    window_id: context.window_id,
                     size: restore_bounds.size,
                 });
             } else {
@@ -480,7 +504,7 @@ impl WindowsWindow {
 
                 // Save current style to WindowContext
                 let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
-                ctx.restore_style.set(current_style);
+                context.state.lock().restore_style = current_style;
 
                 // Save current bounds
                 let restore_bounds = Bounds {
@@ -535,15 +559,15 @@ impl WindowsWindow {
                 }
 
                 // Update state
-                ctx.mode.set(candidate);
+                context.state.lock().mode = candidate;
 
                 // Dispatch Fullscreen event
                 let size = Size::new(
                     flui_types::geometry::DevicePixels(monitor_rect.right - monitor_rect.left),
                     flui_types::geometry::DevicePixels(monitor_rect.bottom - monitor_rect.top),
                 );
-                ctx.dispatch_event(crate::traits::WindowEvent::Fullscreen {
-                    window_id: ctx.window_id,
+                context.dispatch_event(crate::traits::WindowEvent::Fullscreen {
+                    window_id: context.window_id,
                     size,
                 });
             }
@@ -552,25 +576,12 @@ impl WindowsWindow {
 
     /// Toggle fullscreen mode for this window
     pub fn toggle_fullscreen(&self) {
-        Self::toggle_fullscreen_for_hwnd(self.hwnd);
+        self.set_fullscreen(!self.is_fullscreen());
     }
 
     /// Check if the window is currently in fullscreen mode
     pub fn is_fullscreen(&self) -> bool {
-        // SAFETY: same `GWLP_USERDATA` contract as
-        // `toggle_fullscreen_for_hwnd` above — non-null implies `new`
-        // populated it and `WM_DESTROY` (owning thread only) hasn't cleared
-        // it yet; the same cross-thread race is a known, undischarged gap
-        // when this is called off that thread.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return false;
-            }
-            let ctx = &*ctx_ptr;
-            ctx.mode.get().is_fullscreen()
-        }
+        self.state.lock().mode.is_fullscreen()
     }
 
     /// Set fullscreen mode
@@ -578,32 +589,89 @@ impl WindowsWindow {
     /// # Arguments
     /// * `fullscreen` - true to enter fullscreen, false to exit fullscreen
     pub fn set_fullscreen(&self, fullscreen: bool) {
-        let is_fullscreen = self.is_fullscreen();
-
-        // Only toggle if state needs to change
-        if fullscreen != is_fullscreen {
-            Self::toggle_fullscreen_for_hwnd(self.hwnd);
-        }
+        let command = if fullscreen {
+            WindowCommand::EnterFullscreen
+        } else {
+            WindowCommand::ExitFullscreen
+        };
+        self.execute_or_post(command);
     }
 
     /// Check if rendering should be skipped for this window
     ///
     /// Returns true if the window is minimized, as rendering minimized windows
     /// wastes CPU/GPU resources without any visible output.
-    pub fn should_skip_render(hwnd: HWND) -> bool {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above. Every current call site (`platform.rs`'s `WM_PAINT` arm)
-        // runs on the owning thread, so the race noted there does not apply
-        // here today — but the function itself does not enforce that, since
-        // it takes a bare `HWND` from any caller.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return false;
+    pub(super) fn should_skip_render(context: &super::platform::WindowContext) -> bool {
+        context.state.lock().mode.is_minimized()
+    }
+
+    fn execute_or_post(&self, command: WindowCommand) {
+        let (is_owner, is_destroyed) = {
+            let state = self.state.lock();
+            (
+                state.owner_thread == thread::current().id(),
+                state.is_destroyed,
+            )
+        };
+        if is_destroyed {
+            return;
+        }
+        if is_owner {
+            Self::execute_window_command(self.hwnd, &self.context, command);
+        } else if let Err(error) = self.post_command(command) {
+            tracing::warn!(
+                hwnd = ?self.hwnd,
+                ?command,
+                ?error,
+                "PostMessageW failed for owner-thread window command"
+            );
+        }
+    }
+
+    fn post_command(&self, command: WindowCommand) -> windows::core::Result<()> {
+        // SAFETY: these private messages carry no pointer payload. The HWND
+        // owner thread decodes the closed `WindowCommand` vocabulary in its
+        // WNDPROC and uses the invocation-local Arc pin acquired there.
+        unsafe { PostMessageW(Some(self.hwnd), command.message(), WPARAM(0), LPARAM(0)) }
+    }
+
+    pub(super) fn execute_window_command(
+        hwnd: HWND,
+        context: &super::platform::WindowContext,
+        command: WindowCommand,
+    ) {
+        match command {
+            WindowCommand::EnterFullscreen => {
+                Self::set_fullscreen_for_context(hwnd, context, true);
             }
-            let ctx = &*ctx_ptr;
-            ctx.mode.get().is_minimized()
+            WindowCommand::ExitFullscreen => {
+                Self::set_fullscreen_for_context(hwnd, context, false);
+            }
+            WindowCommand::ApplyCursor => {
+                let cursor = {
+                    let state = context.state.lock();
+                    if state.is_destroyed || !state.is_hovered {
+                        return;
+                    }
+                    state.cursor
+                };
+                if let Err(error) = Self::apply_native_cursor(cursor) {
+                    tracing::warn!(?hwnd, ?error, "failed to apply owner-thread cursor command");
+                }
+            }
+            WindowCommand::Close => {
+                if context.state.lock().is_destroyed {
+                    return;
+                }
+                // SAFETY: this function is only invoked directly on the
+                // recorded owner thread or from the HWND's WNDPROC. Win32
+                // synchronously dispatches `WM_DESTROY` before returning.
+                unsafe {
+                    if let Err(error) = DestroyWindow(hwnd) {
+                        tracing::warn!(?hwnd, ?error, "DestroyWindow failed for close command");
+                    }
+                }
+            }
         }
     }
 
@@ -691,20 +759,25 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn set_cursor(&self, cursor: CursorIcon) -> Result<(), CursorError> {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above; `.as_ref()` turns the possibly-null raw pointer into
-        // `Option<&WindowContext>` without dereferencing a null pointer, and
-        // the cross-thread `WM_DESTROY` race documented there applies
-        // equally here.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            let context = ctx_ptr
-                .as_ref()
-                .ok_or_else(|| CursorError::Backend("the native window is closed".to_string()))?;
-            context.cursor.set(cursor);
-            if context.is_hovered.get() {
+        let (is_owner, should_apply) = {
+            let mut state = self.state.lock();
+            if state.is_destroyed {
+                return Err(CursorError::Backend(
+                    "the native window is closed".to_string(),
+                ));
+            }
+            state.cursor = cursor;
+            (
+                state.owner_thread == thread::current().id(),
+                state.is_hovered,
+            )
+        };
+        if should_apply {
+            if is_owner {
                 Self::apply_native_cursor(cursor)?;
+            } else {
+                self.post_command(WindowCommand::ApplyCursor)
+                    .map_err(|error| CursorError::Backend(error.to_string()))?;
             }
         }
         Ok(())
@@ -737,17 +810,8 @@ impl PlatformWindow for WindowsWindow {
 
     fn window_bounds(&self) -> WindowBounds {
         let bounds = self.bounds();
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above, including the same undischarged cross-thread race.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if !ctx_ptr.is_null() {
-                let ctx = &*ctx_ptr;
-                if ctx.mode.get().is_fullscreen() {
-                    return WindowBounds::Fullscreen(bounds);
-                }
-            }
+        if self.state.lock().mode.is_fullscreen() {
+            return WindowBounds::Fullscreen(bounds);
         }
         if PlatformWindow::is_maximized(self) {
             WindowBounds::Maximized(bounds)
@@ -757,10 +821,7 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn is_maximized(&self) -> bool {
-        // SAFETY: `IsZoomed` takes `self.hwnd` by value and returns a
-        // `BOOL` — no pointer arguments, no invariant beyond an ordinary
-        // FFI call.
-        unsafe { IsZoomed(self.hwnd).as_bool() }
+        self.state.lock().mode.is_maximized()
     }
 
     fn is_fullscreen(&self) -> bool {
@@ -769,25 +830,22 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn is_active(&self) -> bool {
+        if self.state.lock().is_destroyed {
+            return false;
+        }
         // SAFETY: `GetForegroundWindow` takes no arguments; comparing its
         // result to `self.hwnd` is a plain integer/handle comparison.
         unsafe { GetForegroundWindow() == self.hwnd }
     }
 
     fn is_hovered(&self) -> bool {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above, including the same undischarged cross-thread race.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return false;
-            }
-            (*ctx_ptr).is_hovered.get()
-        }
+        self.state.lock().is_hovered
     }
 
     fn mouse_position(&self) -> Point<Pixels> {
+        if self.state.lock().is_destroyed {
+            return Point::default();
+        }
         // SAFETY: `cursor_pos` is a stack-local `POINT`; `&raw mut
         // cursor_pos` gives both `GetCursorPos` and `ScreenToClient` a
         // valid, correctly-sized out-parameter. The `is_ok()`/`as_bool()`
@@ -810,30 +868,18 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn modifiers(&self) -> keyboard_types::Modifiers {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above, including the same undischarged cross-thread race.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return keyboard_types::Modifiers::empty();
-            }
-            (*ctx_ptr).modifiers.get()
-        }
+        self.state.lock().modifiers
     }
 
     fn appearance(&self) -> WindowAppearance {
-        // SAFETY: the `GWLP_USERDATA` read shares the contract documented on
-        // `toggle_fullscreen_for_hwnd` above. `DwmGetWindowAttribute` below
+        if self.state.lock().is_destroyed {
+            return WindowAppearance::default();
+        }
+        // SAFETY: `DwmGetWindowAttribute` below
         // writes through `&raw mut dark_mode` cast to `c_void`, sized via
         // `size_of::<i32>()` to match the stack-local `i32` it points at;
         // `dark_mode` is only read after checking `result.is_ok()`.
         unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return WindowAppearance::default();
-            }
             // Check DWM dark mode attribute
             use windows::Win32::Graphics::Dwm::{DWMWINDOWATTRIBUTE, DwmGetWindowAttribute};
             let mut dark_mode: i32 = 0;
@@ -852,6 +898,9 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn display(&self) -> Option<Arc<dyn PlatformDisplay>> {
+        if self.state.lock().is_destroyed {
+            return None;
+        }
         // SAFETY: `MonitorFromWindow` takes `self.hwnd` by value and a flag;
         // `MONITOR_DEFAULTTOPRIMARY` guarantees a non-null `HMONITOR` even
         // for an invalid `hwnd`, so the `is_invalid()` check below is
@@ -959,16 +1008,7 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn close(&self) {
-        // SAFETY: `DestroyWindow` takes `self.hwnd` by value; `WM_DESTROY`
-        // (handled in `platform.rs`) reclaims the `GWLP_USERDATA` allocation
-        // synchronously within this same call before it returns, on this
-        // thread — Win32 dispatches `WM_DESTROY` to the window procedure
-        // before `DestroyWindow` returns.
-        unsafe {
-            if let Err(error) = DestroyWindow(self.hwnd) {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow (PlatformWindow::close) failed");
-            }
-        }
+        self.execute_or_post(WindowCommand::Close);
     }
 
     fn set_background_appearance(&self, appearance: WindowBackgroundAppearance) {
@@ -1006,43 +1046,43 @@ impl PlatformWindow for WindowsWindow {
     // ==================== Per-Window Callbacks ====================
 
     fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult + Send>) {
-        *self.callbacks.on_input.lock() = Some(callback);
+        *self.context.callbacks.on_input.lock() = Some(callback);
     }
 
     fn on_request_frame(&self, callback: Box<dyn FnMut() + Send>) {
-        *self.callbacks.on_request_frame.lock() = Some(callback);
+        *self.context.callbacks.on_request_frame.lock() = Some(callback);
     }
 
     fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32) + Send>) {
-        *self.callbacks.on_resize.lock() = Some(callback);
+        *self.context.callbacks.on_resize.lock() = Some(callback);
     }
 
     fn on_moved(&self, callback: Box<dyn FnMut() + Send>) {
-        *self.callbacks.on_moved.lock() = Some(callback);
+        *self.context.callbacks.on_moved.lock() = Some(callback);
     }
 
     fn on_close(&self, callback: Box<dyn FnOnce() + Send>) {
-        *self.callbacks.on_close.lock() = Some(callback);
+        *self.context.callbacks.on_close.lock() = Some(callback);
     }
 
     fn on_should_close(&self, callback: Box<dyn FnMut() -> bool + Send>) {
-        *self.callbacks.on_should_close.lock() = Some(callback);
+        *self.context.callbacks.on_should_close.lock() = Some(callback);
     }
 
     fn on_active_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
-        *self.callbacks.on_active_status_change.lock() = Some(callback);
+        *self.context.callbacks.on_active_status_change.lock() = Some(callback);
     }
 
     fn on_visibility_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
-        *self.callbacks.on_visibility_status_change.lock() = Some(callback);
+        *self.context.callbacks.on_visibility_status_change.lock() = Some(callback);
     }
 
     fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
-        *self.callbacks.on_hover_status_change.lock() = Some(callback);
+        *self.context.callbacks.on_hover_status_change.lock() = Some(callback);
     }
 
     fn on_appearance_changed(&self, callback: Box<dyn FnMut() + Send>) {
-        *self.callbacks.on_appearance_changed.lock() = Some(callback);
+        *self.context.callbacks.on_appearance_changed.lock() = Some(callback);
     }
 
     fn window_handle(
@@ -1095,9 +1135,9 @@ impl HasWindowHandle for WindowsWindow {
         // `WindowHandle` borrowed from it, is still held and used elsewhere
         // (e.g. by wgpu to (re)create a surface). This is the same
         // undischarged-HWND-lifetime class as the documented cross-thread
-        // `GWLP_USERDATA` race on this type's `Send`/`Sync` impls above —
-        // a real gap this comment does not close, not a validity claim
-        // this code has actually established.
+        // userdata lifetime is independently pinned by WNDPROC now, but the
+        // raw native handle's validity still is not tied to `&self`; this
+        // remains a real gap, not a validity claim this code established.
         Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(RawWindowHandle::Win32(handle)) })
     }
 }
@@ -1117,17 +1157,6 @@ impl HasDisplayHandle for WindowsWindow {
         Ok(unsafe {
             raw_window_handle::DisplayHandle::borrow_raw(RawDisplayHandle::Windows(handle))
         })
-    }
-}
-
-impl Clone for WindowsWindow {
-    fn clone(&self) -> Self {
-        Self {
-            hwnd: self.hwnd,
-            state: Arc::clone(&self.state),
-            callbacks: Arc::clone(&self.callbacks),
-            windows_map: Arc::clone(&self.windows_map),
-        }
     }
 }
 
@@ -1218,16 +1247,11 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn state(&self) -> CrossWindowState {
-        let placement = self.get_window_placement();
-
-        if placement.showCmd == SW_MINIMIZE.0 as u32 {
-            CrossWindowState::Minimized
-        } else if placement.showCmd == SW_MAXIMIZE.0 as u32 {
-            CrossWindowState::Maximized
-        } else if self.is_fullscreen() {
-            CrossWindowState::Fullscreen
-        } else {
-            CrossWindowState::Normal
+        match self.state.lock().mode {
+            WindowMode::Minimized { .. } => CrossWindowState::Minimized,
+            WindowMode::Maximized { .. } => CrossWindowState::Maximized,
+            WindowMode::Fullscreen { .. } => CrossWindowState::Fullscreen,
+            WindowMode::Normal => CrossWindowState::Normal,
         }
     }
 
@@ -1398,12 +1422,7 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn close(&mut self) {
-        // SAFETY: see `PlatformWindow::close` above — same call shape.
-        unsafe {
-            if let Err(error) = DestroyWindow(self.hwnd) {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed");
-            }
-        }
+        self.execute_or_post(WindowCommand::Close);
     }
 
     fn request_redraw(&mut self) {
@@ -1443,28 +1462,6 @@ impl WindowTrait for WindowsWindow {
 }
 
 impl WindowsWindow {
-    /// Helper to get window placement
-    fn get_window_placement(&self) -> WINDOWPLACEMENT {
-        // SAFETY: `placement` is a stack-local `WINDOWPLACEMENT` with
-        // `length` pre-filled to its own `size_of` as the API requires;
-        // `&raw mut placement` gives `GetWindowPlacement` a valid,
-        // correctly-sized out-parameter regardless of whether the call
-        // succeeds, so returning `placement` on `Err` is safe (it holds the
-        // `Default` values this function seeded, not uninitialized memory) —
-        // callers just get a placement that will not match SW_MINIMIZE or
-        // SW_MAXIMIZE, i.e. a normal-state placement.
-        unsafe {
-            let mut placement = WINDOWPLACEMENT {
-                length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
-                ..Default::default()
-            };
-            if let Err(error) = GetWindowPlacement(self.hwnd, &raw mut placement) {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "GetWindowPlacement failed");
-            }
-            placement
-        }
-    }
-
     /// Set DWM window attribute
     ///
     /// # Safety
@@ -1820,26 +1817,26 @@ impl WindowsWindowExtTrait for WindowsWindow {
 
 impl Drop for WindowsWindow {
     fn drop(&mut self) {
-        // Only destroy if this is the last reference
-        if Arc::strong_count(&self.state) == 1 {
-            tracing::debug!("Destroying window HWND {:?}", self.hwnd);
+        let (is_owner, is_destroyed) = {
+            let state = self.state.lock();
+            (
+                state.owner_thread == thread::current().id(),
+                state.is_destroyed,
+            )
+        };
+        if is_destroyed || self.hwnd.is_invalid() {
+            return;
+        }
 
-            // SAFETY: `DestroyWindow` takes `self.hwnd` by value; the
-            // `is_invalid()` guard skips the call for a handle that was
-            // never successfully created, and `WM_DESTROY` (handled in
-            // `platform.rs`) reclaims the `GWLP_USERDATA` allocation
-            // synchronously within this call.
-            unsafe {
-                if !self.hwnd.is_invalid()
-                    && let Err(error) = DestroyWindow(self.hwnd)
-                {
-                    tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed in Drop");
-                }
-            }
-
-            // Remove from windows map
-            let hwnd_key = self.hwnd.0 as isize;
-            self.windows_map.lock().remove(&hwnd_key);
+        tracing::debug!("Closing live window from WindowsWindow::drop");
+        if is_owner {
+            Self::execute_window_command(self.hwnd, &self.context, WindowCommand::Close);
+        } else if let Err(error) = self.post_command(WindowCommand::Close) {
+            tracing::warn!(
+                hwnd = ?self.hwnd,
+                ?error,
+                "PostMessageW failed while closing window from foreign-thread Drop"
+            );
         }
     }
 }

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -243,10 +243,12 @@ impl WindowsWindow {
                 focused: false,
                 title: options.title.clone(),
                 mode: WindowMode::Normal,
-                last_size: Size::new(
-                    DevicePixels(logical_to_device(width as f32, scale_factor)),
-                    DevicePixels(logical_to_device(height as f32, scale_factor)),
-                ),
+                // `width`/`height` are ALREADY device pixels — they were
+                // converted from `options.size` above. Converting again here
+                // squared the scale factor, so a 2x display recorded a
+                // `last_size` four times the logical size, which restore and
+                // minimize sizing then read back.
+                last_size: Size::new(DevicePixels(width), DevicePixels(height)),
                 is_hovered: false,
                 modifiers: keyboard_types::Modifiers::empty(),
                 cursor: CursorIcon::default(),
@@ -783,7 +785,7 @@ impl PlatformWindow for WindowsWindow {
         Ok(())
     }
 
-    // ==================== Query Methods (US2) ====================
+    // ==================== Query Methods ====================
 
     fn bounds(&self) -> Bounds<Pixels> {
         self.state.lock().bounds
@@ -925,7 +927,7 @@ impl PlatformWindow for WindowsWindow {
         self.state.lock().title.clone()
     }
 
-    // ==================== Control Methods (US2) ====================
+    // ==================== Control Methods ====================
 
     fn set_title(&self, title: &str) {
         // SAFETY: `title_str` is a live, locally-owned `HSTRING` for the

--- a/docs/safety-review.md
+++ b/docs/safety-review.md
@@ -1,0 +1,161 @@
+# Safety Review: Win32 HWND userdata context lifetime
+
+**Audit date:** 2026-08-10
+
+**Scope:** `flui-platform`'s `WindowContext` ownership at the
+`HWND`/`GWLP_USERDATA` boundary only
+
+**Base revision:** `030f89f520b1384f88b0e3ebc12d6263795013f1`
+
+---
+
+## Unsafe sites
+
+| Site | Operation | Status | Severity | Miri |
+|---|---|---|---|---|
+| `crates/flui-platform/src/platforms/windows/platform.rs:101` (unsafe groups at lines 111–115, 131–135, 145) — `install_window_context` | Transfer one `Arc` strong reference into `GWLP_USERDATA` | Documented | Boundary | Blocked |
+| `crates/flui-platform/src/platforms/windows/platform.rs:162` (unsafe expressions at lines 172, 181–184) — `acquire_window_context` | Increment and reconstruct an invocation-local `Arc` | Documented | Boundary | Blocked |
+| `crates/flui-platform/src/platforms/windows/platform.rs:195` (unsafe expressions at lines 205–209, 215) — `take_window_context` | Clear userdata and consume its strong reference | Documented | Boundary | Blocked |
+| `crates/flui-platform/src/platforms/windows/platform.rs:489` (narrow unsafe expressions at lines 501, 529, 537, 581, 604, 631, 859–860, 895) — `WindowsPlatform::window_proc` | Win32 WNDPROC dispatch and reentrant teardown | Documented | Boundary | Blocked |
+
+This review does not claim to enumerate or approve unrelated unsafe sites in the
+Win32 backend.
+
+---
+
+## Why unsafe is necessary
+
+Win32 exposes `GWLP_USERDATA` as an untyped pointer-sized integer. Rust cannot
+express ownership in that OS-managed slot directly, so the boundary must convert
+one `Arc<WindowContext>` strong reference to a raw pointer and reconstruct it.
+The rest of the backend uses safe `Arc` and `parking_lot::Mutex` ownership; raw
+Arc operations are isolated to three helpers beside WNDPROC.
+
+The conversion deliberately uses strict-provenance APIs: installation calls
+`expose_provenance` before storing the address, and acquisition/teardown call
+`with_exposed_provenance` before any Arc operation. There is no plain
+integer-to-pointer cast at this boundary.
+
+---
+
+## Safety invariants
+
+### `install_window_context` — raw strong-reference transfer
+
+- **Invariant:** the stored pointer was produced by `Arc::into_raw` for exactly
+  one `Arc<WindowContext>` strong reference.
+- **Holds because:** this is the only installation helper, called once after a
+  FLUI HWND is created. It verifies the slot is empty before converting the Arc
+  to raw, so an unexpected foreign value is rejected without being overwritten.
+  A successful write transfers ownership to the slot; a detected write failure
+  reconstructs and drops the reference. If the owner-serialized preflight
+  invariant is externally violated between calls, a successful replacement is
+  left slot-owned for caller-driven HWND destruction rather than creating a
+  dangling pointer.
+
+### `acquire_window_context` — invocation pin
+
+- **Invariant:** a non-null slot value still owns a live strong reference while
+  `Arc::increment_strong_count` executes.
+- **Holds because:** Win32 serializes WNDPROC dispatch for an HWND on its owner
+  thread, and only WNDPROC clears the slot. The increment happens before any
+  callback or nested dispatch. The reconstructed local `Arc` therefore remains
+  live if a callback synchronously causes `WM_DESTROY`.
+
+### `take_window_context` — slot teardown
+
+- **Invariant:** a nonzero value returned while clearing the slot is the exact
+  raw Arc reference previously transferred to it, and is consumed once.
+- **Holds because:** installation and teardown are private to the same module;
+  `WM_DESTROY` is the sole clearing path. A failed ambiguous zero return is
+  reported without reconstructing a pointer, preferring a leak to a guessed
+  double decrement.
+
+### `WindowsPlatform::window_proc` — reentrant callback lifetime
+
+- **Invariant:** every callback observes a live `WindowContext`, and no state or
+  callback-storage lock is held across callback invocation or nested Win32
+  dispatch.
+- **Holds because:** WNDPROC acquires its local Arc before dispatch. Mutable
+  window data is copied or updated under short `WindowState` locks that are
+  dropped before callbacks. `WM_DESTROY` marks the cache destroyed, dispatches
+  close notifications, removes the weak-backed registry entry, then clears the
+  slot; the invocation-local Arc outlives all of those operations.
+
+---
+
+## How invariants are upheld
+
+- All raw userdata reads, writes, and Arc reconstruction live in
+  `platform.rs`'s three private helpers.
+- Raw pointer addresses cross Win32's integer slot only through
+  `expose_provenance` and `with_exposed_provenance`.
+- `WindowContext` contains no `Cell`; its mutable data shares the synchronized
+  `WindowState` used by `WindowsWindow`.
+- A compile-time assertion requires `WindowContext: Send + Sync`.
+- Public window methods never access userdata. Fullscreen, cursor application,
+  and close use a private, closed owner-command vocabulary; foreign-thread
+  calls use `PostMessageW` and trace failures.
+- `WindowContext` holds only a `Weak` registry reference, so the platform map
+  does not participate in an Arc cycle.
+- `WindowsWindow` has no by-value `Clone` implementation; shared ownership is
+  exclusively `Arc<WindowsWindow>`, so each Rust window value has one Drop path.
+- Cached destroyed state makes post-close queries deterministic and prevents
+  recursive native destruction.
+- Constructor and WNDPROC unsafe operations are scoped to the individual FFI or
+  raw-Arc operation; safe state transitions and callback dispatch no longer sit
+  inside function-sized unsafe blocks.
+
+---
+
+## Verification
+
+**Miri**
+
+Miri was attempted for `flui-platform`, but execution is blocked by the
+unsupported `OpenClipboard` foreign-function call. This is not a clean Miri
+run and provides no runtime validation of the Win32-only path.
+
+**Windows cross-target evidence**
+
+```text
+$ cargo clippy -p flui-platform --locked --all-targets \
+  --target x86_64-pc-windows-msvc -- -D warnings
+    Blocking waiting for file lock on build directory
+   Compiling flui-platform v0.2.0 (/mnt/data/worktrees/win32-userdata-lifetime/crates/flui-platform)
+    Finished `dev` profile [optimized + debuginfo] target(s) in 4.13s
+```
+
+This cross-target check compiles and lints the backend but does not link or
+execute it on Windows.
+
+**Structural evidence**
+
+- `rg 'GWLP_USERDATA|Arc::(into_raw|from_raw|increment_strong_count)'` confirms
+  the boundary is centralized in `platform.rs`.
+- `rg 'as \*const WindowContext|as \*mut WindowContext|\.addr\(\)'` confirms
+  no plain integer-to-pointer reconstruction or non-exposed address storage
+  remains at the userdata boundary.
+- `rg 'Cell<'` confirms `WindowContext` has no unsynchronized mutable fields.
+- The compile-time `Send + Sync` assertion is built by the Windows cross-target
+  command.
+
+No sanitizer run or Windows runtime test was performed.
+
+---
+
+## Reviewer sign-off — SAFETY-GATE: partial
+
+| Check | Result |
+|---|---|
+| All unsafe sites in the scoped userdata boundary listed and justified | Complete |
+| Invariants sufficient to rule out userdata use-after-free | Complete — final auditor confirmed all nine blockers resolved |
+| Invariants enforced by the module boundary | Complete |
+| Miri run clean | No — blocked by unsupported `OpenClipboard` FFI |
+| Sanitizer run clean | Not run |
+| Native Windows teardown exercised | Not run |
+
+**SAFETY-GATE:** `PARTIAL`
+
+This document does not grant a whole-backend SAFETY-GATE pass. Native Windows
+runtime validation remains required.


### PR DESCRIPTION
`GWLP_USERDATA` held a raw `WindowContext` the window proc borrowed as
`&*ctx_ptr` for the duration of a dispatch. A callback that reentrantly
destroys the HWND frees that context while the borrow is live. The slot now
owns an `Arc` and `acquire_window_context` pins an invocation-local strong
reference before any callback runs.

Ships `docs/safety-review.md` for the pointer-provenance reasoning: the slot
round-trip uses expose/with-exposed-provenance, because `ptr.addr()` cannot
justify a later `Arc` reconstruction.

Honest scope note: this backend has **no executable coverage anywhere** —
`cross-typecheck` lints it without linking and runs no tests, and `gpu-test` is
Windows/WARP only. The evidence here is the safety review plus
`cargo clippy -p flui-platform --target x86_64-pc-windows-msvc -- -D warnings`.

Base of a two-PR stack: this → #598 (window-proc panic boundary), which had to
be re-derived on top of this one — see that PR.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM