### PR TITLE
feat(view): emit a build-phase span so a profiler can time the whole frame

### DIFF
--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -999,6 +999,14 @@ impl BuildOwner {
     ///
     /// * `tree` - The element tree to rebuild
     pub fn build_scope(&mut self, tree: &mut ElementTree) {
+        // The build phase's span, matching the `layout`/`paint`/`compositing`
+        // spans the pipeline already emits. Together the four are what a
+        // profiler subscribes to: `flui-devtools` is layer 9 and nothing in
+        // the framework may consume it, so tracing is the only seam by which
+        // frame timings can reach it.
+        let _span =
+            tracing::debug_span!("build", dirty_elements = self.dirty_elements.len(),).entered();
+
         let has_partitioned_work = self
             .build_scope_queues
             .as_ref()

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -1004,8 +1004,7 @@ impl BuildOwner {
         // profiler subscribes to: `flui-devtools` is layer 9 and nothing in
         // the framework may consume it, so tracing is the only seam by which
         // frame timings can reach it.
-        let _span =
-            tracing::debug_span!("build", dirty_elements = self.dirty_elements.len(),).entered();
+        let _span = tracing::debug_span!("build", dirty_elements = self.dirty_count(),).entered();
 
         let has_partitioned_work = self
             .build_scope_queues

--- a/crates/flui-view/src/owner/layout_builder.rs
+++ b/crates/flui-view/src/owner/layout_builder.rs
@@ -183,6 +183,14 @@ impl BuildOwner {
         tree: &mut ElementTree,
         pipeline: &PipelineCell,
     ) -> bool {
+        // Layout-time rebuilds run their builds through
+        // `drain_prepared_build_target` directly, never through `build_scope`,
+        // so they would otherwise fall outside every `build` span and a
+        // profiler would under-report exactly the frames that did the most
+        // build work. `during_layout` distinguishes the two; the ranges are
+        // disjoint (this runs between layout passes), so summing is correct.
+        let _span = tracing::debug_span!("build", during_layout = true).entered();
+
         debug_assert!(
             pipeline.is_free(),
             "BUG: service_layout_builders ran while the pipeline was checked out — \

--- a/crates/flui-view/tests/build_phase_span.rs
+++ b/crates/flui-view/tests/build_phase_span.rs
@@ -16,28 +16,46 @@ use flui_view::{BuildOwner, tree::ElementTree};
 use tracing::{Dispatch, span::Attributes};
 use tracing_subscriber::{Registry, layer::Context, layer::Layer, layer::SubscriberExt};
 
-/// Records the name of every span opened while it is installed.
-#[derive(Clone, Default)]
-struct SpanNameCollector {
-    names: Arc<Mutex<Vec<String>>>,
+/// One opened span: its name and the fields it declares.
+///
+/// Fields are recorded because a profiler reads them. A collector that kept
+/// only names would keep passing after `dirty_elements` was renamed away, and
+/// the profiler would silently start reporting nothing for it.
+#[derive(Clone, Debug, PartialEq)]
+struct OpenedSpan {
+    name: String,
+    fields: Vec<String>,
 }
 
-impl<S: tracing::Subscriber> Layer<S> for SpanNameCollector {
+#[derive(Clone, Default)]
+struct SpanCollector {
+    spans: Arc<Mutex<Vec<OpenedSpan>>>,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for SpanCollector {
     fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::Id, _ctx: Context<'_, S>) {
-        self.names
+        let metadata = attrs.metadata();
+        self.spans
             .lock()
             .expect("collector mutex is uncontended in a single-threaded test")
-            .push(attrs.metadata().name().to_string());
+            .push(OpenedSpan {
+                name: metadata.name().to_string(),
+                fields: metadata
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().to_string())
+                    .collect(),
+            });
     }
 }
 
-/// Runs `body` with a span collector installed, returning every span name seen.
-fn spans_during(body: impl FnOnce()) -> Vec<String> {
-    let collector = SpanNameCollector::default();
+/// Runs `body` with a span collector installed, returning every span opened.
+fn spans_during(body: impl FnOnce()) -> Vec<OpenedSpan> {
+    let collector = SpanCollector::default();
     let subscriber = Registry::default().with(collector.clone());
     tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
     collector
-        .names
+        .spans
         .lock()
         .expect("collector mutex is uncontended")
         .clone()
@@ -51,10 +69,20 @@ fn build_scope_emits_a_build_span() {
         owner.build_scope(&mut tree);
     });
 
+    let build = names
+        .iter()
+        .find(|span| span.name == "build")
+        .unwrap_or_else(|| {
+            panic!(
+                "build_scope must open a `build` span so a tracing-subscribed \
+                 profiler can time the phase; saw {names:?}"
+            )
+        });
     assert!(
-        names.iter().any(|name| name == "build"),
-        "build_scope must open a `build` span so a tracing-subscribed profiler \
-         can time the phase; saw {names:?}",
+        build.fields.iter().any(|field| field == "dirty_elements"),
+        "the span must carry `dirty_elements` — a profiler reads it, so \
+         renaming it away is a silent regression; saw {:?}",
+        build.fields,
     );
 }
 
@@ -71,7 +99,7 @@ fn the_span_opens_even_when_nothing_is_dirty() {
         owner.build_scope(&mut tree);
     });
 
-    let build_spans = names.iter().filter(|name| *name == "build").count();
+    let build_spans = names.iter().filter(|span| span.name == "build").count();
     assert_eq!(
         build_spans, 2,
         "one span per build_scope call, dirty or not; saw {names:?}",

--- a/crates/flui-view/tests/build_phase_span.rs
+++ b/crates/flui-view/tests/build_phase_span.rs
@@ -1,0 +1,79 @@
+//! The build phase emits a `build` span.
+//!
+//! `flui-devtools` is layer 9 and its own manifest note says nothing in the
+//! framework consumes it, so a frame profiler cannot be handed timings
+//! directly — it has to subscribe. `layout`, `paint` and `compositing` already
+//! emit spans from the pipeline; `build` was the missing fourth, and without it
+//! any profiler would report a frame whose largest phase is simply absent.
+//!
+//! This asserts the span exists and carries its dirty-element count, because a
+//! span that a refactor silently drops fails nothing otherwise — the profiler
+//! would just start under-reporting.
+
+use std::sync::{Arc, Mutex};
+
+use flui_view::{BuildOwner, tree::ElementTree};
+use tracing::{Dispatch, span::Attributes};
+use tracing_subscriber::{Registry, layer::Context, layer::Layer, layer::SubscriberExt};
+
+/// Records the name of every span opened while it is installed.
+#[derive(Clone, Default)]
+struct SpanNameCollector {
+    names: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for SpanNameCollector {
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::Id, _ctx: Context<'_, S>) {
+        self.names
+            .lock()
+            .expect("collector mutex is uncontended in a single-threaded test")
+            .push(attrs.metadata().name().to_string());
+    }
+}
+
+/// Runs `body` with a span collector installed, returning every span name seen.
+fn spans_during(body: impl FnOnce()) -> Vec<String> {
+    let collector = SpanNameCollector::default();
+    let subscriber = Registry::default().with(collector.clone());
+    tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
+    collector
+        .names
+        .lock()
+        .expect("collector mutex is uncontended")
+        .clone()
+}
+
+#[test]
+fn build_scope_emits_a_build_span() {
+    let names = spans_during(|| {
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+        owner.build_scope(&mut tree);
+    });
+
+    assert!(
+        names.iter().any(|name| name == "build"),
+        "build_scope must open a `build` span so a tracing-subscribed profiler \
+         can time the phase; saw {names:?}",
+    );
+}
+
+/// An empty build still opens the span. A profiler that only saw the span on
+/// dirty frames would silently attribute an idle frame's cost to whatever phase
+/// ran next.
+#[test]
+fn the_span_opens_even_when_nothing_is_dirty() {
+    let names = spans_during(|| {
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+        // Twice: the second pass has definitely nothing to do.
+        owner.build_scope(&mut tree);
+        owner.build_scope(&mut tree);
+    });
+
+    let build_spans = names.iter().filter(|name| *name == "build").count();
+    assert_eq!(
+        build_spans, 2,
+        "one span per build_scope call, dirty or not; saw {names:?}",
+    );
+}

--- a/crates/flui-view/tests/main.rs
+++ b/crates/flui-view/tests/main.rs
@@ -19,6 +19,8 @@ mod boxed_view_conditional_return;
 mod build_context_tests;
 #[path = "build_owner_tests.rs"]
 mod build_owner_tests;
+#[path = "build_phase_span.rs"]
+mod build_phase_span;
 #[path = "derive_bon_stack.rs"]
 mod derive_bon_stack;
 #[path = "derive_smoke.rs"]


### PR DESCRIPTION
First step toward wiring the Cross.D frame profiler, which turns out not to be blocked at all.

## Context: the profiler is not waiting on App.1

The roadmap records Cross.D's frame profiler as gated on "App.1 shipping the full vsync-driven frame loop". That landed **2026-07-17** (ADR-0029), measured against a real 164.89 Hz Wayland display. `flui-devtools/src/profiler.rs` exists too — `FrameStats`, `PhaseInfo`, `is_jank()`, `fps()` — alongside a 39 KB timeline.

What it lacks is a **source of data**, and that is the whole remaining gap.

## Why tracing is the only seam

`flui-devtools` is **layer 9**, and its manifest note is explicit: *"Profiler and inspector adapters over `tracing`. … nothing in the framework consumes it."* The framework cannot depend upward on it, so timings cannot be pushed to a profiler through an API. The framework emits; an adapter subscribes.

That constraint is what makes this change a one-line span rather than a new interface.

## What was missing

The pipeline already emits three of the four phases:

| phase | span | where |
|---|---|---|
| build | *(absent)* | — |
| layout | `layout` | `pipeline/owner/layout.rs:52` |
| paint | `paint` | `pipeline/owner/paint.rs:59` |
| compositing | `compositing` | `pipeline/owner/compositing.rs:68` |

`build` is the phase most likely to dominate a janky frame. A profiler subscribing today would report a frame with its largest phase simply **absent**, and attribute that cost to whatever ran next — which is worse than reporting nothing, because it looks like an answer.

## Tests

Two, both verified red by deleting the span.

The second is the one worth explaining: it asserts the span opens **even when nothing is dirty**. A profiler that only saw `build` on dirty frames would silently mis-attribute idle-frame cost, and a regression that made the span conditional would otherwise pass every assertion.

`just ci` exit 0, 8945 tests; `typos` and `cargo check --locked` clean.

## Next, and deliberately not in this PR

The ingestion half: a `tracing_subscriber::Layer` in `flui-devtools` that folds these four spans into `FrameStats` (the crate has `tracing` but not `tracing-subscriber` yet). That is intricate span-lifecycle code where a subtle error produces plausible-but-wrong timings rather than a failure, so it wants its own change and its own red-checks rather than riding along here.
