### PR TITLE
feat(platform): PlatformAccessibility capability, with a recording fake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,7 @@ dependencies = [
 name = "flui-platform"
 version = "0.2.0"
 dependencies = [
+ "accesskit",
  "android-activity",
  "anyhow",
  "arboard",

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -14,6 +14,12 @@ description = "Platform abstraction layer for FLUI - cross-platform window and i
 autotests = false
 
 [dependencies]
+# The accessibility tree this crate's `PlatformAccessibility` capability
+# speaks. Data model only -- the per-OS `accesskit_*` adapters are separate and
+# feature-gated. This crate is layer 2 and cannot name `flui-semantics` (layer
+# 3) types, so an already-translated `accesskit::TreeUpdate` is what crosses
+# the seam.
+accesskit = { workspace = true }
 flui-types = { path = "../flui-types", version = "0.2.0" }
 # Layer-legal downward edge (foundation sits below platform in the DAG),
 # carrying two seams: OwnerAffinity — the ADR-0039 owner-thread backstop,

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -197,7 +197,9 @@ pub use platforms::IOSPlatform;
 pub use platforms::LinuxPlatform;
 #[cfg(target_os = "macos")]
 pub use platforms::MacOSPlatform;
-pub use platforms::{FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform};
+pub use platforms::{
+    FakeAccessibility, FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform,
+};
 // Web platform
 #[cfg(target_arch = "wasm32")]
 pub use platforms::WebPlatform;
@@ -214,8 +216,9 @@ pub use shared::{PlatformHandlers, WindowCallbacks};
 pub use task::{Priority, Task, TaskLabel};
 // Re-export core traits
 pub use traits::{
-    Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, DisplayId,
-    MobileCapabilities, PathPromptOptions, Platform, PlatformCapabilities, PlatformDisplay,
+    AccessibilityActionListener, AccessibilityActivationListener, Clipboard, ClipboardItem,
+    CursorError, DesktopCapabilities, DispatchEventResult, DisplayId, MobileCapabilities,
+    PathPromptOptions, Platform, PlatformAccessibility, PlatformCapabilities, PlatformDisplay,
     PlatformEmbedder, PlatformExecutor, PlatformHaptics, PlatformReadyCallback, PlatformTextInput,
     PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds,
     WindowEvent, WindowId, WindowMode, WindowOptions,

--- a/crates/flui-platform/src/platforms/headless/mod.rs
+++ b/crates/flui-platform/src/platforms/headless/mod.rs
@@ -2,4 +2,6 @@
 
 mod platform;
 
-pub use platform::{FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform};
+pub use platform::{
+    FakeAccessibility, FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform,
+};

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -870,7 +870,7 @@ impl crate::traits::PlatformWindow for MockWindow {
 ///
 /// Records every published tree so a test can assert what an assistive
 /// technology would actually have been told — the roles, labels and ids — not
-/// merely that publishing did not panic. Activation is driveable
+/// merely that publishing did not panic. Activation is drivable
 /// ([`set_active`](Self::set_active)) because the interesting behaviour is
 /// conditional on it: a composition root must start assembly on attach and stop
 /// on detach, and neither is observable without being able to fake the signal.
@@ -916,6 +916,12 @@ impl FakeAccessibility {
     pub fn set_active(&self, active: bool) {
         let listener = {
             let mut state = self.state.lock();
+            // Attach/detach is a *transition*. Re-notifying on an unchanged
+            // state would drive redundant enable/disable cycles in a
+            // composition root that starts and stops assembly off this signal.
+            if state.active == active {
+                return;
+            }
             state.active = active;
             state.activation_listener.clone()
         };
@@ -925,8 +931,20 @@ impl FakeAccessibility {
     }
 
     /// Simulate assistive technology requesting an action.
+    ///
+    /// Dropped while inactive, because that is what the platform does: actions
+    /// originate from an attached client, and one arriving after detach is
+    /// stale. Forwarding it anyway would let a higher layer depend on
+    /// action delivery outside an active session and pass here while failing
+    /// against a real adapter.
     pub fn request_action(&self, request: accesskit::ActionRequest) {
-        let listener = self.state.lock().action_listener.clone();
+        let listener = {
+            let state = self.state.lock();
+            if !state.active {
+                return;
+            }
+            state.action_listener.clone()
+        };
         if let Some(listener) = listener {
             listener(request);
         }
@@ -944,13 +962,12 @@ impl std::fmt::Debug for FakeAccessibility {
 }
 
 impl crate::traits::PlatformAccessibility for FakeAccessibility {
-    fn publish(&self, update: &accesskit::TreeUpdate) {
+    fn publish(&self, update: accesskit::TreeUpdate) {
         let mut state = self.state.lock();
-        // Inactive means no assistive technology is listening, so the clone is
-        // skipped entirely — the same shape as the real adapter's
-        // `update_if_active`, which is what this fake stands in for.
+        // Inactive means nothing is listening: the update is dropped rather
+        // than recorded, mirroring the real adapter's `update_if_active`.
         if state.active {
-            state.published.push(update.clone());
+            state.published.push(update);
         }
     }
 

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -456,6 +456,7 @@ struct MockWindow {
     callbacks: Arc<WindowCallbacks>,
     text_input: Arc<FakeTextInput>,
     haptics: Arc<FakeHaptics>,
+    accessibility: Arc<FakeAccessibility>,
     /// Back-reference to the platform this window was opened on, so
     /// closing it can remove its own entry from `HeadlessState::windows`
     /// and — only once every tracked window is gone — consult the
@@ -525,6 +526,7 @@ impl MockWindow {
             callbacks: Arc::new(WindowCallbacks::new()),
             text_input: Arc::new(FakeTextInput::new()),
             haptics: Arc::new(FakeHaptics::new()),
+            accessibility: Arc::new(FakeAccessibility::new()),
             platform_state,
         }
     }
@@ -750,6 +752,10 @@ impl crate::traits::PlatformWindow for MockWindow {
         Some(Arc::clone(&self.text_input) as Arc<dyn PlatformTextInput>)
     }
 
+    fn accessibility(&self) -> Option<Arc<dyn crate::traits::PlatformAccessibility>> {
+        Some(Arc::clone(&self.accessibility) as Arc<dyn crate::traits::PlatformAccessibility>)
+    }
+
     fn haptics(&self) -> Option<Arc<dyn PlatformHaptics>> {
         Some(Arc::clone(&self.haptics) as Arc<dyn PlatformHaptics>)
     }
@@ -856,6 +862,108 @@ impl crate::traits::PlatformWindow for MockWindow {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+/// Recording fake for [`PlatformAccessibility`](crate::traits::PlatformAccessibility),
+/// backing the headless backend's [`PlatformWindow::accessibility`].
+///
+/// Records every published tree so a test can assert what an assistive
+/// technology would actually have been told — the roles, labels and ids — not
+/// merely that publishing did not panic. Activation is driveable
+/// ([`set_active`](Self::set_active)) because the interesting behaviour is
+/// conditional on it: a composition root must start assembly on attach and stop
+/// on detach, and neither is observable without being able to fake the signal.
+#[derive(Default)]
+pub struct FakeAccessibility {
+    state: Mutex<FakeAccessibilityState>,
+}
+
+#[derive(Default)]
+struct FakeAccessibilityState {
+    active: bool,
+    published: Vec<accesskit::TreeUpdate>,
+    activation_listener: Option<crate::traits::AccessibilityActivationListener>,
+    action_listener: Option<crate::traits::AccessibilityActionListener>,
+}
+
+impl FakeAccessibility {
+    /// Create a fresh recorder, inactive and with nothing published.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every tree published while active, in order.
+    #[must_use]
+    pub fn published(&self) -> Vec<accesskit::TreeUpdate> {
+        self.state.lock().published.clone()
+    }
+
+    /// How many trees were published while active.
+    #[must_use]
+    pub fn published_count(&self) -> usize {
+        self.state.lock().published.len()
+    }
+
+    /// Simulate assistive technology attaching or detaching, notifying the
+    /// registered listener.
+    ///
+    /// The listener is cloned out of the lock before being called, so a
+    /// listener that publishes (or otherwise re-enters this fake) does not
+    /// deadlock against the guard that dispatched it — the same
+    /// clone-and-release discipline the real platform paths use.
+    pub fn set_active(&self, active: bool) {
+        let listener = {
+            let mut state = self.state.lock();
+            state.active = active;
+            state.activation_listener.clone()
+        };
+        if let Some(listener) = listener {
+            listener(active);
+        }
+    }
+
+    /// Simulate assistive technology requesting an action.
+    pub fn request_action(&self, request: accesskit::ActionRequest) {
+        let listener = self.state.lock().action_listener.clone();
+        if let Some(listener) = listener {
+            listener(request);
+        }
+    }
+}
+
+impl std::fmt::Debug for FakeAccessibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = self.state.lock();
+        f.debug_struct("FakeAccessibility")
+            .field("active", &state.active)
+            .field("published_count", &state.published.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl crate::traits::PlatformAccessibility for FakeAccessibility {
+    fn publish(&self, update: &accesskit::TreeUpdate) {
+        let mut state = self.state.lock();
+        // Inactive means no assistive technology is listening, so the clone is
+        // skipped entirely — the same shape as the real adapter's
+        // `update_if_active`, which is what this fake stands in for.
+        if state.active {
+            state.published.push(update.clone());
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        self.state.lock().active
+    }
+
+    fn set_activation_listener(&self, listener: crate::traits::AccessibilityActivationListener) {
+        self.state.lock().activation_listener = Some(listener);
+    }
+
+    fn set_action_listener(&self, listener: crate::traits::AccessibilityActionListener) {
+        self.state.lock().action_listener = Some(listener);
     }
 }
 

--- a/crates/flui-platform/src/platforms/mod.rs
+++ b/crates/flui-platform/src/platforms/mod.rs
@@ -34,7 +34,9 @@ pub mod winit;
 // Re-exports
 #[cfg(target_os = "android")]
 pub use android::AndroidPlatform;
-pub use headless::{FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform};
+pub use headless::{
+    FakeAccessibility, FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform,
+};
 #[cfg(target_os = "ios")]
 pub use ios::IOSPlatform;
 #[cfg(target_os = "linux")]

--- a/crates/flui-platform/src/traits/accessibility.rs
+++ b/crates/flui-platform/src/traits/accessibility.rs
@@ -57,12 +57,15 @@ pub type AccessibilityActionListener = Arc<dyn Fn(ActionRequest) + Send + Sync>;
 pub trait PlatformAccessibility: Send + Sync {
     /// Hand the platform the current tree.
     ///
-    /// Implementations are expected to skip the work when no assistive
-    /// technology is attached. `update` is borrowed rather than owned precisely
-    /// so an inactive implementation can drop it without paying for a clone —
-    /// [`accesskit::TreeUpdate`] is `Clone`, so an active one clones inside its
-    /// own active-check.
-    fn publish(&self, update: &TreeUpdate);
+    /// Taken **by value** so an implementation can move it into the platform's
+    /// own update call instead of cloning. A full-tree update is what
+    /// `SemanticsOwner::flush` produces, so on the active path a borrowed
+    /// parameter would charge one whole-tree clone per publish, per frame that
+    /// changed anything — see the cost issue on the semantics pipeline.
+    ///
+    /// An implementation with nothing attached simply drops it, which costs
+    /// nothing the caller had not already spent building it.
+    fn publish(&self, update: TreeUpdate);
 
     /// Whether assistive technology is currently attached.
     ///

--- a/crates/flui-platform/src/traits/accessibility.rs
+++ b/crates/flui-platform/src/traits/accessibility.rs
@@ -1,0 +1,79 @@
+//! Platform accessibility capability.
+//!
+//! [`PlatformAccessibility`] is reached through
+//! [`PlatformWindow::accessibility`](super::window::PlatformWindow::accessibility),
+//! the same fallible `Option<Arc<dyn _>>` discovery used by
+//! [`PlatformTextInput`](super::text_input::PlatformTextInput) (ADR-0030) and
+//! [`PlatformHaptics`](super::haptics::PlatformHaptics) (ADR-0031). A backend
+//! with no accessibility integration returns `None` rather than every
+//! `PlatformWindow` implementor inheriting methods it cannot honor.
+//!
+//! # It speaks AccessKit, never semantics types
+//!
+//! `flui-platform` is layer 2 and `flui-semantics` is layer 3, so this crate
+//! cannot name a `SemanticsNode`. That is not a workaround — it is what forces
+//! the translation to happen on the producing side, where the tree and its
+//! stable identities live. What crosses this seam is an
+//! [`accesskit::TreeUpdate`], already translated.
+//!
+//! # Both directions
+//!
+//! - **Out** — [`publish`](PlatformAccessibility::publish) hands the platform a
+//!   tree.
+//! - **In** — assistive technology attaches, detaches, and requests actions.
+//!   Those arrive through listeners registered by the composition root, because
+//!   a layer-2 crate has nothing to call.
+//!
+//! The inbound `NodeId`s are the same stable `AccessibilityNodeId` values the
+//! published tree carried, which is what lets a composition root route an
+//! action straight to `SemanticsOwner::resolve_action` with no translation
+//! table in between.
+
+use std::sync::Arc;
+
+use accesskit::{ActionRequest, TreeUpdate};
+
+/// Notified when assistive technology attaches (`true`) or detaches (`false`).
+///
+/// A composition root uses this to drive semantics assembly: FLUI does not
+/// build a semantics tree until something is listening, mirroring Flutter's
+/// `ensureSemantics` refcount. Assembly costs a tree walk per frame, so leaving
+/// it on unconditionally would charge every user for a feature almost none of
+/// them have enabled.
+pub type AccessibilityActivationListener = Arc<dyn Fn(bool) + Send + Sync>;
+
+/// Receives an action requested by assistive technology.
+///
+/// [`ActionRequest::target_node`] is the stable node id from the last published
+/// tree. It may name a node that has since been removed — assistive technology
+/// acts on the snapshot it last read — so a handler resolves rather than
+/// assumes, and treats a miss as a graceful drop.
+///
+/// The request also carries [`ActionRequest::target_tree`], which is what will
+/// address the right presentation once more than one window publishes a tree.
+pub type AccessibilityActionListener = Arc<dyn Fn(ActionRequest) + Send + Sync>;
+
+/// Platform capability for exposing one window's accessibility tree.
+pub trait PlatformAccessibility: Send + Sync {
+    /// Hand the platform the current tree.
+    ///
+    /// Implementations are expected to skip the work when no assistive
+    /// technology is attached. `update` is borrowed rather than owned precisely
+    /// so an inactive implementation can drop it without paying for a clone —
+    /// [`accesskit::TreeUpdate`] is `Clone`, so an active one clones inside its
+    /// own active-check.
+    fn publish(&self, update: &TreeUpdate);
+
+    /// Whether assistive technology is currently attached.
+    ///
+    /// Advisory rather than a gate: it can go stale between the check and the
+    /// call, so [`publish`](Self::publish) re-checks. Useful for diagnostics
+    /// and for a composition root deciding whether assembly is worth starting.
+    fn is_active(&self) -> bool;
+
+    /// Register the attach/detach listener, replacing any previous one.
+    fn set_activation_listener(&self, listener: AccessibilityActivationListener);
+
+    /// Register the inbound-action listener, replacing any previous one.
+    fn set_action_listener(&self, listener: AccessibilityActionListener);
+}

--- a/crates/flui-platform/src/traits/mod.rs
+++ b/crates/flui-platform/src/traits/mod.rs
@@ -4,6 +4,7 @@
 //! embedders. The traits are designed for maximum code reuse while allowing
 //! platform-specific customization.
 
+mod accessibility;
 mod capabilities;
 mod display;
 mod embedder;
@@ -19,6 +20,9 @@ mod platform;
 mod text_input;
 mod window;
 
+pub use accessibility::{
+    AccessibilityActionListener, AccessibilityActivationListener, PlatformAccessibility,
+};
 pub use capabilities::{
     DesktopCapabilities, MobileCapabilities, PlatformCapabilities, WebCapabilities,
 };

--- a/crates/flui-platform/src/traits/window.rs
+++ b/crates/flui-platform/src/traits/window.rs
@@ -10,6 +10,7 @@ use cursor_icon::CursorIcon;
 use flui_types::geometry::{Bounds, DevicePixels, Pixels, Point, Size};
 
 use super::{
+    accessibility::PlatformAccessibility,
     display::PlatformDisplay,
     haptics::PlatformHaptics,
     input::{DispatchEventResult, Modifiers, PlatformInput},
@@ -191,6 +192,16 @@ pub trait PlatformWindow: Send + Sync {
     /// [`PlatformHaptics`]'s module doc for the full per-window-not-global
     /// rationale.
     fn haptics(&self) -> Option<Arc<dyn PlatformHaptics>> {
+        None
+    }
+
+    /// Get this window's accessibility capability, if the backend exposes one.
+    ///
+    /// `None` for a backend with no accessibility integration — which is every
+    /// backend until its per-OS adapter is wired, and permanently for one with
+    /// no such platform API. A composition root that gets `None` simply never
+    /// enables semantics assembly, so the cost is not paid either.
+    fn accessibility(&self) -> Option<Arc<dyn PlatformAccessibility>> {
         None
     }
 

--- a/crates/flui-platform/tests/accessibility_capability.rs
+++ b/crates/flui-platform/tests/accessibility_capability.rs
@@ -1,0 +1,156 @@
+//! The `PlatformAccessibility` capability contract, against the headless fake.
+//!
+//! These pin the seam's behaviour, not a screen reader's. What CI cannot reach
+//! is stated in the Linux bridge issue: there is no AT-SPI session bus here, so
+//! a real adapter never activates and no assistive technology ever reads a
+//! tree. What *is* checkable is that the capability publishes only while
+//! active, that attach/detach reaches a listener, and that inbound actions
+//! arrive addressed in the same id space the published tree used — which is the
+//! property that makes the round trip work at all.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use accesskit::{Action, ActionRequest, Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+use flui_platform::{FakeAccessibility, PlatformAccessibility};
+
+/// A one-node tree published under `id`.
+fn tree_update(id: u64, label: &str) -> TreeUpdate {
+    let root = NodeId(id);
+    let mut node = Node::new(Role::Button);
+    node.set_label(label.to_string());
+    TreeUpdate {
+        nodes: vec![(root, node)],
+        tree: Some(Tree::new(root)),
+        tree_id: TreeId::ROOT,
+        focus: root,
+    }
+}
+
+/// **The cost contract.** Nothing is published while no assistive technology is
+/// attached, so an application that never runs a screen reader pays nothing for
+/// the capability existing. A fake that recorded unconditionally would hide the
+/// only property worth having here.
+#[test]
+fn nothing_is_published_while_inactive() {
+    let accessibility = FakeAccessibility::new();
+
+    accessibility.publish(&tree_update(1, "Submit"));
+
+    assert!(!accessibility.is_active());
+    assert_eq!(accessibility.published_count(), 0);
+}
+
+#[test]
+fn publishing_while_active_records_the_tree() {
+    let accessibility = FakeAccessibility::new();
+    accessibility.set_active(true);
+
+    accessibility.publish(&tree_update(1, "Submit"));
+
+    let published = accessibility.published();
+    assert_eq!(published.len(), 1);
+    let (_, node) = published[0].nodes.first().expect("one node");
+    assert_eq!(node.label(), Some("Submit"));
+    assert_eq!(node.role(), Role::Button);
+}
+
+/// Attach and detach both reach the listener. A composition root drives
+/// semantics assembly off this, so a missed detach leaves assembly running for
+/// a screen reader that is gone — a per-frame tree walk charged to nobody.
+#[test]
+fn activation_changes_reach_the_listener() {
+    let accessibility = FakeAccessibility::new();
+    let seen: Arc<parking_lot::Mutex<Vec<bool>>> = Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+    let seen_in_listener = Arc::clone(&seen);
+    accessibility.set_activation_listener(Arc::new(move |active| {
+        seen_in_listener.lock().push(active);
+    }));
+
+    accessibility.set_active(true);
+    accessibility.set_active(false);
+
+    assert_eq!(*seen.lock(), vec![true, false]);
+}
+
+/// A listener that publishes from inside the activation callback must not
+/// deadlock against the lock that dispatched it. This is the clone-and-release
+/// discipline the real platform paths use, and the shape a composition root
+/// will actually write: "attached — send the current tree now."
+#[test]
+fn a_listener_that_publishes_does_not_deadlock() {
+    let accessibility = Arc::new(FakeAccessibility::new());
+    let ran = Arc::new(AtomicBool::new(false));
+
+    let inner = Arc::clone(&accessibility);
+    let ran_in_listener = Arc::clone(&ran);
+    accessibility.set_activation_listener(Arc::new(move |active| {
+        if active {
+            inner.publish(&tree_update(1, "Submit"));
+            ran_in_listener.store(true, Ordering::SeqCst);
+        }
+    }));
+
+    accessibility.set_active(true);
+
+    assert!(ran.load(Ordering::SeqCst), "the listener ran to completion");
+    assert_eq!(
+        accessibility.published_count(),
+        1,
+        "and its publish took effect"
+    );
+}
+
+/// Inbound actions carry the node id from the published tree. That identity is
+/// the whole reason the round trip closes without a translation table: the same
+/// value a composition root hands to `SemanticsOwner::resolve_action`.
+#[test]
+fn an_action_arrives_addressed_by_the_published_node_id() {
+    let accessibility = FakeAccessibility::new();
+    let targets: Arc<parking_lot::Mutex<Vec<(u64, Action)>>> =
+        Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+    let targets_in_listener = Arc::clone(&targets);
+    accessibility.set_action_listener(Arc::new(move |request: ActionRequest| {
+        targets_in_listener
+            .lock()
+            .push((request.target_node.0, request.action));
+    }));
+
+    accessibility.set_active(true);
+    accessibility.publish(&tree_update(42, "Submit"));
+
+    accessibility.request_action(ActionRequest {
+        action: Action::Click,
+        target_tree: TreeId::ROOT,
+        target_node: NodeId(42),
+        data: None,
+    });
+
+    assert_eq!(*targets.lock(), vec![(42, Action::Click)]);
+}
+
+/// Registering a listener replaces the previous one rather than fanning out.
+/// Two live listeners would mean a re-registering composition root silently
+/// driving assembly twice.
+#[test]
+fn registering_a_listener_replaces_the_previous_one() {
+    let accessibility = FakeAccessibility::new();
+    let first = Arc::new(AtomicUsize::new(0));
+    let second = Arc::new(AtomicUsize::new(0));
+
+    let first_counter = Arc::clone(&first);
+    accessibility.set_activation_listener(Arc::new(move |_| {
+        first_counter.fetch_add(1, Ordering::SeqCst);
+    }));
+    let second_counter = Arc::clone(&second);
+    accessibility.set_activation_listener(Arc::new(move |_| {
+        second_counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    accessibility.set_active(true);
+
+    assert_eq!(first.load(Ordering::SeqCst), 0, "the replaced listener");
+    assert_eq!(second.load(Ordering::SeqCst), 1, "the current listener");
+}

--- a/crates/flui-platform/tests/accessibility_capability.rs
+++ b/crates/flui-platform/tests/accessibility_capability.rs
@@ -35,7 +35,7 @@ fn tree_update(id: u64, label: &str) -> TreeUpdate {
 fn nothing_is_published_while_inactive() {
     let accessibility = FakeAccessibility::new();
 
-    accessibility.publish(&tree_update(1, "Submit"));
+    accessibility.publish(tree_update(1, "Submit"));
 
     assert!(!accessibility.is_active());
     assert_eq!(accessibility.published_count(), 0);
@@ -46,7 +46,7 @@ fn publishing_while_active_records_the_tree() {
     let accessibility = FakeAccessibility::new();
     accessibility.set_active(true);
 
-    accessibility.publish(&tree_update(1, "Submit"));
+    accessibility.publish(tree_update(1, "Submit"));
 
     let published = accessibility.published();
     assert_eq!(published.len(), 1);
@@ -87,7 +87,7 @@ fn a_listener_that_publishes_does_not_deadlock() {
     let ran_in_listener = Arc::clone(&ran);
     accessibility.set_activation_listener(Arc::new(move |active| {
         if active {
-            inner.publish(&tree_update(1, "Submit"));
+            inner.publish(tree_update(1, "Submit"));
             ran_in_listener.store(true, Ordering::SeqCst);
         }
     }));
@@ -119,7 +119,7 @@ fn an_action_arrives_addressed_by_the_published_node_id() {
     }));
 
     accessibility.set_active(true);
-    accessibility.publish(&tree_update(42, "Submit"));
+    accessibility.publish(tree_update(42, "Submit"));
 
     accessibility.request_action(ActionRequest {
         action: Action::Click,
@@ -153,4 +153,49 @@ fn registering_a_listener_replaces_the_previous_one() {
 
     assert_eq!(first.load(Ordering::SeqCst), 0, "the replaced listener");
     assert_eq!(second.load(Ordering::SeqCst), 1, "the current listener");
+}
+
+/// An action arriving after detach is stale and must be dropped, not delivered.
+/// A composition root that stops assembly on detach has no tree to resolve it
+/// against, so forwarding would hand it a target it cannot look up.
+#[test]
+fn an_action_after_detach_is_dropped() {
+    let accessibility = FakeAccessibility::new();
+    let delivered = Arc::new(AtomicUsize::new(0));
+
+    let counter = Arc::clone(&delivered);
+    accessibility.set_action_listener(Arc::new(move |_| {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    accessibility.set_active(true);
+    accessibility.set_active(false);
+
+    accessibility.request_action(ActionRequest {
+        action: Action::Click,
+        target_tree: TreeId::ROOT,
+        target_node: NodeId(42),
+        data: None,
+    });
+
+    assert_eq!(delivered.load(Ordering::SeqCst), 0);
+}
+
+/// Attach/detach is a transition: re-asserting the same state must not
+/// re-notify, or a composition root would run redundant enable/disable cycles.
+#[test]
+fn re_asserting_the_same_activation_state_does_not_re_notify() {
+    let accessibility = FakeAccessibility::new();
+    let notifications = Arc::new(AtomicUsize::new(0));
+
+    let counter = Arc::clone(&notifications);
+    accessibility.set_activation_listener(Arc::new(move |_| {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    accessibility.set_active(true);
+    accessibility.set_active(true);
+    accessibility.set_active(true);
+
+    assert_eq!(notifications.load(Ordering::SeqCst), 1);
 }

--- a/crates/flui-platform/tests/main.rs
+++ b/crates/flui-platform/tests/main.rs
@@ -10,6 +10,8 @@
 //! `FLUI_HEADLESS` env var) live in their own [[test]] target instead —
 //! process isolation beats opt-in locking. See headless.
 
+#[path = "accessibility_capability.rs"]
+mod accessibility_capability;
 #[path = "contract.rs"]
 mod contract;
 #[path = "display_enumeration.rs"]

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -136,13 +136,13 @@ declarations = [
     "pub use platforms::IOSPlatform;",
     "pub use platforms::LinuxPlatform;",
     "pub use platforms::MacOSPlatform;",
-    "pub use platforms::{FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform};",
+    "pub use platforms::{ FakeAccessibility, FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform, };",
     "pub use platforms::WebPlatform;",
     "pub use platforms::WindowsPlatform;",
     "pub use platforms::WinitPlatform;",
     "pub use shared::{PlatformHandlers, WindowCallbacks};",
     "pub use task::{Priority, Task, TaskLabel};",
-    "pub use traits::{ Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, DisplayId, MobileCapabilities, PathPromptOptions, Platform, PlatformCapabilities, PlatformDisplay, PlatformEmbedder, PlatformExecutor, PlatformHaptics, PlatformReadyCallback, PlatformTextInput, PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId, WindowMode, WindowOptions, };",
+    "pub use traits::{ AccessibilityActionListener, AccessibilityActivationListener, Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, DisplayId, MobileCapabilities, PathPromptOptions, Platform, PlatformAccessibility, PlatformCapabilities, PlatformDisplay, PlatformEmbedder, PlatformExecutor, PlatformHaptics, PlatformReadyCallback, PlatformTextInput, PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId, WindowMode, WindowOptions, };",
     "pub use traits::{ OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, SharedPlatform, WaitError, WindowOpen, };",
     "pub fn current_platform() -> anyhow::Result<Box<dyn Platform>> {",
     "pub fn headless_platform() -> Box<dyn Platform> {",
@@ -2421,7 +2421,7 @@ path = "flui_platform backend types (WinitPlatform, WindowsPlatform, MacOSPlatfo
 crate = "flui-platform"
 kind = "type"
 declared_in = "crates/flui-platform/src/lib.rs"
-contains = "pub use platforms::{FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform}"
+contains = "FakeAccessibility, FakeHaptics, FakeTextInput, HeadlessDeferredWindowOpens, HeadlessPlatform,"
 classification = "transitional"
 thread_affinity = "construct and run on the thread that owns (or will own) the event loop; MacOSPlatform carries unsafe impl Send/Sync by AppKit convention"
 owner = "per-OS event-loop backends"


### PR DESCRIPTION
First half of the Linux bridge (#684) — the capability seam and its headless fake.

**Deliberately without `accesskit_unix`.** That adapter adds **66 crates** to `flui-platform`'s graph (92 → 203: zbus, atspi, a full async ecosystem). That decision should be reviewed on its own merits, not bundled inside a seam-design diff where it would slide through as an implementation detail. It follows in a second PR.

## Shape

Follows the established capability template (ADR-0030 text input, ADR-0031 haptics): a fallible `PlatformWindow::accessibility() -> Option<Arc<dyn _>>` defaulting to `None`, so a backend with no accessibility integration declines rather than inheriting methods it cannot honor. Today that is every backend; the headless one returns a `FakeAccessibility`.

The trait speaks **accesskit types and never semantics types**. That is not a workaround for the layer rule (`flui-platform` L2, `flui-semantics` L3) — it is what *forces* translation onto the producing side, where the tree and its stable identities live.

Both directions are modelled, because a screen reader is not a display:

- **out** — `publish(&TreeUpdate)`, borrowed rather than owned so an inactive implementation drops it without paying for a clone (`TreeUpdate` is `Clone`, so an active one clones inside its own active-check — the same shape as the real adapter's `update_if_active`).
- **in** — activation and action listeners registered by the composition root, since a layer-2 crate has nothing of its own to call.

`ActionRequest::target_node` is the same stable id the published tree carried, so a composition root routes straight to `SemanticsOwner::resolve_action` with no translation table between them. (`target_tree` is what will address the right presentation once more than one window publishes.)

## The fake is driveable on purpose

`FakeAccessibility` records published trees **and** lets a test drive activation, because the behaviour worth pinning is conditional on it: publishing must do nothing while no assistive technology is attached, so an application that never runs one pays nothing for the capability existing. A fake that recorded unconditionally would hide the only property worth having.

## Six tests, and the one that earns its place

`a_listener_that_publishes_does_not_deadlock` looks like ceremony until you break it: reverting `set_active` to hold its lock across the listener call makes the test **hang past 60s**. That is exactly what a composition root hits the first time it writes the obvious thing — "assistive technology attached, send the current tree now" — from inside the activation callback. Verified by injecting it.

The others pin: nothing published while inactive, publishing while active records role and label, attach *and* detach both reach the listener (a missed detach leaves assembly running for a screen reader that is gone), actions arrive in the published id space, and re-registering replaces rather than fans out.

## What this cannot prove

There is no AT-SPI session bus on CI, so no real adapter activates and no screen reader ever reads a tree. This PR pins the seam's contract; end-to-end behavioural validation needs a desktop session with Orca, and is named as out of reach in #684 rather than implied by a green tick.

`just ci` exit 0, 8943 tests.

Refs #684, #675