### PR TITLE
test(testing): pin merge-descendants and exclude-subtree through translation

### DIFF
--- a/crates/flui-testing/tests/a11y_query.rs
+++ b/crates/flui-testing/tests/a11y_query.rs
@@ -69,11 +69,35 @@ fn binding_with(leaf: SemanticLeaf) -> HeadlessBinding {
     )
 }
 
-/// A single-child container, so a test can put the focused control somewhere
-/// other than the root. A single-node tree cannot distinguish "focus was
-/// derived" from "focus fell back to the root" — they are the same node.
+/// A single-child container. Two jobs: it lets a test put the focused control
+/// somewhere other than the root (a single-node tree cannot distinguish "focus
+/// was derived" from "focus fell back to the root" — same node), and it carries
+/// the boundary/merge/exclude configuration the assembly phase acts on.
 #[derive(Debug, Default)]
-struct SemanticContainer;
+struct SemanticContainer {
+    label: Option<&'static str>,
+    boundary: bool,
+    merge_descendants: bool,
+    exclude_descendants: bool,
+}
+
+impl SemanticContainer {
+    fn merging(label: &'static str) -> Self {
+        Self {
+            label: Some(label),
+            boundary: true,
+            merge_descendants: true,
+            exclude_descendants: false,
+        }
+    }
+
+    fn excluding() -> Self {
+        Self {
+            exclude_descendants: true,
+            ..Self::default()
+        }
+    }
+}
 
 impl flui_foundation::Diagnosticable for SemanticContainer {}
 
@@ -95,12 +119,26 @@ impl RenderBox for SemanticContainer {
     flui_rendering::forward_single_child_box_queries!();
 
     fn paint(&self, _ctx: &mut PaintCx<'_, Single>) {}
+
+    fn describe_semantics_configuration(&self, config: &mut SemanticsConfiguration) {
+        config.set_semantics_boundary(self.boundary);
+        if self.merge_descendants {
+            config.set_merging_semantics_of_descendants(true);
+        }
+        if let Some(label) = self.label {
+            config.set_label(label);
+        }
+    }
+
+    fn excludes_semantics_subtree(&self) -> bool {
+        self.exclude_descendants
+    }
 }
 
 /// A container root with `leaf` as its only child, so the leaf is not the root.
 fn binding_with_child(leaf: SemanticLeaf) -> HeadlessBinding {
     let mut owner = PipelineOwner::new();
-    let root = owner.insert::<BoxProtocol>(Box::new(SemanticContainer));
+    let root = owner.insert::<BoxProtocol>(Box::new(SemanticContainer::default()));
     owner
         .insert_child_render_object(root, Box::new(leaf))
         .expect("the container accepts one child");
@@ -285,5 +323,115 @@ fn focus_names_the_focused_child_rather_than_the_root() {
         focused.id(),
         tree.raw().tree.as_ref().expect("tree").root,
         "the fixture is only meaningful while the focused node is not the root"
+    );
+}
+
+/// Builds root -> middle -> leaf, so merge/exclude configuration on `middle`
+/// has a descendant to act on.
+fn binding_with_chain(middle: SemanticContainer, leaf: SemanticLeaf) -> HeadlessBinding {
+    let mut owner = PipelineOwner::new();
+    let root = owner.insert::<BoxProtocol>(Box::new(SemanticContainer::default()));
+    let middle_id = owner
+        .insert_child_render_object(root, Box::new(middle))
+        .expect("root accepts one child");
+    owner
+        .insert_child_render_object(middle_id, Box::new(leaf))
+        .expect("middle accepts one child");
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    HeadlessBinding::with_tree(
+        BuildOwner::new(),
+        ElementTree::new(),
+        PipelineCell::new(owner),
+    )
+}
+
+/// Merge-descendants collapses a boundary descendant into its ancestor during
+/// assembly. The published tree must show the collapsed shape — one node
+/// carrying the combined label, with no child — because a translation that
+/// walked the render tree, or re-expanded children from anywhere but the
+/// assembled semantics tree, would republish the descendant the merge removed.
+///
+/// Oracle: `run_semantics_merge_descendants_collapses_boundary_grandchild`
+/// (flui-rendering), which pins the same shape one layer down.
+#[test]
+fn merge_descendants_survives_translation() {
+    let mut binding = binding_with_chain(
+        SemanticContainer::merging("Group"),
+        SemanticLeaf {
+            label: "Child".to_string(),
+            ..Default::default()
+        },
+    );
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding.a11y_tree().expect("tree exists");
+
+    assert_eq!(
+        tree.len(),
+        2,
+        "root plus the merged node, and nothing else: {}",
+        tree.describe()
+    );
+    let merged = tree
+        .find_by_label("Group Child")
+        .unwrap_or_else(|e| panic!("the merged node must carry the combined label: {e}"));
+    assert!(
+        merged.child_ids().is_empty(),
+        "merge-descendants suppressed the descendant, so the published node has no children"
+    );
+    assert!(
+        tree.find_all_by_label("Child").is_empty(),
+        "the merged-away descendant must not reappear as its own node"
+    );
+}
+
+/// Exclude-subtree drops a descendant's semantics during assembly. The published
+/// tree must not contain it — this is the case where leaking would be worst,
+/// since the app deliberately hid that content from assistive technology.
+///
+/// Oracle: `run_semantics_excluding_node_skips_descendant_subtree`
+/// (flui-rendering).
+#[test]
+fn exclude_subtree_survives_translation() {
+    let mut binding = binding_with_chain(
+        SemanticContainer::excluding(),
+        SemanticLeaf {
+            label: "Hidden label".to_string(),
+            button: true,
+            ..Default::default()
+        },
+    );
+
+    binding.enable_semantics().expect("binding is tree-bound");
+    pump(&mut binding);
+
+    let tree = binding.a11y_tree().expect("tree exists");
+
+    // A positive shape assertion first: pure absence would also "pass" against
+    // a tree that failed to assemble at all.
+    assert_eq!(
+        tree.len(),
+        1,
+        "only the root survives the exclusion: {}",
+        tree.describe()
+    );
+    assert!(
+        tree.find_all_by_label("Hidden label").is_empty(),
+        "excluded content must not reach the published tree: {}",
+        tree.describe()
+    );
+    assert!(
+        tree.find_all(Role::Button).is_empty(),
+        "nor its role: {}",
+        tree.describe()
     );
 }


### PR DESCRIPTION
Closes the one slice-1 acceptance item from #675 that was **not actually met**:

> - [ ] Merge-descendants and exclude-subtree behaviour survives translation — those are the two cases `run_semantics` already pins, so the translation must not silently flatten them.

I reported slice 1 complete in #677/#678 without this. Re-reading the acceptance list is what surfaced it, not a failing test — worth saying plainly, because "gates green" was true the whole time.

## What was missing

`run_semantics` collapses a boundary descendant into its merging ancestor, and drops an excluded subtree entirely. Both were pinned one layer down (`run_semantics_merge_descendants_collapses_boundary_grandchild`, `run_semantics_excluding_node_skips_descendant_subtree`) and nothing checked that the *published AccessKit tree* still shows those shapes.

Both new tests run end-to-end through `HeadlessBinding`, so they exercise real assembly rather than a hand-built tree. Verified shapes:

| Case | Published tree |
|---|---|
| merge | 2 nodes — root, plus one carrying the combined label `"Group Child"` with no child |
| exclude | 1 node — the root alone |

## The two tests are not equally strong, and I'd rather say so

Each asserts a **positive shape before asserting absence**. That matters: `find_all_by_label(..).is_empty()` is trivially true of an empty tree, so pure absence is the shape of a test that cannot fail.

- **The merge test is red-verified.** Dropping child wiring from the translation fails it — the merged node stops being reachable and the count drops to 1.
- **The exclude test cannot be made red by mutating today's translation.** Exclusion is enforced upstream during assembly and the excluded node never enters the arena at all (`unreachable_count == 0`), so there is nothing for the translation to leak. It guards against a *future* translation that reconstructs structure from the render tree rather than the assembled semantics tree — which is exactly the failure the acceptance criterion names. A regression guard, not a proof, and I am not going to dress it up as one.

## Slice 1 acceptance, now

- [x] Translation with roles, labels, actions, parent/child structure (#677)
- [x] Merge-descendants and exclude-subtree survive translation — **this PR**
- [x] Query-by-role on the headless harness, with a test that fails when a widget stops exposing role or label (#678, verified red)
- [x] No `flui-platform` → `flui-semantics` dependency (the edge added was `flui-testing` → `flui-semantics`, layer 6 → 3)
- [x] `just ci` green + `cargo deny` on the new dependency

One deviation from the issue's wording worth flagging: it specifies `SemanticsNodeUpdate` → `accesskit::TreeUpdate`. #677 removed that entry point — `SemanticsNodeUpdate` carries only `SemanticsId`s and structurally cannot express stable identity. The translation is `SemanticsTree` → `TreeUpdate` instead. Same product, different input type, for a reason documented there.

`just ci` exit 0, 8940 tests.

Refs #675