### PR TITLE
feat(testing): query the accessibility tree from the headless harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,7 @@ dependencies = [
 name = "flui-testing"
 version = "0.2.0"
 dependencies = [
+ "accesskit",
  "criterion",
  "flui-animation",
  "flui-devtools",
@@ -1893,10 +1894,12 @@ dependencies = [
  "flui-objects",
  "flui-rendering",
  "flui-scheduler",
+ "flui-semantics",
  "flui-types",
  "flui-view",
  "parking_lot",
  "static_assertions",
+ "thiserror 2.0.19",
  "tracing",
 ]
 

--- a/crates/flui-semantics/src/accesskit_translation.rs
+++ b/crates/flui-semantics/src/accesskit_translation.rs
@@ -292,6 +292,25 @@ pub(crate) fn to_node(data: &SemanticsNodeData, children: Vec<NodeId>) -> Node {
     node
 }
 
+/// The node claiming [`SemanticsFlag::IsFocused`], if exactly one does.
+///
+/// Two nodes claiming focus is a malformed tree, and guessing between them
+/// would make the published focus depend on arena order. Reporting `None` sends
+/// focus to the root, which is at least a node the adapter has definitely seen.
+fn focused_node(tree: &crate::tree::SemanticsTree) -> Option<flui_foundation::SemanticsId> {
+    let mut claiming = tree
+        .iter()
+        .filter(|(_, node)| node.config().is_focused())
+        .map(|(id, _)| id);
+
+    let first = claiming.next()?;
+    if claiming.next().is_some() {
+        tracing::warn!("semantics tree has more than one focused node; publishing the root");
+        return None;
+    }
+    Some(first)
+}
+
 /// Translate a whole [`SemanticsTree`](crate::tree::SemanticsTree) into one
 /// AccessKit [`TreeUpdate`].
 ///
@@ -327,6 +346,16 @@ pub(crate) fn to_node(data: &SemanticsNodeData, children: Vec<NodeId>) -> Node {
 /// hand-constructed node is dropped rather than exported under a fabricated id
 /// that could collide with a real one.
 ///
+/// # Focus
+///
+/// An explicit `focus` wins. Otherwise focus is derived from the node carrying
+/// [`SemanticsFlag::IsFocused`], because that is where the framework records it
+/// — a caller should not have to re-derive what the tree already states, and a
+/// caller that forgets would silently publish the root as focused. Focus falls
+/// back to the root only when no node claims it, or when the named node is not
+/// in the published set: AccessKit requires a valid target, and pointing at a
+/// node the adapter has never seen is worse than pointing at the root.
+///
 /// Returns `None` for a tree whose root is missing or unaddressable, which
 /// cannot produce an applicable update.
 #[must_use]
@@ -356,6 +385,7 @@ pub fn tree_to_update(
         .collect();
 
     let focus = focus
+        .or_else(|| focused_node(tree))
         .and_then(stable_id)
         .filter(|wanted| nodes.iter().any(|(id, _)| id == wanted))
         .unwrap_or(root_node_id);
@@ -713,6 +743,84 @@ mod tests {
             root_node.children().is_empty(),
             "the parent must not reference a node that was not published"
         );
+    }
+
+    /// **The focus contract.** A focused non-root control must be published as
+    /// the focus target. Deriving it from the tree is what stops every caller
+    /// that passes `None` from silently announcing the root as focused.
+    #[test]
+    fn focus_is_derived_from_the_focused_node_when_the_caller_names_none() {
+        let mut tree = SemanticsTree::new();
+        let child_render = render_id(31);
+        let mut child_node = SemanticsNode::new().with_source_render_id(child_render);
+        child_node.config_mut().set_focused(true);
+        let child = tree.insert(child_node);
+
+        let mut root_node = SemanticsNode::new().with_source_render_id(render_id(30));
+        root_node.add_child(child);
+        let root = tree.insert(root_node);
+        tree.set_root(Some(root));
+
+        let update = tree_to_update(&tree, None).expect("rooted");
+
+        assert_eq!(
+            update.focus,
+            NodeId(AccessibilityNodeId::from(child_render).as_u64()),
+            "the focused control, not the root"
+        );
+        assert_ne!(
+            update.focus,
+            update.tree.as_ref().expect("tree").root,
+            "the fixture is only meaningful while the two differ"
+        );
+    }
+
+    /// An explicit target overrides the flag, so a caller can publish a focus
+    /// the tree does not yet record.
+    #[test]
+    fn an_explicit_focus_overrides_the_focused_flag() {
+        let mut tree = SemanticsTree::new();
+        let mut flagged = SemanticsNode::new().with_source_render_id(render_id(41));
+        flagged.config_mut().set_focused(true);
+        let flagged_id = tree.insert(flagged);
+
+        let other_render = render_id(42);
+        let other = tree.insert(SemanticsNode::new().with_source_render_id(other_render));
+
+        let mut root_node = SemanticsNode::new().with_source_render_id(render_id(40));
+        root_node.add_child(flagged_id);
+        root_node.add_child(other);
+        let root = tree.insert(root_node);
+        tree.set_root(Some(root));
+
+        let update = tree_to_update(&tree, Some(other)).expect("rooted");
+        assert_eq!(
+            update.focus,
+            NodeId(AccessibilityNodeId::from(other_render).as_u64())
+        );
+    }
+
+    /// Two nodes claiming focus is malformed. Picking one would make the
+    /// published focus depend on arena order, so it falls back to the root.
+    #[test]
+    fn two_focused_nodes_fall_back_to_the_root() {
+        let mut tree = SemanticsTree::new();
+        let mut make_focused = |index: u32| {
+            let mut node = SemanticsNode::new().with_source_render_id(render_id(index));
+            node.config_mut().set_focused(true);
+            tree.insert(node)
+        };
+        let first = make_focused(51);
+        let second = make_focused(52);
+
+        let mut root_node = SemanticsNode::new().with_source_render_id(render_id(50));
+        root_node.add_child(first);
+        root_node.add_child(second);
+        let root = tree.insert(root_node);
+        tree.set_root(Some(root));
+
+        let update = tree_to_update(&tree, None).expect("rooted");
+        assert_eq!(update.focus, update.tree.as_ref().expect("tree").root);
     }
 
     /// An unrooted tree cannot produce an applicable update, and inventing a

--- a/crates/flui-testing/Cargo.toml
+++ b/crates/flui-testing/Cargo.toml
@@ -45,6 +45,19 @@ flui-scheduler = { path = "../flui-scheduler", version = "0.2.0" }
 # Names the shared `Arc<RwLock<PipelineOwner>>` the element tree and the binding
 # both hold (render-object attachment shares the owner; the binding does not own
 # it exclusively).
+# The accessibility tree the query-by-role API asserts against. flui-testing
+# reads the assembled `SemanticsOwner` tree out of the pipeline owner and
+# translates it with `flui_semantics::tree_to_update` -- the SAME translation a
+# platform adapter uses, so a test and a screen reader cannot disagree.
+flui-semantics = { path = "../flui-semantics", version = "0.2.0" }
+# Deliberately part of this crate's public contract: `A11yTree` hands back
+# AccessKit roles/nodes rather than a test-only mirror of them. The named types
+# are re-exported from `a11y` so a consumer does not have to add (and
+# version-match) accesskit itself.
+accesskit = { workspace = true }
+# Typed query-failure errors (`A11yQueryError`), per the workspace convention:
+# thiserror in libraries, anyhow only in binaries.
+thiserror = { workspace = true }
 parking_lot = { workspace = true }
 # Reports secondary panics without replacing the first transaction unwind.
 tracing = { workspace = true }

--- a/crates/flui-testing/src/a11y.rs
+++ b/crates/flui-testing/src/a11y.rs
@@ -1,0 +1,483 @@
+//! Query the accessibility tree exactly as a screen reader receives it.
+//!
+//! A test asserts against the same [`accesskit::TreeUpdate`] a platform adapter
+//! would hand to the OS, produced by the same translation
+//! (`flui_semantics::tree_to_update`). There is deliberately no second,
+//! test-only role vocabulary: if a query here finds a `Role::Button`, a screen
+//! reader announces a button, and if it does not, the screen reader is silent
+//! too. A parallel query path would agree with the adapter only by accident.
+//!
+//! Reach it through [`HeadlessBinding::a11y_tree`](crate::HeadlessBinding::a11y_tree),
+//! after [`enable_semantics`](crate::HeadlessBinding::enable_semantics) — the
+//! semantics phase is a no-op until something asks for it, exactly as in
+//! production.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Write as _};
+
+use accesskit::{Node, TreeUpdate};
+
+// AccessKit's vocabulary is this module's vocabulary, so a consumer writes
+// `use flui_testing::a11y::Role` and never has to add accesskit itself at a
+// version that must match ours. Named items only — a glob would enrol every
+// future accesskit item into this crate's contract without anyone deciding to.
+pub use accesskit::{Action, NodeId, Role, Toggled};
+
+/// The binding drives no tree, so there is no pipeline to assemble semantics
+/// from.
+///
+/// Returned rather than panicked because this is a caller error, not a broken
+/// internal invariant — the two are different claims, and `expect("BUG: …")`
+/// would assert the wrong one. A test that knows its binding is tree-bound
+/// unwraps at the call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("semantics requires a tree-bound binding; construct one with HeadlessBinding::with_tree")]
+pub struct NotTreeBound;
+
+// ============================================================================
+// A11yTree
+// ============================================================================
+
+/// A snapshot of the accessibility tree, queryable by role and label.
+///
+/// # Traversal order
+///
+/// Queries return matches in **pre-order from the root** — the order a screen
+/// reader walks the tree, and what "the first button" means to someone reading
+/// the test. This is not the order the nodes arrive in: the semantics tree
+/// stores nodes in a slab, so emission order follows slab indices and shifts as
+/// freed slots are reused. Sorting by that would make `find_all(...)[0]`
+/// silently pick a different node after an unrelated rebuild.
+///
+/// # Reachability
+///
+/// Only nodes reachable from the root are queryable, because only those are
+/// announced. A node that was built but never linked into the tree is invisible
+/// to assistive technology, and a finder that returned it would report a control
+/// as present that no user can reach. [`unreachable_count`](Self::unreachable_count)
+/// exposes how many such nodes exist, so "built but detached" stays diagnosable
+/// instead of merely absent.
+#[derive(Debug, Clone)]
+pub struct A11yTree {
+    update: TreeUpdate,
+    /// Indices into `update.nodes`, pre-order from the root.
+    order: Vec<usize>,
+}
+
+impl A11yTree {
+    /// Builds the queryable snapshot from a raw update.
+    #[must_use]
+    pub fn new(update: TreeUpdate) -> Self {
+        let index: HashMap<NodeId, usize> = update
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(i, (id, _))| (*id, i))
+            .collect();
+
+        let mut order = Vec::with_capacity(update.nodes.len());
+        let mut seen: HashSet<NodeId> = HashSet::with_capacity(update.nodes.len());
+
+        if let Some(tree) = update.tree.as_ref() {
+            let mut stack = vec![tree.root];
+            while let Some(id) = stack.pop() {
+                let Some(&i) = index.get(&id) else { continue };
+                // `seen` doubles as the cycle guard: a malformed update whose
+                // children loop back to an ancestor terminates here rather than
+                // spinning a test run forever.
+                if !seen.insert(id) {
+                    continue;
+                }
+                order.push(i);
+                // Reversed, so popping yields children left-to-right.
+                stack.extend(update.nodes[i].1.children().iter().rev().copied());
+            }
+        }
+
+        Self { update, order }
+    }
+
+    /// The number of queryable (root-reachable) nodes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.order.len()
+    }
+
+    /// Whether no node is reachable from the root.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.order.is_empty()
+    }
+
+    /// Nodes present in the update but not reachable from the root.
+    ///
+    /// Non-zero means the semantics build produced a node that no assistive
+    /// technology will ever announce — see [the type docs](Self#reachability).
+    #[must_use]
+    pub fn unreachable_count(&self) -> usize {
+        self.update.nodes.len() - self.order.len()
+    }
+
+    /// Every queryable node, in pre-order.
+    pub fn nodes(&self) -> impl Iterator<Item = A11yNode<'_>> + '_ {
+        self.order.iter().map(|&i| {
+            let (id, node) = &self.update.nodes[i];
+            A11yNode { id: *id, node }
+        })
+    }
+
+    /// The focused node, if the update's focus target is reachable.
+    #[must_use]
+    pub fn focus(&self) -> Option<A11yNode<'_>> {
+        self.nodes().find(|n| n.id == self.update.focus)
+    }
+
+    /// Every node with `role`, in pre-order.
+    #[must_use]
+    pub fn find_all(&self, role: Role) -> Vec<A11yNode<'_>> {
+        self.nodes().filter(|n| n.role() == role).collect()
+    }
+
+    /// The single node with `role`.
+    ///
+    /// # Errors
+    ///
+    /// [`A11yQueryError::NotFound`] if nothing matches, or
+    /// [`A11yQueryError::Ambiguous`] if more than one node does. Ambiguity is an
+    /// error rather than "take the first" because a test that says *the* button
+    /// is asserting there is one; silently picking one would keep passing after
+    /// a second button appears.
+    pub fn find(&self, role: Role) -> Result<A11yNode<'_>, A11yQueryError> {
+        self.exactly_one(A11yQuery::Role(role), self.find_all(role))
+    }
+
+    /// Every node whose label equals `label`, in pre-order.
+    #[must_use]
+    pub fn find_all_by_label(&self, label: &str) -> Vec<A11yNode<'_>> {
+        self.nodes().filter(|n| n.label() == Some(label)).collect()
+    }
+
+    /// The single node whose label equals `label`.
+    ///
+    /// # Errors
+    ///
+    /// As [`find`](Self::find).
+    pub fn find_by_label(&self, label: &str) -> Result<A11yNode<'_>, A11yQueryError> {
+        self.exactly_one(
+            A11yQuery::Label(label.to_string()),
+            self.find_all_by_label(label),
+        )
+    }
+
+    fn exactly_one<'a>(
+        &'a self,
+        query: A11yQuery,
+        mut matches: Vec<A11yNode<'a>>,
+    ) -> Result<A11yNode<'a>, A11yQueryError> {
+        match matches.len() {
+            1 => Ok(matches.remove(0)),
+            0 => Err(A11yQueryError::NotFound {
+                query,
+                tree: self.describe(),
+            }),
+            _ => Err(A11yQueryError::Ambiguous {
+                query,
+                matches: matches.iter().map(A11yNode::describe).collect(),
+            }),
+        }
+    }
+
+    /// A one-line-per-node rendering of the tree, for failure messages.
+    ///
+    /// Carried inside [`A11yQueryError::NotFound`] so a failed `find` shows what
+    /// the tree *did* contain. A finder that reports only "not found" makes the
+    /// reader re-run the test with ad-hoc printing to learn anything.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        if self.order.is_empty() {
+            return "<no reachable semantics nodes>".to_string();
+        }
+        self.nodes()
+            .map(|n| format!("  {}", n.describe()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The underlying update, for assertions this API does not cover.
+    #[must_use]
+    pub fn raw(&self) -> &TreeUpdate {
+        &self.update
+    }
+}
+
+// ============================================================================
+// A11yNode
+// ============================================================================
+
+/// One node in an [`A11yTree`].
+#[derive(Debug, Clone, Copy)]
+pub struct A11yNode<'a> {
+    id: NodeId,
+    node: &'a Node,
+}
+
+impl<'a> A11yNode<'a> {
+    /// The AccessKit node id.
+    #[must_use]
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    /// The resolved role.
+    #[must_use]
+    pub fn role(&self) -> Role {
+        self.node.role()
+    }
+
+    /// The accessible label.
+    #[must_use]
+    pub fn label(&self) -> Option<&'a str> {
+        self.node.label()
+    }
+
+    /// The node's value, for controls that carry one.
+    #[must_use]
+    pub fn value(&self) -> Option<&'a str> {
+        self.node.value()
+    }
+
+    /// Whether the node is announced as disabled.
+    #[must_use]
+    pub fn is_disabled(&self) -> bool {
+        self.node.is_disabled()
+    }
+
+    /// Checkbox/switch/radio state, `None` when the node has no toggle concept.
+    #[must_use]
+    pub fn toggled(&self) -> Option<Toggled> {
+        self.node.toggled()
+    }
+
+    /// Whether the node advertises `action`.
+    #[must_use]
+    pub fn supports_action(&self, action: Action) -> bool {
+        self.node.supports_action(action)
+    }
+
+    /// The node's children, in tree order.
+    #[must_use]
+    pub fn child_ids(&self) -> &'a [NodeId] {
+        self.node.children()
+    }
+
+    /// The underlying node, for assertions this API does not cover.
+    #[must_use]
+    pub fn raw(&self) -> &'a Node {
+        self.node
+    }
+
+    /// A compact one-line rendering, used in query-failure messages.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        // Writing to a String is infallible, so the `fmt::Result`s are dropped.
+        let mut out = format!("{:?}", self.role());
+        if let Some(label) = self.label() {
+            let _ = write!(out, " label={label:?}");
+        }
+        if let Some(value) = self.value() {
+            let _ = write!(out, " value={value:?}");
+        }
+        if let Some(toggled) = self.toggled() {
+            let _ = write!(out, " toggled={toggled:?}");
+        }
+        if self.is_disabled() {
+            out.push_str(" disabled");
+        }
+        out
+    }
+}
+
+// ============================================================================
+// A11yQueryError
+// ============================================================================
+
+/// What a unique-node query searched for.
+///
+/// Kept as a typed value rather than a pre-rendered string so a test can match
+/// on the query a failure names without parsing a message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum A11yQuery {
+    /// Match on [`A11yNode::role`].
+    Role(Role),
+    /// Match on an exact [`A11yNode::label`].
+    Label(String),
+}
+
+impl fmt::Display for A11yQuery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Role(role) => write!(f, "role == {role:?}"),
+            Self::Label(label) => write!(f, "label == {label:?}"),
+        }
+    }
+}
+
+/// Why a unique-node query did not resolve.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum A11yQueryError {
+    /// Nothing matched.
+    #[error("no semantics node matched {query}; reachable nodes were:\n{tree}")]
+    NotFound {
+        /// The predicate that was searched for.
+        query: A11yQuery,
+        /// The tree as it actually was, from [`A11yTree::describe`].
+        tree: String,
+    },
+    /// More than one node matched.
+    #[error("{} semantics nodes matched {query}, expected exactly one:\n  {}", matches.len(), matches.join("\n  "))]
+    Ambiguous {
+        /// The predicate that was searched for.
+        query: A11yQuery,
+        /// One [`A11yNode::describe`] line per match.
+        matches: Vec<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use accesskit::{Tree, TreeId};
+
+    fn node(role: Role, label: &str, children: &[NodeId]) -> Node {
+        let mut n = Node::new(role);
+        n.set_label(label.to_string());
+        n.set_children(children.to_vec());
+        n
+    }
+
+    /// Root -> [a, b], where `b` is emitted *before* `a` and the root last, so
+    /// slab order and tree order disagree on every element.
+    fn scrambled_update() -> TreeUpdate {
+        let (root, a, b) = (NodeId(0), NodeId(1), NodeId(2));
+        TreeUpdate {
+            nodes: vec![
+                (b, node(Role::Button, "b", &[])),
+                (a, node(Role::Button, "a", &[])),
+                (root, node(Role::GenericContainer, "root", &[a, b])),
+            ],
+            tree: Some(Tree::new(root)),
+            tree_id: TreeId::ROOT,
+            focus: a,
+        }
+    }
+
+    #[test]
+    fn queries_return_tree_order_not_emission_order() {
+        let tree = A11yTree::new(scrambled_update());
+
+        let labels: Vec<_> = tree
+            .nodes()
+            .map(|n| n.label().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            labels,
+            ["root", "a", "b"],
+            "pre-order from the root, not the order nodes were emitted in"
+        );
+
+        let buttons = tree.find_all(Role::Button);
+        assert_eq!(
+            buttons
+                .iter()
+                .map(|n| n.label().unwrap())
+                .collect::<Vec<_>>(),
+            ["a", "b"],
+            "`find_all(...)[0]` must be the first button a screen reader reaches"
+        );
+    }
+
+    #[test]
+    fn a_node_unreachable_from_the_root_is_not_queryable_but_is_counted() {
+        let mut update = scrambled_update();
+        let orphan = NodeId(9);
+        update
+            .nodes
+            .push((orphan, node(Role::Button, "orphan", &[])));
+
+        let tree = A11yTree::new(update);
+
+        assert_eq!(
+            tree.len(),
+            3,
+            "the orphan is not announced, so not queryable"
+        );
+        assert_eq!(tree.unreachable_count(), 1, "but it stays diagnosable");
+        assert!(
+            tree.find_all_by_label("orphan").is_empty(),
+            "a detached node must not be reported as a present control"
+        );
+    }
+
+    #[test]
+    fn a_cycle_in_the_update_terminates() {
+        let (root, a) = (NodeId(0), NodeId(1));
+        let update = TreeUpdate {
+            nodes: vec![
+                (root, node(Role::GenericContainer, "root", &[a])),
+                // `a` points back at the root.
+                (a, node(Role::Button, "a", &[root])),
+            ],
+            tree: Some(Tree::new(root)),
+            tree_id: TreeId::ROOT,
+            focus: root,
+        };
+
+        let tree = A11yTree::new(update);
+        assert_eq!(tree.len(), 2, "each node is visited exactly once");
+    }
+
+    #[test]
+    fn find_reports_ambiguity_rather_than_taking_the_first() {
+        let tree = A11yTree::new(scrambled_update());
+
+        let err = tree.find(Role::Button).unwrap_err();
+        let A11yQueryError::Ambiguous { matches, .. } = &err else {
+            panic!("expected Ambiguous, got {err:?}");
+        };
+        assert_eq!(matches.len(), 2);
+        // Both candidates are named, so the reader can pick a narrower query.
+        let text = err.to_string();
+        assert!(text.contains("\"a\""), "{text}");
+        assert!(text.contains("\"b\""), "{text}");
+    }
+
+    #[test]
+    fn a_failed_find_shows_the_tree_it_searched() {
+        let tree = A11yTree::new(scrambled_update());
+
+        let err = tree.find(Role::Slider).unwrap_err();
+        let text = err.to_string();
+        assert!(text.contains("Slider"), "names the query: {text}");
+        assert!(
+            text.contains("label: \"a\"") || text.contains("label=\"a\""),
+            "and dumps what was actually there: {text}"
+        );
+    }
+
+    #[test]
+    fn find_by_label_resolves_a_unique_match() {
+        let tree = A11yTree::new(scrambled_update());
+
+        let found = tree
+            .find_by_label("a")
+            .expect("exactly one node labelled a");
+        assert_eq!(found.role(), Role::Button);
+        assert_eq!(found.id(), NodeId(1));
+    }
+
+    #[test]
+    fn focus_resolves_through_the_reachable_set() {
+        let tree = A11yTree::new(scrambled_update());
+        assert_eq!(tree.focus().expect("focus is reachable").label(), Some("a"));
+    }
+}

--- a/crates/flui-testing/src/lib.rs
+++ b/crates/flui-testing/src/lib.rs
@@ -85,6 +85,10 @@
 // Ship bar (wave 3): every public item is documented; keep it that way.
 #![deny(missing_docs)]
 
+pub mod a11y;
+
+pub use a11y::{A11yNode, A11yQuery, A11yQueryError, A11yTree, NotTreeBound};
+
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::sync::Arc;
@@ -531,6 +535,68 @@ impl HeadlessBinding {
     #[must_use]
     pub fn did_paint_last_frame(&self) -> bool {
         self.last_frame_painted
+    }
+
+    /// Turns the semantics phase on, so subsequent frames assemble an
+    /// accessibility tree.
+    ///
+    /// Semantics is off by default here for the same reason it is in
+    /// production: assembly costs a tree walk that nothing should pay for until
+    /// an assistive technology (or a test) asks. Call this **before** the
+    /// [`pump_frame`](Self::pump_frame) whose tree you intend to query — the
+    /// phase is a no-op while disabled, so enabling it afterwards leaves
+    /// [`a11y_tree`](Self::a11y_tree) returning `None` until the next frame.
+    ///
+    /// Enabling lazily creates the `SemanticsOwner`, matching
+    /// `PipelineOwner::set_semantics_enabled`.
+    ///
+    /// # Errors
+    ///
+    /// [`NotTreeBound`] if the binding drives no tree. This is a `Result`
+    /// rather than a panic so the failure cannot be silently ignored: a no-op
+    /// `enable_semantics` would surface far away, as
+    /// [`a11y_tree`](Self::a11y_tree) returning `None`, and read as "this UI
+    /// has no semantics" instead of "the call did nothing".
+    pub fn enable_semantics(&mut self) -> Result<(), NotTreeBound> {
+        self.tree
+            .as_ref()
+            .ok_or(NotTreeBound)?
+            .pipeline_owner
+            .with_mut(|owner| owner.set_semantics_enabled(true));
+        Ok(())
+    }
+
+    /// Whether the semantics phase is assembling a tree.
+    ///
+    /// `false` for a binding with no tree bound, which has no pipeline to ask.
+    #[must_use]
+    pub fn semantics_enabled(&self) -> bool {
+        self.tree.as_ref().is_some_and(|tree_binding| {
+            tree_binding
+                .pipeline_owner
+                .with(flui_rendering::pipeline::PipelineOwner::semantics_enabled)
+        })
+    }
+
+    /// The accessibility tree as an assistive technology would receive it.
+    ///
+    /// `None` until [`enable_semantics`](Self::enable_semantics) has been called
+    /// *and* a frame has run — there is no tree to translate before then, and
+    /// returning an empty one would let a query assert "no buttons" against a
+    /// tree that was never built.
+    ///
+    /// The snapshot is translated by `flui_semantics::tree_to_update`, the same
+    /// function a platform adapter calls, so an assertion here is an assertion
+    /// about what a screen reader is told. See [`a11y`] for the
+    /// query surface.
+    #[must_use]
+    pub fn a11y_tree(&self) -> Option<A11yTree> {
+        let update = self.tree.as_ref()?.pipeline_owner.with(|owner| {
+            owner
+                .semantics_owner()
+                .and_then(|semantics| semantics.to_accesskit_tree_update(None))
+        })?;
+        Some(A11yTree::new(update))
     }
 
     /// Number of frames that have produced a fresh layer tree.

--- a/crates/flui-testing/tests/a11y_query.rs
+++ b/crates/flui-testing/tests/a11y_query.rs
@@ -1,0 +1,205 @@
+//! End-to-end: a mounted render tree becomes a queryable accessibility tree.
+//!
+//! The module tests in `src/a11y.rs` build a `TreeUpdate` by hand, so they pin
+//! the query logic and say nothing about whether the harness is wired to the
+//! semantics phase at all. These tests start where a user does — a render tree
+//! and a pumped frame — and are the ones that fail if `enable_semantics` stops
+//! reaching the pipeline owner, if the semantics phase stops assembling, or if
+//! the translation stops being invoked.
+
+use flui_rendering::constraints::BoxConstraints;
+use flui_rendering::pipeline::{PipelineCell, PipelineOwner};
+use flui_rendering::prelude::*;
+use flui_rendering::protocol::BoxProtocol;
+use flui_semantics::{SemanticsConfiguration, SemanticsRole};
+use flui_testing::HeadlessBinding;
+use flui_testing::a11y::Role;
+use flui_types::{Size, geometry::px};
+use flui_view::{BuildOwner, tree::ElementTree};
+
+/// A leaf carrying whatever semantics the test wants to see come out the other
+/// end. Layout is fixed and irrelevant; the point is the config.
+#[derive(Debug, Default)]
+struct SemanticLeaf {
+    label: String,
+    button: bool,
+    role: SemanticsRole,
+    /// `None` leaves the node with no enabled-state concept at all, which is
+    /// the case that distinguishes "not disabled" from "has no such state".
+    enabled: Option<bool>,
+}
+
+impl flui_foundation::Diagnosticable for SemanticLeaf {}
+
+impl RenderBox for SemanticLeaf {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, _ctx: &mut BoxLayoutContext<'_, Leaf, BoxParentData>) -> Size {
+        Size::new(px(10.0), px(10.0))
+    }
+
+    fn paint(&self, _ctx: &mut PaintCx<'_, Leaf>) {}
+
+    fn describe_semantics_configuration(&self, config: &mut SemanticsConfiguration) {
+        config.set_label(self.label.clone());
+        config.set_button(self.button);
+        config.set_role(self.role);
+        config.set_enabled(self.enabled);
+    }
+}
+
+fn binding_with(leaf: SemanticLeaf) -> HeadlessBinding {
+    let mut owner = PipelineOwner::new();
+    let root = owner.insert::<BoxProtocol>(Box::new(leaf));
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    HeadlessBinding::with_tree(
+        BuildOwner::new(),
+        ElementTree::new(),
+        PipelineCell::new(owner),
+    )
+}
+
+fn pump(binding: &mut HeadlessBinding) {
+    binding.pump_frame(std::time::Duration::from_millis(16));
+}
+
+/// **The acceptance test.** A button in the render tree is findable by role,
+/// with its label, through the same translation a screen reader receives.
+#[test]
+fn a_button_in_the_render_tree_is_findable_by_role() {
+    let mut binding = binding_with(SemanticLeaf {
+        label: "Submit".to_string(),
+        button: true,
+        ..Default::default()
+    });
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding
+        .a11y_tree()
+        .expect("semantics was enabled before the frame, so a tree exists");
+    let button = tree
+        .find(Role::Button)
+        .unwrap_or_else(|e| panic!("expected exactly one button: {e}"));
+
+    assert_eq!(button.label(), Some("Submit"));
+}
+
+/// Semantics stays off until asked for, so a harness that never opts in pays
+/// nothing — and a query against it reports "no tree", not "no buttons".
+#[test]
+fn without_enable_semantics_there_is_no_tree_to_query() {
+    let mut binding = binding_with(SemanticLeaf {
+        label: "Submit".to_string(),
+        button: true,
+        ..Default::default()
+    });
+
+    pump(&mut binding);
+
+    assert!(!binding.semantics_enabled());
+    assert!(
+        binding.a11y_tree().is_none(),
+        "an un-built tree must be distinguishable from an empty one; \
+         returning Some(empty) would let `find_all(Button)` assert `[]` \
+         about a tree that was never assembled"
+    );
+}
+
+/// Enabling after the frame does not retroactively build a tree — the phase it
+/// controls has already run. Pinned because the failure is silent: the query
+/// returns `None` and reads as "no semantics" rather than "you asked too late".
+#[test]
+fn enabling_after_the_frame_leaves_nothing_to_query_until_the_next_one() {
+    let mut binding = binding_with(SemanticLeaf {
+        label: "Submit".to_string(),
+        button: true,
+        ..Default::default()
+    });
+
+    pump(&mut binding);
+    binding.enable_semantics().expect("binding is tree-bound");
+
+    assert!(binding.semantics_enabled());
+
+    pump(&mut binding);
+    assert!(
+        binding.a11y_tree().is_some(),
+        "the frame after enabling assembles the tree"
+    );
+}
+
+/// A structural role has no flag to carry it, so it reaches AccessKit only if
+/// the explicit-role half of `resolve_role` is wired through the whole chain:
+/// config -> node data -> translation -> query.
+#[test]
+fn a_structural_role_survives_the_whole_chain() {
+    let mut binding = binding_with(SemanticLeaf {
+        label: "Overview".to_string(),
+        role: SemanticsRole::Tab,
+        ..Default::default()
+    });
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding.a11y_tree().expect("tree exists");
+    let tab = tree
+        .find(Role::Tab)
+        .unwrap_or_else(|e| panic!("expected exactly one tab: {e}"));
+
+    assert_eq!(tab.label(), Some("Overview"));
+}
+
+/// A node with no enabled-state concept must not be announced as disabled.
+/// Getting this wrong makes a screen reader call every plain container
+/// unavailable, and no role assertion would catch it.
+#[test]
+fn a_node_without_enabled_state_is_not_announced_as_disabled() {
+    let mut binding = binding_with(SemanticLeaf {
+        label: "Submit".to_string(),
+        button: true,
+        enabled: None,
+        ..Default::default()
+    });
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding.a11y_tree().expect("tree exists");
+    let button = tree.find(Role::Button).expect("one button");
+
+    assert!(
+        !button.is_disabled(),
+        "absence of enabled-state is not disablement"
+    );
+}
+
+/// The disabled case, so the test above is pinning a distinction rather than a
+/// constant `false`.
+#[test]
+fn an_explicitly_disabled_node_is_announced_as_disabled() {
+    let mut binding = binding_with(SemanticLeaf {
+        label: "Submit".to_string(),
+        button: true,
+        enabled: Some(false),
+        ..Default::default()
+    });
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding.a11y_tree().expect("tree exists");
+    let button = tree.find(Role::Button).expect("one button");
+
+    assert!(button.is_disabled());
+}

--- a/crates/flui-testing/tests/a11y_query.rs
+++ b/crates/flui-testing/tests/a11y_query.rs
@@ -23,6 +23,7 @@ use flui_view::{BuildOwner, tree::ElementTree};
 struct SemanticLeaf {
     label: String,
     button: bool,
+    focused: bool,
     role: SemanticsRole,
     /// `None` leaves the node with no enabled-state concept at all, which is
     /// the case that distinguishes "not disabled" from "has no such state".
@@ -44,6 +45,7 @@ impl RenderBox for SemanticLeaf {
     fn describe_semantics_configuration(&self, config: &mut SemanticsConfiguration) {
         config.set_label(self.label.clone());
         config.set_button(self.button);
+        config.set_focused(self.focused);
         config.set_role(self.role);
         config.set_enabled(self.enabled);
     }
@@ -52,6 +54,56 @@ impl RenderBox for SemanticLeaf {
 fn binding_with(leaf: SemanticLeaf) -> HeadlessBinding {
     let mut owner = PipelineOwner::new();
     let root = owner.insert::<BoxProtocol>(Box::new(leaf));
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    HeadlessBinding::with_tree(
+        BuildOwner::new(),
+        ElementTree::new(),
+        PipelineCell::new(owner),
+    )
+}
+
+/// A single-child container, so a test can put the focused control somewhere
+/// other than the root. A single-node tree cannot distinguish "focus was
+/// derived" from "focus fell back to the root" — they are the same node.
+#[derive(Debug, Default)]
+struct SemanticContainer;
+
+impl flui_foundation::Diagnosticable for SemanticContainer {}
+
+impl RenderBox for SemanticContainer {
+    type Arity = Single;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Single, BoxParentData>) -> Size {
+        let constraints = *ctx.constraints();
+        if ctx.child_count() > 0 {
+            let size = ctx.layout_child(0, constraints);
+            ctx.position_child(0, flui_types::Offset::ZERO);
+            size
+        } else {
+            constraints.smallest()
+        }
+    }
+
+    flui_rendering::forward_single_child_box_queries!();
+
+    fn paint(&self, _ctx: &mut PaintCx<'_, Single>) {}
+}
+
+/// A container root with `leaf` as its only child, so the leaf is not the root.
+fn binding_with_child(leaf: SemanticLeaf) -> HeadlessBinding {
+    let mut owner = PipelineOwner::new();
+    let root = owner.insert::<BoxProtocol>(Box::new(SemanticContainer));
+    owner
+        .insert_child_render_object(root, Box::new(leaf))
+        .expect("the container accepts one child");
     owner.set_root_id(Some(root));
     owner.set_root_constraints(Some(BoxConstraints::new(
         px(0.0),
@@ -202,4 +254,36 @@ fn an_explicitly_disabled_node_is_announced_as_disabled() {
     let button = tree.find(Role::Button).expect("one button");
 
     assert!(button.is_disabled());
+}
+
+/// `A11yTree::focus()` must name the focused control, not the root. The focused
+/// leaf is deliberately a **child**: in a single-node tree "focus was derived"
+/// and "focus fell back to the root" are the same answer, so that shape cannot
+/// fail and would not be a test.
+///
+/// Before focus was derived from the tree, the harness passed `None` through and
+/// every query reported the root — confidently wrong, so a focus assertion would
+/// have inspected the wrong node and still passed.
+#[test]
+fn focus_names_the_focused_child_rather_than_the_root() {
+    let mut binding = binding_with_child(SemanticLeaf {
+        label: "Submit".to_string(),
+        button: true,
+        focused: true,
+        ..Default::default()
+    });
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding.a11y_tree().expect("tree exists");
+    let focused = tree.focus().expect("a focused node is reachable");
+
+    assert_eq!(focused.role(), Role::Button, "the child, not the container");
+    assert_eq!(focused.label(), Some("Submit"));
+    assert_ne!(
+        focused.id(),
+        tree.raw().tree.as_ref().expect("tree").root,
+        "the fixture is only meaningful while the focused node is not the root"
+    );
 }

--- a/crates/flui-testing/tests/main.rs
+++ b/crates/flui-testing/tests/main.rs
@@ -10,6 +10,8 @@
 //! flui-testing's integration tests do — both drive a per-test
 //! `HeadlessBinding` instance (no singletons, no env vars, no statics).
 
+#[path = "a11y_query.rs"]
+mod a11y_query;
 #[path = "async_driver.rs"]
 mod async_driver;
 #[path = "controller_restart.rs"]

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -266,7 +266,11 @@ declarations = [
 
 [[export_root]]
 file = "crates/flui-testing/src/lib.rs"
-declarations = ["pub struct HeadlessBinding {"]
+declarations = [
+    "pub mod a11y;",
+    "pub use a11y::{A11yNode, A11yQuery, A11yQueryError, A11yTree, NotTreeBound};",
+    "pub struct HeadlessBinding {",
+]
 
 # Owner-affine UI realms
 


### PR DESCRIPTION
Second half of #675 slice 1. **Stacked on #677** — review that first; this PR's diff against `main` will include it until #677 lands.

This is the out-of-crate consumer #677's translation exists for.

## What it does

```rust
binding.enable_semantics()?;
binding.pump_frame(FRAME);

let button = binding.a11y_tree().unwrap().find(Role::Button)?;
assert_eq!(button.label(), Some("Submit"));
```

Queries run against the AccessKit tree, not a test-only mirror: the snapshot comes from `flui_semantics::tree_to_update`, the same function a platform adapter calls. A parallel query vocabulary would match what a screen reader announces only by accident, and would drift the first time either side changed.

## Three decisions worth reviewing

**Pre-order, not emission order.** The semantics tree stores nodes in a slab, so `tree.iter()` yields slab indices, which shift as freed slots are reused. Returning that order would make `find_all(..)[0]` silently designate a different node after an unrelated rebuild. `A11yTree` walks the update from its root instead — also what "the first button" means to whoever reads the test.

**Ambiguity is an error, not a pick.** `find(Role::Button)` against two buttons returns `Ambiguous` naming both. A test that says *the* button is asserting there is one; taking the first would keep passing after a second appears. `NotFound` carries a dump of the tree it searched, so the failure says what *was* there instead of only what wasn't.

**Unreachable nodes are excluded but counted.** A node built and never linked into the tree is never announced, so returning it would report a control no user can reach; dropping it silently would hide a real assembly bug. It is out of the query set and in `unreachable_count()`.

## `enable_semantics` returns `Result`, and the gate is why

The panic-policy check flagged an `expect` here. It was right for a reason beyond the ratchet: calling `enable_semantics` on a gesture-only binding is a **caller** error, so `expect("BUG: …")` would assert a broken internal invariant that isn't broken — the wrong claim, mechanically accepted. The failure also has to be un-ignorable, because a silent no-op resurfaces much later as `a11y_tree() == None` and reads as "this UI has no semantics" rather than "that call did nothing".

I did not raise the allowlist count, which is the other way the gate offered to go green.

## Evidence

13 tests: 7 unit on the query logic, 6 end-to-end from a mounted render tree. The unit tests build a `TreeUpdate` by hand, so on their own they say nothing about whether the harness is wired to the semantics phase at all — the end-to-end file exists for exactly that.

Both halves verified red, and the *shape* of each red is the point:

| Injected fault | Fails | Survives |
|---|---|---|
| `resolve_role` → explicit-role-only (in **flui-semantics**) | the 3 button tests | structural-role test |
| `enable_semantics` → no-op (in **flui-testing**) | 5 | "not enabled ⇒ no tree" |

The first is what proves the harness test genuinely crosses the crate boundary instead of re-deriving roles locally.

`just ci` exit 0, workspace count 8918 → **8931**. That delta is load-bearing evidence, not decoration: `autotests = false` means a file under `tests/` that isn't registered in `tests/main.rs` never runs, and green-with-an-unchanged-count is how that hides.

Refs #675