### PR TITLE
feat(devtools): feed the profiler from the framework's frame spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "tracing-subscriber",
  "web-time",
  "windows-sys 0.61.2",
 ]

--- a/crates/flui-devtools/Cargo.toml
+++ b/crates/flui-devtools/Cargo.toml
@@ -23,6 +23,7 @@ flui-hot-reload = { path = "../flui-hot-reload", version = "0.2.0", optional = t
 ] }
 flui-foundation = { path = "../flui-foundation", version = "0.2.0", optional = true }
 tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 
 # FrameSnapshot/InputEpoch: the frame-telemetry types `timeline`'s
 # `Timeline::record_frame_snapshots` turns into Chrome-trace events, reusing
@@ -45,8 +46,10 @@ windows-sys = { version = "0.61", features = [
 default = []
 
 # === Core Features ===
-# Performance profiling support
-profiling = []
+# Performance profiling support. `tracing-subscriber` is what lets the
+# profiler be *fed*: layer 9 cannot be called by the framework, so it
+# subscribes to the frame spans the framework already emits.
+profiling = ["dep:tracing", "dep:tracing-subscriber"]
 
 # Timeline/frame history tracking
 timeline = ["dep:flui-scheduler"]

--- a/crates/flui-devtools/src/frame_timing_layer.rs
+++ b/crates/flui-devtools/src/frame_timing_layer.rs
@@ -24,6 +24,17 @@
 //! a neighbouring frame — a headless test or a one-off layout pass is not a
 //! frame, and attributing its cost to one would be a fabricated measurement.
 //!
+//! # One frame at a time, by span identity
+//!
+//! The layer owns at most one frame at a time, keyed by the frame span's `Id`.
+//! Phase spans count only when they are *descendants* of that owning span, and
+//! only its own close ends the frame. So when two `UiRealm`s render
+//! concurrently under one shared subscriber, the second realm's frame — and
+//! every phase inside it — is **dropped whole** rather than mixed into the
+//! first realm's measurements: a missing frame is honest, a blended one is a
+//! fabrication. To profile several realms at once, install one
+//! `FrameTimingLayer` + [`Profiler`] pair per realm.
+//!
 //! # Timing comes from the span, not the callback
 //!
 //! Duration is measured by a [`PhaseGuard`](crate::profiler::PhaseGuard) parked
@@ -89,13 +100,23 @@ struct ActivePhase(PhaseGuard);
 #[derive(Clone)]
 pub struct FrameTimingLayer {
     profiler: Arc<Profiler>,
+    /// The frame span currently being measured, if any.
+    ///
+    /// Shared across clones (`Arc`) so a cloned layer still sees the same
+    /// single-frame ownership. `Some` from the owning span's creation until
+    /// its close; a frame span created while this is `Some` belongs to a
+    /// concurrently rendering realm and is ignored entirely.
+    active_frame: Arc<parking_lot::Mutex<Option<Id>>>,
 }
 
 impl FrameTimingLayer {
     /// Wraps a profiler this layer will feed.
     #[must_use]
     pub fn new(profiler: Arc<Profiler>) -> Self {
-        Self { profiler }
+        Self {
+            profiler,
+            active_frame: Arc::new(parking_lot::Mutex::new(None)),
+        }
     }
 }
 
@@ -109,13 +130,21 @@ impl<S> Layer<S> for FrameTimingLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, _ctx: Context<'_, S>) {
         if attrs.metadata().name() != FRAME_SPAN {
             return;
         }
         // Frame boundaries open here rather than on enter: a frame span is
         // entered once, and opening on creation keeps `begin_frame` ahead of
         // any phase span the same frame may create.
+        let mut active_frame = self.active_frame.lock();
+        if active_frame.is_some() {
+            // A second realm's frame under the same subscriber. Dropping it
+            // whole is honest; letting its `begin_frame` reset the running
+            // frame would blend two realms' timings into one measurement.
+            return;
+        }
+        *active_frame = Some(id.clone());
         self.profiler.begin_frame();
     }
 
@@ -124,6 +153,15 @@ where
         let Some(phase) = phase_for(span.name()) else {
             return;
         };
+
+        // Only phases inside the owning frame span count. A phase from a
+        // concurrently rendering realm — or outside any frame — must not be
+        // attributed to the frame being measured.
+        let owning_frame = self.active_frame.lock().clone();
+        let Some(frame_id) = owning_frame else { return };
+        if !span.scope().any(|ancestor| ancestor.id() == frame_id) {
+            return;
+        }
 
         let mut extensions = span.extensions_mut();
         if extensions.get_mut::<ActivePhase>().is_some() {
@@ -145,7 +183,14 @@ where
         }
 
         if name == FRAME_SPAN {
-            self.profiler.end_frame();
+            // Only the owning span's close ends the frame; the lock is held
+            // across `end_frame` so a frame beginning on another thread
+            // cannot slot in between the release and the recording.
+            let mut active_frame = self.active_frame.lock();
+            if active_frame.as_ref() == Some(&id) {
+                self.profiler.end_frame();
+                *active_frame = None;
+            }
         }
     }
 }
@@ -181,6 +226,9 @@ mod tests {
             {
                 let _paint = tracing::debug_span!("paint").entered();
             }
+            {
+                let _compositing = tracing::debug_span!("compositing").entered();
+            }
         });
 
         let stats = profiler
@@ -199,6 +247,10 @@ mod tests {
         assert!(
             phases.contains(&FramePhase::Paint),
             "paint span must land as a Paint phase; saw {phases:?}",
+        );
+        assert!(
+            phases.contains(&FramePhase::Custom("Compositing")),
+            "compositing span must land as a Compositing phase; saw {phases:?}",
         );
     }
 
@@ -232,6 +284,69 @@ mod tests {
         assert!(
             profiler.frame_stats().is_none(),
             "no frame span opened, so there is no frame to attribute work to",
+        );
+    }
+
+    /// A second realm's frame under the same subscriber is dropped whole —
+    /// its `begin_frame` must not reset the running frame, its phases must
+    /// not be attributed to it, and its close must not end it. `parent: None`
+    /// makes the second frame a structural sibling, exactly what a
+    /// concurrently rendering realm's span looks like to a shared layer.
+    #[test]
+    fn a_concurrent_frame_is_dropped_rather_than_blended() {
+        let profiler = profile(|| {
+            let own_frame = tracing::debug_span!("render_frame_entered");
+            let _own = own_frame.enter();
+            {
+                // The other realm's whole frame, opened mid-way through ours.
+                let other_frame = tracing::debug_span!(parent: None, "render_frame_entered");
+                let _other = other_frame.enter();
+                let _other_layout = tracing::debug_span!("layout").entered();
+            } // ...and closed while ours is still running.
+            let _own_build = tracing::debug_span!("build").entered();
+        });
+
+        assert_eq!(
+            profiler.frame_history().len(),
+            1,
+            "only the owning frame records; the concurrent one is dropped",
+        );
+        let stats = profiler.frame_stats().expect("the owning frame closed");
+        let phases: Vec<_> = stats.phases.iter().map(|info| info.phase).collect();
+        assert_eq!(
+            phases,
+            vec![FramePhase::Build],
+            "the other realm's layout must not leak into this frame",
+        );
+    }
+
+    /// Build work split across several spans in one frame (the global build
+    /// plus a layout-builder rebuild) reports as ONE Build entry, because
+    /// `FrameStats::phase` returns the first match and separate entries
+    /// would hide everything after it.
+    #[test]
+    fn repeated_build_spans_report_one_build_phase() {
+        let profiler = profile(|| {
+            let _frame = tracing::debug_span!("render_frame_entered").entered();
+            {
+                let _build = tracing::debug_span!("build", dirty_elements = 2).entered();
+            }
+            {
+                let _layout = tracing::debug_span!("layout").entered();
+                let _rebuild = tracing::debug_span!("build", during_layout = true).entered();
+            }
+        });
+
+        let stats = profiler.frame_stats().expect("a frame was recorded");
+        let build_entries = stats
+            .phases
+            .iter()
+            .filter(|info| info.phase == FramePhase::Build)
+            .count();
+        assert_eq!(
+            build_entries, 1,
+            "both build spans merge into one Build total; saw {:?}",
+            stats.phases,
         );
     }
 

--- a/crates/flui-devtools/src/frame_timing_layer.rs
+++ b/crates/flui-devtools/src/frame_timing_layer.rs
@@ -1,0 +1,255 @@
+//! [`FrameTimingLayer`] — feeds the [`Profiler`](crate::profiler::Profiler) from
+//! the framework's own tracing spans.
+//!
+//! # Why a subscriber and not a call
+//!
+//! `flui-devtools` is layer 9 of the workspace DAG and nothing in the framework
+//! may depend on it, so frame timings cannot be pushed here through an API. The
+//! framework *emits* — `build`, `layout`, `paint` and `compositing` spans from
+//! the pipeline — and this adapter subscribes. That is the only seam the
+//! layering permits, and it is why the framework needed no knowledge of the
+//! profiler at all.
+//!
+//! # What it listens to
+//!
+//! | span | phase |
+//! |------|-------|
+//! | `build` | [`FramePhase::Build`] |
+//! | `layout` | [`FramePhase::Layout`] |
+//! | `paint` | [`FramePhase::Paint`] |
+//! | `compositing` | `FramePhase::Custom("Compositing")` |
+//!
+//! A frame is delimited by the `render_frame_entered` span that `UiRealm` opens
+//! per frame. Phase spans outside any frame are ignored rather than folded into
+//! a neighbouring frame — a headless test or a one-off layout pass is not a
+//! frame, and attributing its cost to one would be a fabricated measurement.
+//!
+//! # Timing comes from the span, not the callback
+//!
+//! Duration is measured by a [`PhaseGuard`](crate::profiler::PhaseGuard) parked
+//! in the span's own extensions: created when the span is *entered*, dropped
+//! when it closes. That measures the span's real extent even when a subscriber
+//! callback runs late, and it means a span entered and exited repeatedly (as
+//! `layout` is, across a fixpoint) still reports one contiguous phase rather
+//! than a sum of visits.
+
+use std::sync::Arc;
+
+use tracing::Subscriber;
+use tracing::span::{Attributes, Id};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::profiler::{FramePhase, PhaseGuard, Profiler};
+
+/// The span `UiRealm` opens once per frame.
+const FRAME_SPAN: &str = "render_frame_entered";
+
+/// Maps a span name to the phase it measures, or `None` if it is not a phase.
+fn phase_for(name: &str) -> Option<FramePhase> {
+    match name {
+        "build" => Some(FramePhase::Build),
+        "layout" => Some(FramePhase::Layout),
+        "paint" => Some(FramePhase::Paint),
+        "compositing" => Some(FramePhase::Custom("Compositing")),
+        _ => None,
+    }
+}
+
+/// Parked in a phase span's extensions for the span's lifetime.
+///
+/// A newtype rather than a bare `PhaseGuard` so this layer's entry cannot
+/// collide with another layer storing the same type in the same extensions map.
+// The field is never read on purpose: the guard records the phase duration when
+// it is *dropped*, which is the whole mechanism.
+#[allow(dead_code)]
+struct ActivePhase(PhaseGuard);
+
+/// Subscriber layer that turns the framework's frame spans into
+/// [`FrameStats`](crate::profiler::FrameStats).
+///
+/// Install it on any `tracing_subscriber` registry:
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use flui_devtools::profiler::Profiler;
+/// # use flui_devtools::frame_timing_layer::FrameTimingLayer;
+/// use tracing_subscriber::layer::SubscriberExt;
+///
+/// let profiler = Arc::new(Profiler::new());
+/// let subscriber =
+///     tracing_subscriber::registry().with(FrameTimingLayer::new(Arc::clone(&profiler)));
+/// tracing::subscriber::set_global_default(subscriber).expect("no subscriber installed yet");
+/// ```
+///
+/// The framework emits its frame spans at `DEBUG`, so a filter above that level
+/// silently starves this layer. That is a filter misconfiguration rather than a
+/// bug here, but it looks identical to “profiling is broken”, so it is worth
+/// checking first.
+#[derive(Clone)]
+pub struct FrameTimingLayer {
+    profiler: Arc<Profiler>,
+}
+
+impl FrameTimingLayer {
+    /// Wraps a profiler this layer will feed.
+    #[must_use]
+    pub fn new(profiler: Arc<Profiler>) -> Self {
+        Self { profiler }
+    }
+}
+
+impl std::fmt::Debug for FrameTimingLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FrameTimingLayer").finish_non_exhaustive()
+    }
+}
+
+impl<S> Layer<S> for FrameTimingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+        if attrs.metadata().name() != FRAME_SPAN {
+            return;
+        }
+        // Frame boundaries open here rather than on enter: a frame span is
+        // entered once, and opening on creation keeps `begin_frame` ahead of
+        // any phase span the same frame may create.
+        self.profiler.begin_frame();
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let Some(phase) = phase_for(span.name()) else {
+            return;
+        };
+
+        let mut extensions = span.extensions_mut();
+        if extensions.get_mut::<ActivePhase>().is_some() {
+            // Re-entered without closing: the guard already running measures
+            // the full extent, so a second one would double-count.
+            return;
+        }
+        extensions.insert(ActivePhase(self.profiler.profile_phase(phase)));
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let name = span.name();
+
+        if phase_for(name).is_some() {
+            // Dropping the guard is what records the duration.
+            drop(span.extensions_mut().remove::<ActivePhase>());
+            return;
+        }
+
+        if name == FRAME_SPAN {
+            self.profiler.end_frame();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::Dispatch;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// Runs `body` with the layer installed against a fresh profiler.
+    fn profile(body: impl FnOnce()) -> Arc<Profiler> {
+        let profiler = Arc::new(Profiler::new());
+        let subscriber =
+            tracing_subscriber::registry().with(FrameTimingLayer::new(Arc::clone(&profiler)));
+        tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
+        profiler
+    }
+
+    /// **The wiring contract.** The framework's own span names must reach the
+    /// profiler as phases. If a span is renamed on either side this fails,
+    /// which is the point — the two halves are coupled only by these strings.
+    #[test]
+    fn the_frameworks_phase_spans_become_profiler_phases() {
+        let profiler = profile(|| {
+            let _frame = tracing::debug_span!("render_frame_entered").entered();
+            {
+                let _build = tracing::debug_span!("build", dirty_elements = 3).entered();
+            }
+            {
+                let _layout = tracing::debug_span!("layout", dirty_nodes = 1).entered();
+            }
+            {
+                let _paint = tracing::debug_span!("paint").entered();
+            }
+        });
+
+        let stats = profiler
+            .frame_stats()
+            .expect("the frame span closed, so a frame was recorded");
+
+        let phases: Vec<_> = stats.phases.iter().map(|info| info.phase).collect();
+        assert!(
+            phases.contains(&FramePhase::Build),
+            "build span must land as a Build phase; saw {phases:?}",
+        );
+        assert!(
+            phases.contains(&FramePhase::Layout),
+            "layout span must land as a Layout phase; saw {phases:?}",
+        );
+        assert!(
+            phases.contains(&FramePhase::Paint),
+            "paint span must land as a Paint phase; saw {phases:?}",
+        );
+    }
+
+    /// A span the framework does not emit as a phase must not become one.
+    /// Without this, any unrelated span in the process would be timed as frame
+    /// work and the profile would be quietly wrong rather than empty.
+    #[test]
+    fn unrelated_spans_are_not_phases() {
+        let profiler = profile(|| {
+            let _frame = tracing::debug_span!("render_frame_entered").entered();
+            let _other = tracing::debug_span!("some_unrelated_work").entered();
+        });
+
+        let stats = profiler.frame_stats().expect("a frame was recorded");
+        assert!(
+            stats.phases.is_empty(),
+            "only the framework's four phase spans count; saw {:?}",
+            stats.phases,
+        );
+    }
+
+    /// Phase work outside any frame is dropped rather than folded into a
+    /// neighbouring frame. A headless layout pass is not a frame, and
+    /// attributing its cost to one would be a fabricated measurement.
+    #[test]
+    fn a_phase_outside_a_frame_records_no_frame() {
+        let profiler = profile(|| {
+            let _layout = tracing::debug_span!("layout").entered();
+        });
+
+        assert!(
+            profiler.frame_stats().is_none(),
+            "no frame span opened, so there is no frame to attribute work to",
+        );
+    }
+
+    /// Two frames stay separate. A layer that failed to close a frame would
+    /// report one enormous frame and every jank threshold would misfire.
+    #[test]
+    fn consecutive_frames_are_recorded_separately() {
+        let profiler = profile(|| {
+            for _ in 0..2 {
+                let _frame = tracing::debug_span!("render_frame_entered").entered();
+                let _build = tracing::debug_span!("build").entered();
+            }
+        });
+
+        assert_eq!(
+            profiler.frame_history().len(),
+            2,
+            "each frame span must close its own frame",
+        );
+    }
+}

--- a/crates/flui-devtools/src/lib.rs
+++ b/crates/flui-devtools/src/lib.rs
@@ -95,6 +95,10 @@
 #![deny(missing_docs)]
 #![warn(missing_debug_implementations)]
 mod common;
+/// Feeds the profiler from the framework's own frame spans — the only seam
+/// layering permits, since nothing in the framework may depend on this crate.
+#[cfg(feature = "profiling")]
+pub mod frame_timing_layer;
 #[cfg(feature = "hot-reload")]
 pub mod hot_reload;
 #[cfg(feature = "inspector")]
@@ -107,6 +111,8 @@ pub mod timeline;
 // Re-exports
 pub use common::*;
 #[cfg(feature = "profiling")]
+pub use frame_timing_layer::FrameTimingLayer;
+#[cfg(feature = "profiling")]
 pub use profiler::Profiler;
 
 /// DevTools version
@@ -118,6 +124,8 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// use flui_devtools::prelude::*;
 /// ```
 pub mod prelude {
+    #[cfg(feature = "profiling")]
+    pub use crate::frame_timing_layer::FrameTimingLayer;
     #[cfg(feature = "hot-reload")]
     pub use crate::hot_reload::HotReloader;
     #[cfg(feature = "inspector")]

--- a/crates/flui-devtools/src/lib.rs
+++ b/crates/flui-devtools/src/lib.rs
@@ -7,7 +7,8 @@
 //!
 //! ## 🎯 Performance Profiler (feature: profiling)
 //! - Frame timing and jank detection
-//! - Build/layout/paint phase profiling, fed manually by the caller
+//! - Build/layout/paint phase profiling — fed manually by the caller, or
+//!   from the framework's own frame spans via `FrameTimingLayer`
 //! - Performance timeline with markers
 //!
 //! ## ⏱️ Timeline View (feature: timeline)
@@ -81,7 +82,9 @@
 //! # Feature Flags
 //!
 //! - `default`: no features enabled; opt in via `profiling`, `timeline`, or `hot-reload`
-//! - `profiling`: Performance profiling tools (no external dependencies)
+//! - `profiling`: Performance profiling tools (pulls in `tracing` +
+//!   `tracing-subscriber`, which is how the profiler is fed — the framework
+//!   cannot call this crate, so `FrameTimingLayer` subscribes to its spans)
 //! - `timeline`: Timeline view for events
 //! - `hot-reload`: File watching (reports changes; nothing more)
 //! - `inspector`: Counting/logging tree observer over the ADR-0040 seam

--- a/crates/flui-devtools/src/profiler.rs
+++ b/crates/flui-devtools/src/profiler.rs
@@ -134,6 +134,11 @@ impl FrameStats {
     }
 
     /// Get phase by type
+    ///
+    /// Each phase appears at most once per frame: a phase that ran in several
+    /// segments (an initial build plus layout-builder rebuilds, say) is
+    /// recorded as one entry holding the summed duration and the first
+    /// segment's start offset.
     pub fn phase(&self, phase: FramePhase) -> Option<&PhaseInfo> {
         self.phases.iter().find(|p| p.phase == phase)
     }
@@ -252,6 +257,15 @@ impl ProfilerInner {
     }
 
     fn end_phase(&mut self, phase: FramePhase, duration: Duration) {
+        // A phase can run more than once per frame — a layout-builder rebuild
+        // is still Build work. Segments merge into one total per phase because
+        // `FrameStats::phase` returns the first match: separate entries would
+        // silently hide every segment after the first.
+        if let Some(recorded) = self.current_phases.iter_mut().find(|p| p.phase == phase) {
+            recorded.duration += duration;
+            return;
+        }
+
         let start_offset = if let Some(frame_start) = self.frame_start {
             frame_start.elapsed().saturating_sub(duration)
         } else {
@@ -571,6 +585,39 @@ mod tests {
         // Should be frames 5-9
         assert_eq!(history[0].frame_number, 5);
         assert_eq!(history[4].frame_number, 9);
+    }
+
+    /// A phase that runs twice in one frame reports one summed entry. With
+    /// separate entries, `phase()`'s `find` would return only the first
+    /// segment and every later one would be silently unreported.
+    #[test]
+    fn repeated_phase_segments_merge_into_one_total() {
+        let profiler = Profiler::new();
+
+        profiler.begin_frame();
+        {
+            let _guard = profiler.profile_phase(FramePhase::Build);
+            thread::sleep(Duration::from_millis(3));
+        }
+        {
+            let _guard = profiler.profile_phase(FramePhase::Build);
+            thread::sleep(Duration::from_millis(3));
+        }
+        profiler.end_frame();
+
+        let stats = profiler.frame_stats().unwrap();
+        let build_entries = stats
+            .phases
+            .iter()
+            .filter(|p| p.phase == FramePhase::Build)
+            .count();
+        assert_eq!(build_entries, 1, "segments of one phase merge");
+        let build = stats.phase(FramePhase::Build).unwrap();
+        assert!(
+            build.duration_ms() >= 6.0,
+            "the merged entry holds the sum of both segments, got {:.2}ms",
+            build.duration_ms(),
+        );
     }
 
     #[test]

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -999,6 +999,14 @@ impl BuildOwner {
     ///
     /// * `tree` - The element tree to rebuild
     pub fn build_scope(&mut self, tree: &mut ElementTree) {
+        // The build phase's span, matching the `layout`/`paint`/`compositing`
+        // spans the pipeline already emits. Together the four are what a
+        // profiler subscribes to: `flui-devtools` is layer 9 and nothing in
+        // the framework may consume it, so tracing is the only seam by which
+        // frame timings can reach it.
+        let _span =
+            tracing::debug_span!("build", dirty_elements = self.dirty_elements.len(),).entered();
+
         let has_partitioned_work = self
             .build_scope_queues
             .as_ref()

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -1004,8 +1004,7 @@ impl BuildOwner {
         // profiler subscribes to: `flui-devtools` is layer 9 and nothing in
         // the framework may consume it, so tracing is the only seam by which
         // frame timings can reach it.
-        let _span =
-            tracing::debug_span!("build", dirty_elements = self.dirty_elements.len(),).entered();
+        let _span = tracing::debug_span!("build", dirty_elements = self.dirty_count(),).entered();
 
         let has_partitioned_work = self
             .build_scope_queues

--- a/crates/flui-view/src/owner/layout_builder.rs
+++ b/crates/flui-view/src/owner/layout_builder.rs
@@ -183,6 +183,14 @@ impl BuildOwner {
         tree: &mut ElementTree,
         pipeline: &PipelineCell,
     ) -> bool {
+        // Layout-time rebuilds run their builds through
+        // `drain_prepared_build_target` directly, never through `build_scope`,
+        // so they would otherwise fall outside every `build` span and a
+        // profiler would under-report exactly the frames that did the most
+        // build work. `during_layout` distinguishes the two; the ranges are
+        // disjoint (this runs between layout passes), so summing is correct.
+        let _span = tracing::debug_span!("build", during_layout = true).entered();
+
         debug_assert!(
             pipeline.is_free(),
             "BUG: service_layout_builders ran while the pipeline was checked out — \

--- a/crates/flui-view/tests/build_phase_span.rs
+++ b/crates/flui-view/tests/build_phase_span.rs
@@ -16,28 +16,46 @@ use flui_view::{BuildOwner, tree::ElementTree};
 use tracing::{Dispatch, span::Attributes};
 use tracing_subscriber::{Registry, layer::Context, layer::Layer, layer::SubscriberExt};
 
-/// Records the name of every span opened while it is installed.
-#[derive(Clone, Default)]
-struct SpanNameCollector {
-    names: Arc<Mutex<Vec<String>>>,
+/// One opened span: its name and the fields it declares.
+///
+/// Fields are recorded because a profiler reads them. A collector that kept
+/// only names would keep passing after `dirty_elements` was renamed away, and
+/// the profiler would silently start reporting nothing for it.
+#[derive(Clone, Debug, PartialEq)]
+struct OpenedSpan {
+    name: String,
+    fields: Vec<String>,
 }
 
-impl<S: tracing::Subscriber> Layer<S> for SpanNameCollector {
+#[derive(Clone, Default)]
+struct SpanCollector {
+    spans: Arc<Mutex<Vec<OpenedSpan>>>,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for SpanCollector {
     fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::Id, _ctx: Context<'_, S>) {
-        self.names
+        let metadata = attrs.metadata();
+        self.spans
             .lock()
             .expect("collector mutex is uncontended in a single-threaded test")
-            .push(attrs.metadata().name().to_string());
+            .push(OpenedSpan {
+                name: metadata.name().to_string(),
+                fields: metadata
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().to_string())
+                    .collect(),
+            });
     }
 }
 
-/// Runs `body` with a span collector installed, returning every span name seen.
-fn spans_during(body: impl FnOnce()) -> Vec<String> {
-    let collector = SpanNameCollector::default();
+/// Runs `body` with a span collector installed, returning every span opened.
+fn spans_during(body: impl FnOnce()) -> Vec<OpenedSpan> {
+    let collector = SpanCollector::default();
     let subscriber = Registry::default().with(collector.clone());
     tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
     collector
-        .names
+        .spans
         .lock()
         .expect("collector mutex is uncontended")
         .clone()
@@ -51,10 +69,20 @@ fn build_scope_emits_a_build_span() {
         owner.build_scope(&mut tree);
     });
 
+    let build = names
+        .iter()
+        .find(|span| span.name == "build")
+        .unwrap_or_else(|| {
+            panic!(
+                "build_scope must open a `build` span so a tracing-subscribed \
+                 profiler can time the phase; saw {names:?}"
+            )
+        });
     assert!(
-        names.iter().any(|name| name == "build"),
-        "build_scope must open a `build` span so a tracing-subscribed profiler \
-         can time the phase; saw {names:?}",
+        build.fields.iter().any(|field| field == "dirty_elements"),
+        "the span must carry `dirty_elements` — a profiler reads it, so \
+         renaming it away is a silent regression; saw {:?}",
+        build.fields,
     );
 }
 
@@ -71,7 +99,7 @@ fn the_span_opens_even_when_nothing_is_dirty() {
         owner.build_scope(&mut tree);
     });
 
-    let build_spans = names.iter().filter(|name| *name == "build").count();
+    let build_spans = names.iter().filter(|span| span.name == "build").count();
     assert_eq!(
         build_spans, 2,
         "one span per build_scope call, dirty or not; saw {names:?}",

--- a/crates/flui-view/tests/build_phase_span.rs
+++ b/crates/flui-view/tests/build_phase_span.rs
@@ -1,0 +1,79 @@
+//! The build phase emits a `build` span.
+//!
+//! `flui-devtools` is layer 9 and its own manifest note says nothing in the
+//! framework consumes it, so a frame profiler cannot be handed timings
+//! directly — it has to subscribe. `layout`, `paint` and `compositing` already
+//! emit spans from the pipeline; `build` was the missing fourth, and without it
+//! any profiler would report a frame whose largest phase is simply absent.
+//!
+//! This asserts the span exists and carries its dirty-element count, because a
+//! span that a refactor silently drops fails nothing otherwise — the profiler
+//! would just start under-reporting.
+
+use std::sync::{Arc, Mutex};
+
+use flui_view::{BuildOwner, tree::ElementTree};
+use tracing::{Dispatch, span::Attributes};
+use tracing_subscriber::{Registry, layer::Context, layer::Layer, layer::SubscriberExt};
+
+/// Records the name of every span opened while it is installed.
+#[derive(Clone, Default)]
+struct SpanNameCollector {
+    names: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for SpanNameCollector {
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::Id, _ctx: Context<'_, S>) {
+        self.names
+            .lock()
+            .expect("collector mutex is uncontended in a single-threaded test")
+            .push(attrs.metadata().name().to_string());
+    }
+}
+
+/// Runs `body` with a span collector installed, returning every span name seen.
+fn spans_during(body: impl FnOnce()) -> Vec<String> {
+    let collector = SpanNameCollector::default();
+    let subscriber = Registry::default().with(collector.clone());
+    tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
+    collector
+        .names
+        .lock()
+        .expect("collector mutex is uncontended")
+        .clone()
+}
+
+#[test]
+fn build_scope_emits_a_build_span() {
+    let names = spans_during(|| {
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+        owner.build_scope(&mut tree);
+    });
+
+    assert!(
+        names.iter().any(|name| name == "build"),
+        "build_scope must open a `build` span so a tracing-subscribed profiler \
+         can time the phase; saw {names:?}",
+    );
+}
+
+/// An empty build still opens the span. A profiler that only saw the span on
+/// dirty frames would silently attribute an idle frame's cost to whatever phase
+/// ran next.
+#[test]
+fn the_span_opens_even_when_nothing_is_dirty() {
+    let names = spans_during(|| {
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+        // Twice: the second pass has definitely nothing to do.
+        owner.build_scope(&mut tree);
+        owner.build_scope(&mut tree);
+    });
+
+    let build_spans = names.iter().filter(|name| *name == "build").count();
+    assert_eq!(
+        build_spans, 2,
+        "one span per build_scope call, dirty or not; saw {names:?}",
+    );
+}

--- a/crates/flui-view/tests/main.rs
+++ b/crates/flui-view/tests/main.rs
@@ -19,6 +19,8 @@ mod boxed_view_conditional_return;
 mod build_context_tests;
 #[path = "build_owner_tests.rs"]
 mod build_owner_tests;
+#[path = "build_phase_span.rs"]
+mod build_phase_span;
 #[path = "derive_bon_stack.rs"]
 mod derive_bon_stack;
 #[path = "derive_smoke.rs"]


### PR DESCRIPTION
Closes the Cross.D frame profiler's actual gap, which was never App.1.

`profiler.rs` has existed for a while — `FrameStats`, `PhaseInfo`, `is_jank()`, `fps()`, plus a 39 KB timeline — with **no source of data**. This is that source. With #693 (the `build` span) it makes the profiler functional.

## The seam is forced by layering, not chosen

`flui-devtools` is **layer 9**, and its manifest note is explicit: *"nothing in the framework consumes it."* Timings cannot be pushed here through an API. The framework emits `build`/`layout`/`paint`/`compositing` spans; this subscribes.

The framework needed **no knowledge of the profiler at all** — that is the point, and it is why the emission side (#693) was a one-line span rather than an interface.

## Timing comes from the span, not the callback

A `PhaseGuard` is parked in the span's own extensions — created on enter, dropped on close. That measures the span's real extent rather than whenever a subscriber callback happened to run, and a span entered and exited repeatedly (as `layout` is, across a fixpoint) reports **one contiguous phase** instead of a sum of visits.

## Four tests, three pinning "quietly wrong" rather than "broken"

| test | what it prevents |
|---|---|
| phase outside a frame records **no** frame | folding a headless layout pass into a neighbouring frame — a *fabricated* measurement, worse than a missing one |
| an unrelated span is not a phase | any span anywhere in the process being timed as frame work, yielding a plausibly-wrong profile |
| consecutive frames stay separate | a layer that never closes a frame reporting one enormous frame, misfiring every jank threshold |
| the framework's span names become phases | a rename on either side silently producing an empty profile |

That last one is red-verified: renaming the `build` mapping fails it. The two halves are coupled **only by these four strings** — deliberately, since that is what lets layer 9 read a layer-3 pipeline — so a test pinning them is the only thing between a rename and a silently empty profile.

## Note on trigger 11

Port-check refused the new `pub mod` until it was declared external API surface. Worth recording why the obvious escape does not apply: the trigger's feature-gate exemption accepts only `unstable-*` and `testing`, deliberately — hiding a consumer-less module behind a *shipped* feature like `profiling` does not make it less speculative. Resolved by re-exporting `FrameTimingLayer` from the crate root and prelude, matching how `Profiler` itself is exposed.

`profiling` now enables `tracing-subscriber`. `just ci` exit 0, 8945 tests; `typos`, `taplo fmt --check` and `cargo check --locked` clean.
