### PR TITLE
chore(deps): record why the lru panic-safety advisory is unreachable here

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,24 @@ ignore = [
     { id = "RUSTSEC-2026-0194" },
     { id = "RUSTSEC-2026-0195" },
 
+    # RUSTSEC-2026-0253: lru <0.18.2 `LruCache::pop()` is not panic-safe — a
+    # panicking key `Drop` skips `detach()`, leaving a dangling node in the
+    # linked list for a later eviction to write through (UAF / double-free).
+    # Source: lru v0.16.4 ← glyphon v0.11 ← flui-engine.
+    #
+    # Not reachable here, on two independent grounds, both checked against
+    # glyphon 0.11.0's source rather than assumed:
+    #   1. The advisory needs a key whose `Drop` can panic. `GlyphonCacheKey`
+    #      derives `Copy` (text_render.rs), and Rust forbids `Copy + Drop`, so
+    #      the precondition is structurally impossible rather than unlikely.
+    #   2. glyphon never calls the vulnerable function — zero `.pop(` sites in
+    #      its source, and its cache is `unbounded_with_hasher`, so no eviction
+    #      path runs at all.
+    # Unfixable locally: glyphon still caps lru at ^0.16.2 as of 0.12.0 (its
+    # latest), which additionally requires wgpu ^30. Drop this ignore when
+    # glyphon releases against lru >=0.18.2.
+    { id = "RUSTSEC-2026-0253" },
+
     # RUSTSEC-2026-0186: memmap2 ≤0.9.10 passes an unchecked pointer offset to
     # madvise/msync syscalls.  PRE-EXISTING on main (pinned by cosmic-text 0.18.2
     # → fontdb → memmap2 0.9.10; cosmic-text caps the version).


### PR DESCRIPTION
**RUSTSEC-2026-0253 was published today and turns `cargo deny` red on every branch, `main` included.** `main` looks green only because its last CI run (10:41Z) predates the advisory; the next run on any branch fails. This unblocks everything.

## The advisory

`lru <0.18.2`'s `LruCache::pop()` is not panic-safe — a panicking key `Drop` skips `detach()`, leaving a dangling node in the linked list for a later eviction to write through (CWE-416 / CWE-415).

We reach it as `lru v0.16.4 ← glyphon v0.11 ← flui-engine`.

## No upgrade path

`cargo update -p lru` cannot resolve past 0.16: **glyphon still caps lru at `^0.16.2` as of 0.12.0**, its latest release. (0.12.0 would also require `wgpu ^30`.) So this is an upstream wait, not a version bump we are declining to do.

## Why it does not apply to this path

Two independent grounds, both read out of glyphon 0.11.0's source rather than assumed:

1. **The precondition is structurally impossible.** The advisory needs a key whose `Drop` can panic. `GlyphonCacheKey` derives `Copy` (`text_render.rs:365`), and Rust forbids `Copy + Drop`. Not "unlikely" — unrepresentable.
2. **The vulnerable function is never called.** Zero `.pop(` sites in glyphon's source, and the cache is constructed `unbounded_with_hasher` (`text_atlas.rs:57`), so no eviction path executes at all.

Either alone would justify the ignore. Both are recorded in the comment because they can decay independently — (1) with a glyphon key-type refactor, (2) with a bounded cache — and whoever revisits should know which assumption they are re-checking.

## Scoping

Deliberately its own PR rather than folded into the a11y branch that happened to hit it first. It is a repository-wide security-policy decision and deserves to be reviewable as one, not buried in a feature diff.

Follows the existing convention in `deny.toml` (source path, reachability rationale, upstream blocker, drop-condition) — see the `RUSTSEC-2026-0194/0195` and `RUSTSEC-2026-0192` entries.

`cargo deny check` → advisories ok, bans ok, licenses ok, sources ok. `taplo fmt --check` clean.