### PR TITLE
refactor(view): make the build-during-layout registry payload-blind

### DIFF
--- a/crates/flui-objects/src/layout/layout_constraints_cell.rs
+++ b/crates/flui-objects/src/layout/layout_constraints_cell.rs
@@ -49,6 +49,41 @@ struct CellState {
     needs_build: bool,
 }
 
+/// The registry-facing half of a build-during-layout mailbox.
+///
+/// The servicing loop (`BuildOwner::service_layout_builders`) needs to know
+/// only three things about a cell: whether its owner must rebuild, whether it
+/// has ever been laid out, and when to mark the published value as built. It
+/// never reads the payload — the element does that, and the element is the one
+/// place that knows the concrete cell type.
+///
+/// Keeping the payload off this trait is what lets a second kind of
+/// build-during-layout node share the registry. `LayoutBuilder` publishes
+/// `BoxConstraints`; a sliver persistent header would publish its shrink offset
+/// and overlap flag. Both need identical servicing and nothing else in common.
+pub trait BuildDuringLayoutCell: std::fmt::Debug + Send + Sync + std::any::Any {
+    /// Whether the owning element must rebuild before the next layout pass.
+    fn needs_build(&self) -> bool;
+
+    /// Whether anything has been published yet.
+    ///
+    /// `false` before the node's first layout. A scope with nothing published
+    /// has no value to build against, so servicing skips it rather than
+    /// building against a placeholder.
+    fn has_published(&self) -> bool;
+
+    /// Marks the published value as built, clearing `needs_build`.
+    fn commit(&self);
+
+    /// Recover the concrete cell, for a caller that knows which kind it is.
+    ///
+    /// The registry is deliberately payload-blind, but the *owner* of a cell
+    /// knows its type and sometimes needs the payload back out of an erased
+    /// handle — a test driving a publish without a real layout pass, or an
+    /// inspector reporting what a node was last laid out with.
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
 /// Shared constraints mailbox between a render object and its element.
 ///
 /// Cloneable only behind an `Arc` — the render object and the
@@ -106,6 +141,24 @@ impl LayoutConstraintsCell {
         let mut state = self.inner.lock();
         state.last_built = state.published;
         state.needs_build = false;
+    }
+}
+
+impl BuildDuringLayoutCell for LayoutConstraintsCell {
+    fn needs_build(&self) -> bool {
+        Self::needs_build(self)
+    }
+
+    fn has_published(&self) -> bool {
+        Self::constraints(self).is_some()
+    }
+
+    fn commit(&self) {
+        Self::commit(self);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/crates/flui-objects/src/layout/mod.rs
+++ b/crates/flui-objects/src/layout/mod.rs
@@ -50,7 +50,7 @@ pub use fractionally_sized_box::*;
 pub use intrinsic_height::*;
 pub use intrinsic_width::*;
 pub use layout_builder::RenderLayoutBuilder;
-pub use layout_constraints_cell::LayoutConstraintsCell;
+pub use layout_constraints_cell::{BuildDuringLayoutCell, LayoutConstraintsCell};
 pub use limited_box::*;
 pub use list_body::*;
 pub use overflow_box::*;

--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -50,8 +50,8 @@ pub use layout::{
     WrapCrossAlignment,
 };
 pub use layout::{
-    AspectRatioFactor, FractionFactor, LayoutConstraintsCell, RenderAlign, RenderAnimatedSize,
-    RenderAspectRatio, RenderBaseline, RenderCenter, RenderConstrainedBox,
+    AspectRatioFactor, BuildDuringLayoutCell, FractionFactor, LayoutConstraintsCell, RenderAlign,
+    RenderAnimatedSize, RenderAspectRatio, RenderBaseline, RenderCenter, RenderConstrainedBox,
     RenderConstrainedOverflowBox, RenderConstraintsTransformBox, RenderCustomMultiChildLayoutBox,
     RenderCustomSingleChildLayoutBox, RenderFittedBox, RenderFlex, RenderFlow,
     RenderFractionalTranslation, RenderFractionallySizedBox, RenderIndexedStack,

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -2560,6 +2560,10 @@ mod tests {
                 .expect("live LayoutBuilder registration");
             (*render_id, Arc::clone(&entry.cell))
         });
+        let cell = cell
+            .as_any()
+            .downcast_ref::<flui_objects::LayoutConstraintsCell>()
+            .expect("a LayoutBuilder registration holds a LayoutConstraintsCell");
         cell.publish(flui_rendering::constraints::BoxConstraints::tight_for(
             Some(flui_types::geometry::px(100.0)),
             Some(flui_types::geometry::px(100.0)),

--- a/crates/flui-view/src/owner/element_owner.rs
+++ b/crates/flui-view/src/owner/element_owner.rs
@@ -43,7 +43,7 @@ use flui_foundation::{ElementId, RenderId};
 use flui_interaction::FocusManager;
 use parking_lot::Mutex;
 
-use flui_objects::LayoutConstraintsCell;
+use flui_objects::BuildDuringLayoutCell;
 
 use super::RebuildReason;
 use super::build_owner::{DirtyElement, ExternalBuildScheduler, InactiveElement};
@@ -495,7 +495,7 @@ impl ElementOwner<'_> {
         &mut self,
         render_id: RenderId,
         element: ElementId,
-        cell: Arc<LayoutConstraintsCell>,
+        cell: Arc<dyn BuildDuringLayoutCell>, // PORT-CHECK-OK-DYN: the registry services heterogeneous build-during-layout nodes (LayoutBuilder's constraints cell, and a sliver persistent header's shrink cell next) and needs only needs_build/has_published/commit; a generic would monomorphise the registry per payload type, so one map could not hold both
     ) {
         self.layout_builder_registry
             .insert(render_id, LayoutBuilderEntry { element, cell });

--- a/crates/flui-view/src/owner/element_owner.rs
+++ b/crates/flui-view/src/owner/element_owner.rs
@@ -490,7 +490,10 @@ impl ElementOwner<'_> {
     /// registry.
     ///
     /// `cell` must be the same `Arc` the render object registered under
-    /// `render_id` publishes its constraints into.
+    /// `render_id` publishes into. The registry is payload-blind — a
+    /// `LayoutBuilder` publishes box constraints, a sliver persistent header
+    /// its shrink state — so what matters here is only that both halves hold
+    /// the same mailbox.
     pub(crate) fn register_layout_builder(
         &mut self,
         render_id: RenderId,

--- a/crates/flui-view/src/owner/layout_builder.rs
+++ b/crates/flui-view/src/owner/layout_builder.rs
@@ -39,6 +39,10 @@ use std::{
 };
 
 use flui_foundation::{ElementId, RenderId};
+use flui_objects::BuildDuringLayoutCell;
+// Only the test-utils registration helper names the concrete cell; the registry
+// itself is payload-blind.
+#[cfg(any(test, feature = "test-utils"))]
 use flui_objects::LayoutConstraintsCell;
 use flui_rendering::pipeline::PipelineCell;
 use parking_lot::Mutex;
@@ -66,7 +70,12 @@ pub(crate) struct LayoutBuilderEntry {
     /// Element rebuilt when the cell reports `needs_build`.
     pub(crate) element: ElementId,
     /// Shared with the render object registered under the same `RenderId`.
-    pub(crate) cell: Arc<LayoutConstraintsCell>,
+    ///
+    /// Type-erased so the registry can service any build-during-layout node,
+    /// not only `LayoutBuilder`. Servicing needs `needs_build`/`has_published`/
+    /// `commit` and never the payload — reading that is the owning element's
+    /// job, and only it knows the concrete cell type.
+    pub(crate) cell: Arc<dyn BuildDuringLayoutCell>, // PORT-CHECK-OK-DYN: the registry services heterogeneous build-during-layout nodes (LayoutBuilder's constraints cell, and a sliver persistent header's shrink cell next) and needs only needs_build/has_published/commit; a generic would monomorphise the registry per payload type, so one map could not hold both
 }
 
 /// Registry of live build-during-layout nodes, keyed by render id.
@@ -125,7 +134,7 @@ impl LayoutBuilderRegistry {
 impl BuildOwner {
     fn unchanged_layout_builder_registrations(
         &self,
-        scheduled: &HashMap<ElementId, (RenderId, Arc<LayoutConstraintsCell>)>,
+        scheduled: &HashMap<ElementId, (RenderId, Arc<dyn BuildDuringLayoutCell>)>, // PORT-CHECK-OK-DYN: the registry services heterogeneous build-during-layout nodes (LayoutBuilder's constraints cell, and a sliver persistent header's shrink cell next) and needs only needs_build/has_published/commit; a generic would monomorphise the registry per payload type, so one map could not hold both
     ) -> HashSet<ElementId> {
         self.layout_builder_registry.with_entries(|registry| {
             scheduled
@@ -208,9 +217,9 @@ impl BuildOwner {
         // Prune stale entries and collect the ones that need a build, in one
         // pass over the registry. Both the registry lock and the pipeline
         // borrow are released before `build_scope` runs.
-        let mut scheduled: HashMap<ElementId, (RenderId, Arc<LayoutConstraintsCell>)> =
+        let mut scheduled: HashMap<ElementId, (RenderId, Arc<dyn BuildDuringLayoutCell>)> = // PORT-CHECK-OK-DYN: the registry services heterogeneous build-during-layout nodes (LayoutBuilder's constraints cell, and a sliver persistent header's shrink cell next) and needs only needs_build/has_published/commit; a generic would monomorphise the registry per payload type, so one map could not hold both
             HashMap::new();
-        let mut live_entries: HashMap<ElementId, (RenderId, Arc<LayoutConstraintsCell>)> =
+        let mut live_entries: HashMap<ElementId, (RenderId, Arc<dyn BuildDuringLayoutCell>)> = // PORT-CHECK-OK-DYN: the registry services heterogeneous build-during-layout nodes (LayoutBuilder's constraints cell, and a sliver persistent header's shrink cell next) and needs only needs_build/has_published/commit; a generic would monomorphise the registry per payload type, so one map could not hold both
             HashMap::new();
         let mut live_scopes = HashSet::new();
         pipeline.with(|pipeline_owner| {
@@ -277,7 +286,7 @@ impl BuildOwner {
             .filter(|scope| {
                 live_entries
                     .get(scope)
-                    .is_some_and(|(_, cell)| cell.constraints().is_some())
+                    .is_some_and(|(_, cell)| cell.has_published())
             })
             .collect();
         ready_scopes.extend(
@@ -441,7 +450,7 @@ impl BuildOwner {
             render_id,
             LayoutBuilderEntry {
                 element,
-                cell: Arc::clone(&cell),
+                cell: Arc::clone(&cell) as Arc<dyn BuildDuringLayoutCell>, // PORT-CHECK-OK-DYN: coercion into the registry's erased cell handle, justified at its declaration
             },
         );
         cell
@@ -652,7 +661,7 @@ mod tests {
         owner.element_owner_mut().register_layout_builder(
             render_id,
             ElementId::new(3),
-            Arc::clone(&cell),
+            Arc::clone(&cell) as Arc<dyn BuildDuringLayoutCell>, // PORT-CHECK-OK-DYN: coercion into the registry's erased cell handle, justified at its declaration
         );
         assert_eq!(owner.layout_builder_count(), 1);
     }
@@ -663,7 +672,13 @@ mod tests {
         let render_id = RenderId::new(7_001);
         let element = ElementId::new(7_001);
         let original = owner.register_layout_builder_for_test(render_id, element);
-        let scheduled = HashMap::from([(element, (render_id, Arc::clone(&original)))]);
+        let scheduled = HashMap::from([(
+            element,
+            (
+                render_id,
+                Arc::clone(&original) as Arc<dyn BuildDuringLayoutCell>, // PORT-CHECK-OK-DYN: coercion into the registry's erased cell handle, justified at its declaration
+            ),
+        )]);
         assert!(
             owner
                 .unchanged_layout_builder_registrations(&scheduled)


### PR DESCRIPTION
Unblocks #689. Small diff, and the reason it is small is the finding.

## What was blocking

`SliverPersistentHeader`'s render objects already exist — the full pinned/floating matrix — and already carry the delegate-rebuild hook, correctly edge-triggered:

```rust
if self.needs_update_child
    || self.last_shrink_offset != shrink_offset
    || self.last_overlaps_content != overlaps_content
{
    update_child(shrink_offset, overlaps_content);
```

But every `perform_layout` feeds it `|_, _| {}`. The child never rebuilds as the header shrinks.

Wiring it needs a build-during-layout node. FLUI cannot rebuild inside `perform_layout` the way Flutter does — the layout walk holds `&mut RenderTree` for its whole duration, so building there self-deadlocks on mounting. ADR-0017's answer is a mailbox: the render object publishes what it saw, `service_layout_builders` builds between passes. That machinery existed, but was welded to one payload type, so only `LayoutBuilder` could reach it.

## The finding

**The servicing loop never wanted the payload.** Three uses in the entire production path:

| line | use |
|---|---|
| 233 | `entry.cell.needs_build()` |
| 280 | `cell.constraints().is_some()` — a *presence* check |
| 326 | `cell.commit()` |

So the registry needs three capabilities, not a type. That is now `BuildDuringLayoutCell`, and the registry holds `Arc<dyn BuildDuringLayoutCell>`. Reading the payload stays with the element — the one place that knows the concrete type.

I had earlier written that the servicing side made this a multi-crate unit I could not finish. That was wrong, and it was wrong because I had not read the loop. Checking it turned a "multi-day" estimate into this diff.

## Why `dyn` and not a generic

A generic parameter is the reflexive Rust answer and the wrong one here: it monomorphises the registry per payload type, so a single map could not hold a constraints cell and a shrink cell simultaneously — which is the entire purpose. Recorded as a sanctioned boundary (FR-036) with that reasoning at the declaration, rather than waved through; port-check trigger 9 correctly refused it until it was justified.

## `as_any`

On the trait because an owner sometimes needs its payload back out of an erased handle — a test publishing without a real layout pass, an inspector reporting what a node was last laid out with. The alternative was a test-only escape hatch, which is the same hole with less honesty about it.

## Evidence

No behaviour change: `LayoutBuilder` publishes and services exactly as before, and its **33 tests pass unmodified** — that is the point of the diff, not a footnote. `just ci` exit 0, 8943 tests; `typos` and `taplo fmt --check` clean.

Next on #689: a shrink cell implementing this trait, the element that services it, and the delegate.

Refs #689
