### PR TITLE
perf(semantics): benchmark the publish path, and reorder its backlog by the data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,6 +2090,7 @@ name = "flui-semantics"
 version = "0.2.0"
 dependencies = [
  "accesskit",
+ "criterion",
  "flui-foundation",
  "flui-tree",
  "flui-types",

--- a/crates/flui-semantics/Cargo.toml
+++ b/crates/flui-semantics/Cargo.toml
@@ -56,3 +56,12 @@ thiserror.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+# Cost of a semantics-enabled frame as a function of tree size — the number the
+# pipeline's scalability work has to beat.
+[[bench]]
+name = "publish_cost"
+harness = false

--- a/crates/flui-semantics/benches/publish_cost.rs
+++ b/crates/flui-semantics/benches/publish_cost.rs
@@ -1,0 +1,108 @@
+//! What a semantics-enabled frame costs, as a function of tree size.
+//!
+//! Filed as the prerequisite for the pipeline's scalability work: three costs
+//! are documented as "correct but O(tree)" — full assembly per pass, a
+//! whole-tree `TreeUpdate` per change, and an idle dirty check that scans. Any
+//! optimisation of those needs a number to beat, or the improvement claim is an
+//! assertion.
+//!
+//! This benchmark covers the two costs that live in this crate. Assembly is
+//! upstream (`PipelineOwner::run_semantics`) and is not measured here.
+//!
+//! # The three scenarios
+//!
+//! - **idle** — a clean tree, the common case while a screen reader is
+//!   attached but nothing is changing. This is the one whose cost is
+//!   counter-intuitive: `has_dirty_nodes` short-circuits on the *first dirty*
+//!   node, so a clean tree is scanned to the end. Idle is the worst case, not
+//!   the cheap one.
+//! - **one_dirty** — a single changed node, the shape of a checkbox toggling.
+//!   Measures what one small change costs: today, a full-tree translation.
+//! - **all_dirty** — every node changed, the shape of a route transition, and
+//!   the ceiling `one_dirty` should be far below but currently approaches.
+//!
+//! Sizes span 16..1024 nodes. A real application's semantics tree holds
+//! *boundaries*, not widgets, so 1024 is a large app rather than an absurd one.
+
+// Bench binary: criterion's generated main has no docs (house precedent:
+// the flui-view and flui-testing benches carry the same allow).
+#![allow(missing_docs)]
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use flui_foundation::RenderId;
+use flui_semantics::{SemanticsNode, SemanticsOwner};
+
+/// A render-backed node — production assembly always attaches one, and it is
+/// what makes a node publishable at all.
+fn node(index: u32) -> SemanticsNode {
+    let mut node = SemanticsNode::new().with_source_render_id(RenderId::new_gen(
+        index,
+        core::num::NonZeroU32::new(1).expect("bench generation is non-zero"),
+    ));
+    node.config_mut().set_label(format!("node {index}"));
+    node.config_mut().set_button(index.is_multiple_of(3));
+    node
+}
+
+/// A rooted tree of `count` nodes: one root with `count - 1` children.
+///
+/// Flat rather than deep on purpose — the costs under measurement are per-node
+/// (a scan and a translation), so depth would only add noise.
+fn owner_with(count: u32) -> SemanticsOwner {
+    let mut owner = SemanticsOwner::new(Arc::new(|_| {}));
+    let root = owner.insert(node(0));
+    for index in 1..count {
+        let child = owner.insert(node(index));
+        owner.add_child(root, child);
+    }
+    owner.set_root(Some(root));
+    // Settle: everything starts dirty, so publish once and let the scenarios
+    // decide what is dirty from here.
+    owner.flush();
+    owner
+}
+
+fn publish_cost(c: &mut Criterion) {
+    let mut group = c.benchmark_group("semantics_publish");
+
+    for count in [16u32, 64, 256, 1024] {
+        // A clean tree publishes nothing. What it still pays is the dirty
+        // check — and that check scans furthest precisely when there is
+        // nothing to do.
+        group.bench_with_input(BenchmarkId::new("idle", count), &count, |b, &count| {
+            let mut owner = owner_with(count);
+            b.iter(|| {
+                owner.flush();
+                black_box(owner.needs_flush())
+            });
+        });
+
+        // One changed node. Today this translates and publishes the whole
+        // tree, so it should track `all_dirty` rather than staying flat —
+        // that gap is the thing worth closing.
+        group.bench_with_input(BenchmarkId::new("one_dirty", count), &count, |b, &count| {
+            let mut owner = owner_with(count);
+            let target = owner.root().expect("the tree is rooted");
+            b.iter(|| {
+                owner.mark_dirty(target);
+                owner.flush();
+            });
+        });
+
+        // Every node changed — a route transition. The ceiling.
+        group.bench_with_input(BenchmarkId::new("all_dirty", count), &count, |b, &count| {
+            let mut owner = owner_with(count);
+            b.iter(|| {
+                owner.send_full_tree();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, publish_cost);
+criterion_main!(benches);


### PR DESCRIPTION
The prerequisite #687 asks for before any optimisation: *"a benchmark, before any optimisation, showing per-frame cost as a function of tree size... Without that number, every claim here is an assertion — including mine."*

Running it reordered the backlog I wrote in that issue.

## Measured

criterion, 3s measurement window, median of the reported interval:

| nodes | idle | one_dirty | all_dirty |
|-------|---------|-----------|-----------|
| 16 | 20 ns | 1.69 µs | 1.67 µs |
| 64 | 87 ns | 9.24 µs | 9.26 µs |
| 256 | 331 ns | 40.3 µs | 41.3 µs |
| 1024 | **1.72 µs** | **166 µs** | **174 µs** |

## Finding 1 — changing one node costs what changing every node costs

`one_dirty` tracks `all_dirty` within ~5% at every size. The full-tree republish, quantified rather than described: at 1024 nodes a single checkbox toggle spends **166 µs**, about **1% of a 60fps frame budget**, and it scales with tree size rather than with the size of the change.

That is the number the incremental-diff work has to beat, and it is why #680 (carrying stable identity in the payload) is a performance prerequisite rather than only a latent correctness trap.

## Finding 2 — I had the priority order wrong

I listed the O(1) dirty counter in #687 as an independent early win. The data says otherwise: the idle scan costs **1.72 µs at 1024 nodes** — roughly **0.01% of a frame**, and about **100× less** than the republish sitting next to it.

Doing it first would have optimised the measured non-bottleneck. That is precisely what "profile before optimising" exists to prevent, and I would have walked into it on the strength of "small and independent" — which was true, and irrelevant. It stays worth fixing; it is not worth fixing first.

#687's sequence is updated accordingly.

## A third thing worth attributing

Publish scaling is slightly superlinear: 64× more nodes (16 → 1024) costs 98× more time. Something beyond the per-node translation grows — allocation behaviour in the update vector is the obvious suspect. Worth attributing before optimising rather than assuming.

## Bench fidelity

- Trees are built **outside** `b.iter`, so the measurement is the publish path and not setup.
- Nodes are **render-backed** (`with_source_render_id`). A node without a source render object is not publishable at all, so a tree of them would have measured an early return — a bench that quietly benchmarks the fast exit is worse than none.
- `idle` runs `flush()` on a settled tree, which is the real steady state while a screen reader is attached and nothing is changing.

Numbers are from one machine: a baseline to beat, not a spec. `just ci` exit 0.

Refs #687, #680
