### PR TITLE
docs(semantics): stop advertising arena ids as the platform format (#680)

### DIFF
--- a/crates/flui-semantics/src/node.rs
+++ b/crates/flui-semantics/src/node.rs
@@ -279,7 +279,10 @@ impl SemanticsNode {
 
     // ========== Data Export ==========
 
-    /// Converts this node to SemanticsNodeData for platform consumption.
+    /// Converts this node to [`SemanticsNodeData`] — an in-process batching
+    /// payload whose `id`/`children` are 0-based arena positions, NOT the
+    /// stable platform identity (see `update.rs`'s module doc; the platform
+    /// payload is built by `tree_to_update` from `accessibility_id`).
     pub fn to_node_data(&self, id: SemanticsId) -> SemanticsNodeData {
         SemanticsNodeData {
             id: (id.get() - 1) as u64,

--- a/crates/flui-semantics/src/update.rs
+++ b/crates/flui-semantics/src/update.rs
@@ -18,8 +18,10 @@
 //! produced by [`tree_to_update`](crate::tree_to_update), which takes node
 //! identity from [`SemanticsNode::accessibility_id`](crate::SemanticsNode::accessibility_id)
 //! — never from these payloads. Use this module for in-process batching and
-//! diagnostics; if a consumer ever needs stable identity here, that change is
-//! tracked in issue #680 and is deliberately not made speculatively.
+//! diagnostics. If a consumer ever needs stable identity here, add
+//! `accessibility_id` to the payload *with* that consumer — the field is
+//! deliberately not added speculatively, because an identity nothing reads
+//! cannot be verified against anything.
 
 use flui_foundation::SemanticsId;
 use flui_types::{Matrix4, Rect, geometry::Pixels};

--- a/crates/flui-semantics/src/update.rs
+++ b/crates/flui-semantics/src/update.rs
@@ -1,6 +1,25 @@
-//! Semantics update protocol for platform communication.
+//! Batched semantics-update payloads.
 //!
-//! This module provides types for batched semantics updates to the platform.
+//! # These payloads are NOT the platform format — their ids are arena positions
+//!
+//! Every identity in this module (`SemanticsNodeData::id`, its `children`,
+//! `SemanticsTreeUpdate::removed_node_ids`) is a 0-based arena position in a
+//! tree the pipeline rebuilds every pass. Inserting or removing a sibling
+//! shifts later positions, and a recycled slot hands a retired control's
+//! number to an unrelated one — so publishing these values to an OS
+//! accessibility adapter drops screen-reader focus on unrelated changes, and
+//! an action request addressed back with one of them lands in the wrong
+//! number space entirely (`SemanticsOwner::resolve_action` matches the stable
+//! [`AccessibilityNodeId`](crate::AccessibilityNodeId) space, so every such
+//! action fails as `NodeNotFound`). That is the exact bug the AccessKit
+//! translation shipped once and was caught in review.
+//!
+//! What actually crosses to a platform adapter is [`accesskit::TreeUpdate`],
+//! produced by [`tree_to_update`](crate::tree_to_update), which takes node
+//! identity from [`SemanticsNode::accessibility_id`](crate::SemanticsNode::accessibility_id)
+//! — never from these payloads. Use this module for in-process batching and
+//! diagnostics; if a consumer ever needs stable identity here, that change is
+//! tracked in issue #680 and is deliberately not made speculatively.
 
 use flui_foundation::SemanticsId;
 use flui_types::{Matrix4, Rect, geometry::Pixels};
@@ -14,13 +33,16 @@ use crate::role::SemanticsRole;
 // SemanticsNodeData
 // ============================================================================
 
-/// Serialized data for a semantics node, suitable for sending to the platform.
+/// Serialized data for one semantics node.
 ///
-/// This is the format used when communicating with the platform's accessibility
-/// API.
+/// **Not the platform format**: `id` and `children` are 0-based arena
+/// positions, valid only within the pass that produced them — see the module
+/// doc for why publishing them to an accessibility adapter is a bug and what
+/// the real platform payload is.
 #[derive(Debug, Clone)]
 pub struct SemanticsNodeData {
-    /// Node identifier.
+    /// The node's 0-based arena position — NOT its stable
+    /// [`AccessibilityNodeId`](crate::AccessibilityNodeId); see the module doc.
     pub id: u64,
     /// Flags bitmask.
     pub flags: u64,
@@ -44,7 +66,8 @@ pub struct SemanticsNodeData {
     pub rect: Rect<Pixels>,
     /// Transform matrix.
     pub transform: Matrix4,
-    /// Child node IDs.
+    /// Children as 0-based arena positions — same space and caveat as
+    /// [`Self::id`].
     pub children: SmallVec<[u64; 4]>,
     /// Platform view ID.
     pub platform_view_id: Option<i32>,
@@ -107,11 +130,11 @@ impl Default for SemanticsNodeData {
 // SemanticsTreeUpdate
 // ============================================================================
 
-/// A batched update to the semantics tree to be sent to the platform.
+/// A batched semantics-tree update: added/updated nodes plus removed ids.
 ///
-/// This contains all the information needed to update the platform's
-/// accessibility tree in a single batch, including added/updated nodes
-/// and removed node IDs.
+/// **Not the platform format** — every id here is a 0-based arena position
+/// (see the module doc). In particular, a removal notice keyed on an arena
+/// position would tell an adapter to drop an id it was never given.
 ///
 /// See also [`SemanticsNodeUpdate`](crate::owner::SemanticsNodeUpdate) for
 /// individual node updates.
@@ -120,7 +143,8 @@ pub struct SemanticsTreeUpdate {
     /// Nodes that have been added or updated.
     pub nodes: Vec<SemanticsNodeData>,
 
-    /// IDs of nodes that have been removed.
+    /// 0-based arena positions of nodes that have been removed — the same
+    /// in-process space as [`SemanticsNodeData::id`], with the same caveat.
     pub removed_node_ids: SmallVec<[u64; 8]>,
 }
 
@@ -173,7 +197,8 @@ impl SemanticsTreeUpdateBuilder {
 
     /// Adds a removed node ID.
     pub fn add_removed_node(&mut self, id: SemanticsId) {
-        // Convert to 0-based index for platform API
+        // 0-based arena position — same in-process space as the rest
+        // of this payload, NOT a platform-facing identity (module doc).
         self.removed_node_ids.push((id.get() - 1) as u64);
     }
 


### PR DESCRIPTION
The non-speculative half of #680.

`SemanticsNodeData` and `SemanticsTreeUpdate` documented themselves as *"the format used when communicating with the platform's accessibility API"* while every identity field carries a 0-based arena position — the exact trap #677 shipped and review caught: focus dropped on unrelated sibling changes, and every inbound action failing as `NodeNotFound` because the payload's ids live in a different number space than `resolve_action` matches.

**The fields deliberately do not change.** Both sites have zero consumers (verified in the issue), and adding `accessibility_id` to a payload nothing reads is exactly the speculative scaffolding the architecture contract refuses (SP-4). What could not stay is the advertising — the issue's own risk statement is that *"the first adapter author reasonably trusts them and reproduces the bug."*

The docs now:
- state the id space honestly on the module, both types, `id`, `children`, and `removed_node_ids`;
- name the concrete failure a platform consumer would hit, including the removal-notice variant (telling an adapter to drop an id it was never given);
- point at `tree_to_update` + `accessibility_id()` as the real platform payload;
- keep the field change tracked in #680 for when a consumer appears, explicitly not made speculatively.

Doc-only; `cargo check`, strict rustdoc, fmt, and typos all clean.

Refs #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM