### PR TITLE
fix(semantics): publish the explicit role in serialized node data

### DIFF
--- a/crates/flui-semantics/src/node.rs
+++ b/crates/flui-semantics/src/node.rs
@@ -292,6 +292,7 @@ impl SemanticsNode {
             hint: self.config.hint().map(|h| h.string.clone()),
             tooltip: self.config.tooltip().map(Into::into),
             text_direction: self.config.text_direction(),
+            role: self.config.role(),
             rect: self.rect,
             transform: self.transform.unwrap_or(Matrix4::IDENTITY),
             children: self.children.iter().map(|c| (c.get() - 1) as u64).collect(),
@@ -498,5 +499,43 @@ mod tests {
             SemanticsAction::DidGainAccessibilityFocus.value(),
         );
         assert_eq!(data.rect, node.rect());
+    }
+}
+
+#[cfg(test)]
+mod role_propagation_tests {
+    use super::*;
+    use crate::role::SemanticsRole;
+
+    /// A role set on the configuration must survive into the serialized node
+    /// data, which is the only thing a platform accessibility bridge ever sees.
+    ///
+    /// `to_node_data` copies roughly fifteen fields off the config — flags,
+    /// actions, label, value, hint, tooltip, text direction — and used to omit
+    /// exactly one: the role. So `Semantics(role: ColumnHeader)` in
+    /// `flui-material`'s `DataTable`, and `Tab`/`TabBar` in `NavigationBar`,
+    /// reached the test-only snapshot and nothing else. Screen readers use the
+    /// structural roles for navigation, and none of them were being published.
+    #[test]
+    fn an_explicit_role_survives_into_the_serialized_node_data() {
+        let mut node = SemanticsNode::new();
+        node.config_mut().set_role(SemanticsRole::ColumnHeader);
+
+        let data = node.to_node_data(SemanticsId::new(1));
+
+        assert_eq!(
+            data.role,
+            SemanticsRole::ColumnHeader,
+            "the role a widget set must reach the platform payload, not stop at the snapshot"
+        );
+    }
+
+    /// The common controls carry no explicit role — they are identified by a
+    /// flag — so the default must stay `None` rather than being invented.
+    #[test]
+    fn a_node_without_an_explicit_role_reports_none() {
+        let node = SemanticsNode::new();
+        let data = node.to_node_data(SemanticsId::new(1));
+        assert_eq!(data.role, SemanticsRole::None);
     }
 }

--- a/crates/flui-semantics/src/update.rs
+++ b/crates/flui-semantics/src/update.rs
@@ -8,6 +8,7 @@ use smallvec::SmallVec;
 use smol_str::SmolStr;
 
 use crate::properties::TextDirection;
+use crate::role::SemanticsRole;
 
 // ============================================================================
 // SemanticsNodeData
@@ -61,6 +62,16 @@ pub struct SemanticsNodeData {
     pub scroll_index: Option<i32>,
     /// Scroll child count.
     pub scroll_child_count: Option<i32>,
+    /// The node's explicit accessibility role.
+    ///
+    /// Carried separately from [`Self::flags`] because the two encode role at
+    /// different granularities, exactly as Flutter does. The common controls —
+    /// button, link, text field, slider — are identified by a *flag* and leave
+    /// this [`SemanticsRole::None`]; the structural roles a screen reader needs
+    /// for navigation — `Tab`, `Table`, `ColumnHeader`, `MenuItemRadio` — have
+    /// no flag and live only here. A consumer reading one and not the other
+    /// sees half the tree's meaning.
+    pub role: SemanticsRole,
 }
 
 impl Default for SemanticsNodeData {
@@ -78,6 +89,7 @@ impl Default for SemanticsNodeData {
             text_direction: None,
             rect: Rect::ZERO,
             transform: Matrix4::IDENTITY,
+            role: SemanticsRole::None,
             children: SmallVec::new(),
             platform_view_id: None,
             max_value_length: None,


### PR DESCRIPTION
Prerequisite for #675 (accessibility bridge), found while scoping it.

## The gap

`SemanticsRole` is write-only for anything platform-facing. Widgets set it —
`flui-material`'s `DataTable` sets `ColumnHeader`, `NavigationBar` sets
`Tab`/`TabBar` — and `SemanticsNode` holds the whole `SemanticsConfiguration`.
But `SemanticsNode::to_node_data` copies ~15 fields off that config (flags,
actions, label, value, hint, tooltip, text direction, scroll extents) and omitted
exactly one: the role.

Verified rather than assumed: `config.role()` has a **single** reader in the
workspace — the test-only snapshot at `snapshot.rs:219`. The live assembly path
(`pipeline/owner/semantics.rs`) never mentions role, so it never reached
`SemanticsNodeData`, which is the payload `SemanticsUpdateCallback` carries and
the only thing an accessibility bridge will ever see.

## Why it is not cosmetic

Role is carried at two granularities, exactly as in Flutter:

- **Flags** identify the common controls — `IsButton`, `IsLink`, `IsTextField`,
  `IsSlider`. These leave `SemanticsRole::None`.
- **`SemanticsRole`** carries the structural roles a screen reader uses to
  navigate — `Tab`, `Table`, `ColumnHeader`, `MenuItemRadio`, `Dialog`. These
  have no flag and exist nowhere else.

Dropping the role discarded precisely the half that flags cannot express.

## Scope

One field, one propagation, two tests. **No behaviour changes today** — there is
no consumer yet; the field is populated for the bridge that follows. Deliberately
not in this PR: the `accesskit` dependency, the translation, and the query-by-role
API. Those are #675 slice 1 proper, and they now have something to read.

## Evidence

- `an_explicit_role_survives_into_the_serialized_node_data` fails when the
  propagation is replaced with a hardcoded `None` (verified, not assumed).
- Worth noting the type system is the stronger guard here: `SemanticsNodeData`
  requires the field at this construction site, so *omitting* it does not compile
  — only a wrong value could slip through, which is what the test pins.
- `just ci` exit 0 — 8902 passed, 11 skipped.

Refs #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM