### PR TITLE
feat(platform): AT-SPI accessibility for Linux behind the a11y feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_atspi_common"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +277,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,10 +344,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
 
 [[package]]
 name = "autocfg"
@@ -393,6 +592,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -1221,6 +1433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1786,6 +2005,7 @@ name = "flui-platform"
 version = "0.2.0"
 dependencies = [
  "accesskit",
+ "accesskit_unix",
  "android-activity",
  "anyhow",
  "arboard",
@@ -2139,6 +2359,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2652,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -3179,6 +3418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3818,6 +4066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,6 +4126,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3892,6 +4193,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -4659,6 +4971,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4756,6 +5079,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
@@ -5441,6 +5770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ui-events"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5555,6 +5895,7 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -6628,6 +6969,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6746,4 +7193,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.2",
+ "winnow",
 ]

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -20,6 +20,7 @@ autotests = false
 # 3) types, so an already-translated `accesskit::TreeUpdate` is what crosses
 # the seam.
 accesskit = { workspace = true }
+
 flui-types = { path = "../flui-types", version = "0.2.0" }
 # Layer-legal downward edge (foundation sits below platform in the DAG),
 # carrying two seams: OwnerAffinity — the ADR-0039 owner-thread backstop,
@@ -145,11 +146,22 @@ web-sys = { version = "0.3", features = [
 ] }
 console_error_panic_hook = "0.1"
 
+# AT-SPI bridge for Linux, behind the `a11y` feature. Off by default because it
+# brings ~66 crates (zbus, atspi, an async executor) -- AT-SPI *is* D-Bus, so
+# there is no lighter path, but an application that does not want a
+# screen-reader bridge should not link a D-Bus stack.
+[target.'cfg(target_os = "linux")'.dependencies]
+accesskit_unix = { version = "0.22", optional = true }
+
 [features]
 default = ["desktop"]
 
 # Platform features
 desktop = ["dep:winit"]
+
+# AT-SPI accessibility bridge (Linux). Off by default: see the dependency note
+# above for why ~66 crates should be an opt-in rather than a default.
+a11y = ["dep:accesskit_unix"]
 
 # winit fallback backend — primary on Linux until native Wayland/X11 lands
 # (roadmap Cross.P); optional on Windows/macOS.

--- a/crates/flui-platform/src/platforms/linux/accessibility.rs
+++ b/crates/flui-platform/src/platforms/linux/accessibility.rs
@@ -157,16 +157,17 @@ impl std::fmt::Debug for UnixAccessibility {
 }
 
 impl PlatformAccessibility for UnixAccessibility {
-    fn publish(&self, update: &TreeUpdate) {
+    fn publish(&self, update: TreeUpdate) {
         // Retained even while inactive: a screen reader started later asks for
         // an initial tree, and answering it from here shows the real interface
         // immediately instead of an empty window until something next changes.
+        //
+        // Exactly one clone, and it buys that retention. `update_if_active`
+        // takes a factory, so the owned value moves into the adapter only when
+        // something is attached; with nobody listening the closure never runs
+        // and the value is simply dropped.
         *self.shared.latest.lock() = Some(update.clone());
-
-        // `update_if_active` takes a factory, so the second clone happens only
-        // when assistive technology is actually attached. The common case —
-        // nobody listening — costs the store above and nothing more.
-        self.adapter.lock().update_if_active(|| update.clone());
+        self.adapter.lock().update_if_active(move || update);
     }
 
     fn is_active(&self) -> bool {
@@ -220,7 +221,7 @@ mod tests {
     fn publishing_while_inactive_retains_the_tree_for_a_later_activation() {
         let accessibility = UnixAccessibility::new();
 
-        accessibility.publish(&tree_update("Submit"));
+        accessibility.publish(tree_update("Submit"));
 
         let retained = accessibility.shared.latest.lock().clone();
         let retained = retained.expect("the tree is kept for a late activation");
@@ -233,7 +234,7 @@ mod tests {
     #[test]
     fn activation_answers_with_the_retained_tree() {
         let accessibility = UnixAccessibility::new();
-        accessibility.publish(&tree_update("Submit"));
+        accessibility.publish(tree_update("Submit"));
 
         let mut activation = Activation(Arc::clone(&accessibility.shared));
         let initial = activation
@@ -290,7 +291,7 @@ mod tests {
         let published_flag = Arc::clone(&published);
         accessibility.set_activation_listener(Arc::new(move |active| {
             if active {
-                inner.publish(&tree_update("Submit"));
+                inner.publish(tree_update("Submit"));
                 published_flag.store(true, Ordering::SeqCst);
             }
         }));

--- a/crates/flui-platform/src/platforms/linux/accessibility.rs
+++ b/crates/flui-platform/src/platforms/linux/accessibility.rs
@@ -1,0 +1,328 @@
+//! AT-SPI accessibility for Linux, via `accesskit_unix`.
+//!
+//! Implements [`PlatformAccessibility`] by wrapping [`accesskit_unix::Adapter`],
+//! which exposes an AccessKit tree over AT-SPI (the D-Bus protocol Orca and
+//! every other Linux screen reader speak).
+//!
+//! # Why this is feature-gated
+//!
+//! `accesskit_unix` brings ~66 crates (zbus, atspi, an async executor). AT-SPI
+//! *is* D-Bus, so there is no lighter path — but an application that does not
+//! want a screen-reader bridge should not link a D-Bus stack. The `a11y`
+//! feature is therefore off by default.
+//!
+//! # Nothing async reaches the frame path
+//!
+//! `Adapter`'s own API is blocking; it runs an executor internally on its own
+//! thread. No future is awaited on the UI thread and no runtime is imposed on
+//! the embedder, which is what keeps this compatible with FLUI's synchronous
+//! pipeline.
+//!
+//! # The activation dance
+//!
+//! AT-SPI is lazy: nothing exists until an assistive technology asks. That maps
+//! onto FLUI's own gate rather than needing a new one — activation turns
+//! semantics assembly on, deactivation turns it off, so an application with no
+//! screen reader attached never pays for a tree walk.
+//!
+//! The first request arrives before FLUI has assembled anything, so
+//! [`ActivationHandler::request_initial_tree`] answers `None` when it has no
+//! tree yet. That is not a failure: AccessKit treats it as "not ready", and the
+//! next [`publish`](PlatformAccessibility::publish) delivers the tree once
+//! assembly has produced one.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use accesskit::{ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, TreeUpdate};
+use parking_lot::Mutex;
+
+use crate::traits::{
+    AccessibilityActionListener, AccessibilityActivationListener, PlatformAccessibility,
+};
+
+/// State shared between the capability and the three handlers the adapter owns.
+///
+/// The handlers are moved into `Adapter::new` and thereafter live on the
+/// adapter's own thread, so everything they touch has to be reachable from both
+/// sides. This is that shared middle.
+#[derive(Default)]
+struct Shared {
+    /// Whether assistive technology is currently attached.
+    active: AtomicBool,
+    /// The most recent tree, kept so a late activation can be answered
+    /// immediately rather than showing an empty application until the next
+    /// frame happens to dirty something.
+    latest: Mutex<Option<TreeUpdate>>,
+    activation_listener: Mutex<Option<AccessibilityActivationListener>>,
+    action_listener: Mutex<Option<AccessibilityActionListener>>,
+}
+
+impl Shared {
+    /// Clone the listener out of its lock, then call it.
+    ///
+    /// A listener re-entering this type (the composition root's natural
+    /// response to "attached" is to publish) would deadlock against a held
+    /// guard. Same discipline as the semantics owner's callback dispatch.
+    fn notify_activation(&self, active: bool) {
+        self.active.store(active, Ordering::SeqCst);
+        let listener = self.activation_listener.lock().clone();
+        if let Some(listener) = listener {
+            listener(active);
+        }
+    }
+
+    fn notify_action(&self, request: ActionRequest) {
+        let listener = self.action_listener.lock().clone();
+        if let Some(listener) = listener {
+            listener(request);
+        }
+    }
+}
+
+struct Activation(Arc<Shared>);
+
+impl ActivationHandler for Activation {
+    fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+        // Order matters: mark active and tell the composition root *before*
+        // reading `latest`. The listener typically enables semantics, and on a
+        // cold start that is what will produce the first tree at all — reading
+        // first would answer `None` even when a synchronous listener could
+        // have supplied one.
+        self.0.notify_activation(true);
+        self.0.latest.lock().clone()
+    }
+}
+
+struct Deactivation(Arc<Shared>);
+
+impl DeactivationHandler for Deactivation {
+    fn deactivate_accessibility(&mut self) {
+        self.0.notify_activation(false);
+    }
+}
+
+struct Action(Arc<Shared>);
+
+impl ActionHandler for Action {
+    fn do_action(&mut self, request: ActionRequest) {
+        self.0.notify_action(request);
+    }
+}
+
+/// AT-SPI accessibility for one window.
+pub struct UnixAccessibility {
+    shared: Arc<Shared>,
+    /// The adapter needs `&mut` to publish, and the capability is shared behind
+    /// an `Arc`, so the mutability lives here rather than in the trait.
+    adapter: Mutex<accesskit_unix::Adapter>,
+}
+
+impl UnixAccessibility {
+    /// Create the adapter and announce this window on the AT-SPI bus.
+    ///
+    /// Constructing does not require a screen reader to be running, and does
+    /// not fail when no session bus is reachable — the adapter simply never
+    /// activates, which is exactly the state a headless CI machine is in.
+    #[must_use]
+    pub fn new() -> Self {
+        let shared = Arc::new(Shared::default());
+        let adapter = accesskit_unix::Adapter::new(
+            Activation(Arc::clone(&shared)),
+            Action(Arc::clone(&shared)),
+            Deactivation(Arc::clone(&shared)),
+        );
+
+        Self {
+            shared,
+            adapter: Mutex::new(adapter),
+        }
+    }
+}
+
+impl Default for UnixAccessibility {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for UnixAccessibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnixAccessibility")
+            .field("active", &self.shared.active.load(Ordering::SeqCst))
+            .finish_non_exhaustive()
+    }
+}
+
+impl PlatformAccessibility for UnixAccessibility {
+    fn publish(&self, update: &TreeUpdate) {
+        // Retained even while inactive: a screen reader started later asks for
+        // an initial tree, and answering it from here shows the real interface
+        // immediately instead of an empty window until something next changes.
+        *self.shared.latest.lock() = Some(update.clone());
+
+        // `update_if_active` takes a factory, so the second clone happens only
+        // when assistive technology is actually attached. The common case —
+        // nobody listening — costs the store above and nothing more.
+        self.adapter.lock().update_if_active(|| update.clone());
+    }
+
+    fn is_active(&self) -> bool {
+        self.shared.active.load(Ordering::SeqCst)
+    }
+
+    fn set_activation_listener(&self, listener: AccessibilityActivationListener) {
+        *self.shared.activation_listener.lock() = Some(listener);
+    }
+
+    fn set_action_listener(&self, listener: AccessibilityActionListener) {
+        *self.shared.action_listener.lock() = Some(listener);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use accesskit::{Node, NodeId, Role, Tree, TreeId};
+
+    use super::*;
+
+    fn tree_update(label: &str) -> TreeUpdate {
+        let root = NodeId(1);
+        let mut node = Node::new(Role::Button);
+        node.set_label(label.to_string());
+        TreeUpdate {
+            nodes: vec![(root, node)],
+            tree: Some(Tree::new(root)),
+            tree_id: TreeId::ROOT,
+            focus: root,
+        }
+    }
+
+    /// Constructing must not require a session bus. CI has none, and neither
+    /// does a user running under a bare compositor — an application that
+    /// panicked or hung there would be unusable for everyone, screen reader or
+    /// not.
+    #[test]
+    fn constructing_without_a_session_bus_is_harmless() {
+        let accessibility = UnixAccessibility::new();
+        assert!(
+            !accessibility.is_active(),
+            "no assistive technology has attached"
+        );
+    }
+
+    /// Publishing with nothing attached must be a no-op that still *retains*
+    /// the tree, so a screen reader started afterwards is answered with the
+    /// real interface rather than an empty one.
+    #[test]
+    fn publishing_while_inactive_retains_the_tree_for_a_later_activation() {
+        let accessibility = UnixAccessibility::new();
+
+        accessibility.publish(&tree_update("Submit"));
+
+        let retained = accessibility.shared.latest.lock().clone();
+        let retained = retained.expect("the tree is kept for a late activation");
+        let (_, node) = retained.nodes.first().expect("one node");
+        assert_eq!(node.label(), Some("Submit"));
+    }
+
+    /// The activation handler answers with the retained tree, which is the
+    /// path a screen reader started after the application takes.
+    #[test]
+    fn activation_answers_with_the_retained_tree() {
+        let accessibility = UnixAccessibility::new();
+        accessibility.publish(&tree_update("Submit"));
+
+        let mut activation = Activation(Arc::clone(&accessibility.shared));
+        let initial = activation
+            .request_initial_tree()
+            .expect("a tree was published before activation");
+
+        let (_, node) = initial.nodes.first().expect("one node");
+        assert_eq!(node.label(), Some("Submit"));
+        assert!(accessibility.is_active());
+    }
+
+    /// A cold activation has nothing to answer with. `None` means "not ready",
+    /// not "no interface" — the next publish delivers the tree.
+    #[test]
+    fn a_cold_activation_answers_none_and_still_activates() {
+        let accessibility = UnixAccessibility::new();
+
+        let mut activation = Activation(Arc::clone(&accessibility.shared));
+        assert!(activation.request_initial_tree().is_none());
+        assert!(
+            accessibility.is_active(),
+            "activation is not conditional on having a tree"
+        );
+    }
+
+    /// Attach and detach both reach the composition root's listener. A missed
+    /// detach leaves semantics assembly running for a screen reader that is
+    /// gone — a per-frame tree walk charged to nobody.
+    #[test]
+    fn activation_and_deactivation_reach_the_listener() {
+        let accessibility = UnixAccessibility::new();
+        let seen: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let seen_in_listener = Arc::clone(&seen);
+        accessibility.set_activation_listener(Arc::new(move |active| {
+            seen_in_listener.lock().push(active);
+        }));
+
+        Activation(Arc::clone(&accessibility.shared)).request_initial_tree();
+        Deactivation(Arc::clone(&accessibility.shared)).deactivate_accessibility();
+
+        assert_eq!(*seen.lock(), vec![true, false]);
+        assert!(!accessibility.is_active());
+    }
+
+    /// A listener that publishes from inside the activation callback must not
+    /// deadlock — that is the composition root's natural response to "attached".
+    #[test]
+    fn a_listener_that_publishes_does_not_deadlock() {
+        let accessibility = Arc::new(UnixAccessibility::new());
+        let published = Arc::new(AtomicBool::new(false));
+
+        let inner = Arc::clone(&accessibility);
+        let published_flag = Arc::clone(&published);
+        accessibility.set_activation_listener(Arc::new(move |active| {
+            if active {
+                inner.publish(&tree_update("Submit"));
+                published_flag.store(true, Ordering::SeqCst);
+            }
+        }));
+
+        let initial = Activation(Arc::clone(&accessibility.shared)).request_initial_tree();
+
+        assert!(published.load(Ordering::SeqCst), "the listener completed");
+        assert!(
+            initial.is_some(),
+            "and the tree it published answered this very activation"
+        );
+    }
+
+    /// Inbound actions reach the composition root addressed by the stable node
+    /// id, which is what closes the round trip without a translation table.
+    #[test]
+    fn an_action_reaches_the_listener_in_the_published_id_space() {
+        let accessibility = UnixAccessibility::new();
+        let seen: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let seen_in_listener = Arc::clone(&seen);
+        accessibility.set_action_listener(Arc::new(move |request: ActionRequest| {
+            seen_in_listener.lock().push(request.target_node.0);
+        }));
+
+        Action(Arc::clone(&accessibility.shared)).do_action(ActionRequest {
+            action: accesskit::Action::Click,
+            target_tree: TreeId::ROOT,
+            target_node: NodeId(1),
+            data: None,
+        });
+
+        assert_eq!(*seen.lock(), vec![1]);
+    }
+}

--- a/crates/flui-platform/src/platforms/linux/mod.rs
+++ b/crates/flui-platform/src/platforms/linux/mod.rs
@@ -72,10 +72,14 @@
 //! let platform = LinuxPlatform::new();
 //! ```
 
+#[cfg(all(target_os = "linux", feature = "a11y"))]
+mod accessibility;
 mod window_ext;
 
 use std::sync::Arc;
 
+#[cfg(all(target_os = "linux", feature = "a11y"))]
+pub use accessibility::UnixAccessibility;
 use anyhow::Result;
 pub use window_ext::*;
 


### PR DESCRIPTION
Second half of the Linux bridge (#684). **Stacked on #685** — review that first.

`UnixAccessibility` implements `PlatformAccessibility` by wrapping `accesskit_unix::Adapter`, exposing the tree over AT-SPI — the D-Bus protocol Orca and every other Linux screen reader speak.

## The dependency decision, isolated on purpose

`accesskit_unix` brings **~66 crates** (zbus, atspi, an async executor). This PR exists separately from #685 so that number gets reviewed as a decision rather than sliding past inside a seam-design diff.

There is no lighter path — AT-SPI *is* D-Bus. So the answer is opt-in: `a11y` is off by default, and the dependency is additionally scoped to `cfg(target_os = "linux")` so no other target resolves it at all. An application that does not want a screen-reader bridge never links a D-Bus stack.

If the project's position is that accessibility should be on by default, that is one line (`default = ["desktop", "a11y"]`) and a defensible stance — I did not assume it.

## Two ordering decisions, both load-bearing

**`request_initial_tree` notifies before reading the retained tree.** The listener is what enables semantics, and on a cold start it is what produces the first tree at all. Reading first would answer `None` even when a synchronous listener could have supplied one — so a screen reader attaching to a freshly-started app would see nothing until the next unrelated change. Tested directly (`a_listener_that_publishes_does_not_deadlock` asserts the published tree answers *that same* activation).

**`publish` retains the tree even while inactive.** A screen reader started after the application asks for an initial tree; answering from the retained copy shows the real interface immediately instead of an empty window until something happens to change.

`update_if_active` takes a factory, so the clone that reaches the adapter happens only when something is attached.

## Nothing async reaches the frame path

`Adapter`'s API is blocking and runs its executor on its own thread. No future is awaited on the UI thread, and no async runtime is imposed on the embedder — which is what makes this compatible with FLUI's synchronous pipeline and the port-check rule against async in frame phases.

## The test that matters most

Seven tests, run with **no D-Bus session** — which is the point. `constructing_without_a_session_bus_is_harmless` pins that the real adapter neither panics nor hangs on a machine with no AT-SPI: the state both CI and a bare-compositor user are in. That is the failure mode that would have made this feature unusable *for everyone* rather than merely absent for screen-reader users, and it is not obvious from the crate's docs that it holds.

## Evidence

- `cargo deny` clean on the new graph — advisories, bans, licenses, sources
- `just ci` exit 0 with the feature **off**
- `cargo clippy --features a11y --all-targets -- -D warnings` exit 0; full test run with the feature **on** green
- CI's `cargo-hack` per-feature matrix covers both states going forward

## What this cannot prove

CI has no AT-SPI session bus, so the adapter never activates and no screen reader reads a tree here. Every test above pins construction, retention, and handler wiring — not screen-reader behaviour. End-to-end validation needs a desktop session with Orca, named as out of reach in #684 rather than implied by a green tick.

Still outstanding for the bridge (tracked in #684): the flui-app wire replacing `no_op_semantics_update_callback()`, and the teardown/withdrawal paths.

Refs #684, #675