### PR TITLE
feat(widgets): SliverPersistentHeader — content that rebuilds as it collapses (#689)

### DIFF
--- a/crates/flui-view/src/element/mod.rs
+++ b/crates/flui-view/src/element/mod.rs
@@ -17,6 +17,7 @@ mod notification;
 mod render_object_element;
 mod root;
 pub(crate) mod sliver_adaptor;
+pub(crate) mod sliver_persistent_header;
 pub(crate) mod sparse_children;
 pub(crate) mod stream_builder;
 
@@ -67,6 +68,11 @@ pub use notification::{
 pub use render_object_element::{RenderObjectElement, RenderSlot, RenderTreeRootElement};
 pub use root::{RootElement, RootElementImpl};
 pub use sliver_adaptor::{SliverGridLazy, SliverList};
+pub use sliver_persistent_header::{
+    FloatingPersistentHeaderView, FloatingPinnedPersistentHeaderView, PersistentHeaderView,
+    PinnedPersistentHeaderView, ScrollingPersistentHeaderView, SharedHeaderDelegate,
+    SliverPersistentHeaderDelegate,
+};
 pub use stream_builder::{BoxedResultStream, StreamBuilder, StreamBuilderState, StreamFactory};
 pub use unified::Element;
 

--- a/crates/flui-view/src/element/sliver_persistent_header.rs
+++ b/crates/flui-view/src/element/sliver_persistent_header.rs
@@ -1,0 +1,526 @@
+//! `SliverPersistentHeader` render views + element — the element half of the
+//! persistent-header build-during-layout seam.
+//!
+//! # What this wires together
+//!
+//! - `flui_objects::sliver::sliver_persistent_header`: all four render objects
+//!   of the pinned × floating matrix, whose shared `PersistentHeaderCore`
+//!   publishes `(shrink_offset, overlaps_content)` into a shared
+//!   [`HeaderShrinkCell`] on every layout pass — inside its own change gate, so
+//!   an unchanged pair raises nothing.
+//! - `owner/layout_builder.rs`: the payload-blind build-during-layout registry
+//!   and `BuildOwner::service_layout_builders`, whose entry doc names this
+//!   header as its second consumer.
+//! - This module: the element that mints the cell, installs it on the render
+//!   object at mount, registers `RenderId -> (ElementId, cell)`, and — between
+//!   layout passes — rebuilds its child by handing the *published* shrink state
+//!   to a [`SliverPersistentHeaderDelegate`].
+//!
+//! # Same-frame settling
+//!
+//! Identical to [`LayoutBuilder`](super::layout_builder::LayoutBuilder)'s
+//! fixpoint, with shrink state in place of box constraints:
+//!
+//! ```text
+//! run_layout      → PersistentHeaderCore publishes (shrink, overlaps),
+//!                   raises needs_build iff the pair changed
+//! service_*       → this element rebuilds; delegate.build(shrink, overlaps)
+//!                   produces the child; reconcile mounts it; cell.commit()
+//! run_layout      → the fresh child is laid out at the new extent
+//! service_*       → pair republished == committed ⇒ clean ⇒ converges
+//! ```
+//!
+//! # The first build has no shrink state, and does not invent any
+//!
+//! Before the first layout pass nothing has published — the shrink offset
+//! depends on a scroll offset that does not exist yet. The element builds **no
+//! child** for that one pass rather than guessing `0.0`: the render object
+//! sizes from its extents alone, publishes, and the fixpoint builds the real
+//! child in the same frame. Same rule, same reason, as `LayoutBuilder`'s
+//! constraints (ADR-0017).
+//!
+//! # Public surface
+//!
+//! [`SliverPersistentHeaderDelegate`] and the four concrete views are public:
+//! `flui-widgets`' `SliverPersistentHeader` facade composes over them, picking
+//! the view type from its `pinned`/`floating` flags so that flipping a flag is
+//! a view-type change the reconciler answers by replacement — never an
+//! in-place update against a render object of the wrong variant.
+//!
+//! Cross-checked against `.flutter/packages/flutter/lib/src/widgets/sliver_persistent_header.dart`
+//! (delegate contract, `shouldRebuild` semantics) — the servicing *timing*
+//! deliberately follows FLUI's between-passes fixpoint rather than Flutter's
+//! inside-layout `updateChild`, because FLUI's layout walk holds
+//! `&mut RenderTree` (ADR-0017's rejected alternatives).
+
+use std::{marker::PhantomData, rc::Rc, sync::Arc};
+
+use flui_objects::{
+    HeaderShrinkCell, RenderSliverFloatingPersistentHeader,
+    RenderSliverFloatingPinnedPersistentHeader, RenderSliverPinnedPersistentHeader,
+    RenderSliverScrollingPersistentHeader,
+};
+use flui_rendering::protocol::SliverProtocol;
+
+use super::{
+    Variable,
+    behavior::{ElementBehavior, RenderBehavior, make_build_ctx},
+    behavior_commons::{build_or_recover, should_build_with_trace, single_child_views},
+    generic::ElementCore,
+    unified::Element,
+};
+use crate::{
+    BoxedView, ElementOwner,
+    context::BuildContext,
+    view::{RenderView, View},
+};
+
+// ============================================================================
+// DELEGATE
+// ============================================================================
+
+/// Configuration and child factory for a persistent header.
+///
+/// The header's *box* is owned by the render layer (extent interpolation,
+/// pinning, floating, paint clamping); the delegate owns what the header
+/// **contains** at a given collapse state. `build` runs between layout passes
+/// with the shrink state the render object actually published — never a
+/// guessed or stale pair.
+///
+/// # `should_rebuild` contract
+///
+/// When a rebuilt widget carries a *different* delegate instance, the new
+/// delegate is asked whether the swap is observable. Return `true` whenever
+/// the new delegate could produce different content **or different
+/// `min_extent`/`max_extent`** — the extents are pushed to the render object
+/// on the same update path, so answering `false` freezes both the child and
+/// the geometry. (Flutter's `SliverPersistentHeaderDelegate.shouldRebuild`
+/// states the same obligation.)
+pub trait SliverPersistentHeaderDelegate {
+    /// Build the header's content for the given collapse state.
+    ///
+    /// `shrink_offset` grows from `0.0` (fully expanded) toward
+    /// [`max_extent`](Self::max_extent) as the header scrolls away;
+    /// `overlaps_content` is `true` while the header overlaps the sliver
+    /// after it (the pinned-and-scrolled-under state a shadow usually keys
+    /// on).
+    fn build(
+        &self,
+        ctx: &dyn BuildContext,
+        shrink_offset: f32,
+        overlaps_content: bool,
+    ) -> BoxedView;
+
+    /// The extent the header collapses to.
+    fn min_extent(&self) -> f32;
+
+    /// The extent the header expands to.
+    fn max_extent(&self) -> f32;
+
+    /// Whether replacing `old` with `self` is observable. See the trait doc
+    /// for the obligation this carries.
+    fn should_rebuild(
+        &self,
+        old: &dyn SliverPersistentHeaderDelegate, // PORT-CHECK-OK-DYN: the old delegate is inherently type-erased on the view (see SharedHeaderDelegate); a generic parameter here would make the trait non-object-safe and the view un-erasable
+    ) -> bool {
+        let _ = old;
+        true
+    }
+}
+
+/// The shared delegate handle carried by every persistent-header view.
+///
+/// `Rc` (not a generic parameter) for the same reason as
+/// `LayoutWidgetBuilder`: the view stays cheaply cloneable and object-safe as
+/// a `dyn View`, and the delegate stays UI-owner-local under ADR-0027.
+pub type SharedHeaderDelegate = Rc<dyn SliverPersistentHeaderDelegate>; // PORT-CHECK-OK-DYN: same erasure and ownership shape as LayoutWidgetBuilder — the view must stay cheaply cloneable and object-safe as a dyn View, and the delegate stays UI-owner-local under ADR-0027
+
+// ============================================================================
+// RENDER-OBJECT ABSTRACTION (one behavior, four variants)
+// ============================================================================
+
+/// The slice of the four persistent-header render objects this element needs:
+/// construction from extents, cell installation, and extent refresh.
+///
+/// Sealed by location — implemented here for exactly the four variants; the
+/// pinned/floating *behavior* differences live entirely in the render layer.
+pub trait PersistentHeaderRenderObject:
+    flui_rendering::traits::RenderObject<SliverProtocol> + Send + Sync + 'static
+{
+    /// Construct with the delegate's extents. No cell yet — the element mints
+    /// and installs it at mount, because only the element knows the registry
+    /// entry the cell must also land in.
+    fn create(min_extent: f32, max_extent: f32) -> Self;
+
+    /// Install the shared mailbox this render object publishes shrink state
+    /// into on every layout pass.
+    fn install_shrink_cell(&mut self, cell: Arc<HeaderShrinkCell>);
+
+    /// Refresh both extents from a rebuilt delegate.
+    fn update_extents(
+        &mut self,
+        min_extent: f32,
+        max_extent: f32,
+    ) -> flui_rendering::RenderUpdateImpact;
+}
+
+impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
+    fn create(min_extent: f32, max_extent: f32) -> Self {
+        Self::new(min_extent, max_extent)
+    }
+
+    fn install_shrink_cell(&mut self, cell: Arc<HeaderShrinkCell>) {
+        self.set_shrink_cell(cell);
+    }
+
+    fn update_extents(
+        &mut self,
+        min_extent: f32,
+        max_extent: f32,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
+    }
+}
+
+impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
+    fn create(min_extent: f32, max_extent: f32) -> Self {
+        Self::new(min_extent, max_extent)
+    }
+
+    fn install_shrink_cell(&mut self, cell: Arc<HeaderShrinkCell>) {
+        self.set_shrink_cell(cell);
+    }
+
+    fn update_extents(
+        &mut self,
+        min_extent: f32,
+        max_extent: f32,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
+    }
+}
+
+impl PersistentHeaderRenderObject for RenderSliverFloatingPersistentHeader {
+    fn create(min_extent: f32, max_extent: f32) -> Self {
+        // No controller: snap and programmatic expansion are deferred until a
+        // snap configuration reaches this seam (the facade documents this).
+        Self::new(min_extent, max_extent, None)
+    }
+
+    fn install_shrink_cell(&mut self, cell: Arc<HeaderShrinkCell>) {
+        self.set_shrink_cell(cell);
+    }
+
+    fn update_extents(
+        &mut self,
+        min_extent: f32,
+        max_extent: f32,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
+    }
+}
+
+impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader {
+    fn create(min_extent: f32, max_extent: f32) -> Self {
+        Self::new(min_extent, max_extent, None)
+    }
+
+    fn install_shrink_cell(&mut self, cell: Arc<HeaderShrinkCell>) {
+        self.set_shrink_cell(cell);
+    }
+
+    fn update_extents(
+        &mut self,
+        min_extent: f32,
+        max_extent: f32,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
+    }
+}
+
+// ============================================================================
+// VIEW (generic over the four variants)
+// ============================================================================
+
+/// One persistent-header view, parameterised by which render variant carries
+/// it.
+///
+/// Not used directly by applications — `flui-widgets`' `SliverPersistentHeader`
+/// facade picks the concrete alias from its `pinned`/`floating` flags. The
+/// aliases are distinct *types*, so flipping a flag reconciles as
+/// teardown-and-replace: an in-place update could never migrate a pinned
+/// render object into a floating one.
+pub struct PersistentHeaderView<R> {
+    delegate: SharedHeaderDelegate,
+    _variant: PhantomData<fn() -> R>,
+}
+
+/// The scrolling (neither pinned nor floating) variant.
+pub type ScrollingPersistentHeaderView =
+    PersistentHeaderView<RenderSliverScrollingPersistentHeader>;
+/// The pinned variant.
+pub type PinnedPersistentHeaderView = PersistentHeaderView<RenderSliverPinnedPersistentHeader>;
+/// The floating variant.
+pub type FloatingPersistentHeaderView = PersistentHeaderView<RenderSliverFloatingPersistentHeader>;
+/// The floating + pinned variant.
+pub type FloatingPinnedPersistentHeaderView =
+    PersistentHeaderView<RenderSliverFloatingPinnedPersistentHeader>;
+
+impl<R> PersistentHeaderView<R> {
+    /// Wrap a delegate in this variant.
+    #[must_use]
+    pub fn new(delegate: SharedHeaderDelegate) -> Self {
+        Self {
+            delegate,
+            _variant: PhantomData,
+        }
+    }
+}
+
+impl<R> Clone for PersistentHeaderView<R> {
+    fn clone(&self) -> Self {
+        Self {
+            delegate: Rc::clone(&self.delegate),
+            _variant: PhantomData,
+        }
+    }
+}
+
+impl<R> std::fmt::Debug for PersistentHeaderView<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PersistentHeaderView")
+            .field("min_extent", &self.delegate.min_extent())
+            .field("max_extent", &self.delegate.max_extent())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<R: PersistentHeaderRenderObject> RenderView for PersistentHeaderView<R> {
+    type Protocol = SliverProtocol;
+    type RenderObject = R;
+
+    fn create_render_object(&self, _ctx: &crate::RenderObjectContext<'_>) -> Self::RenderObject {
+        R::create(self.delegate.min_extent(), self.delegate.max_extent())
+    }
+
+    /// Refresh the extents; the child is rebuilt by `build_into_views`, and
+    /// the cell survives rebuilds untouched (same invariant as
+    /// `LayoutBuilder`).
+    fn update_render_object(
+        &self,
+        _ctx: &crate::RenderObjectContext<'_>,
+        render_object: &mut Self::RenderObject,
+    ) -> flui_rendering::RenderUpdateImpact {
+        render_object.update_extents(self.delegate.min_extent(), self.delegate.max_extent())
+    }
+
+    /// The child is produced by `build_into_views` from the published shrink
+    /// state, not carried on the view. Same invariant as `LayoutBuilder`.
+    fn has_children(&self) -> bool {
+        false
+    }
+
+    fn visit_child_views(&self, _visitor: &mut dyn FnMut(&dyn View)) {}
+}
+
+impl<R: PersistentHeaderRenderObject> View for PersistentHeaderView<R> {
+    fn create_element(&self) -> crate::element::ElementKind {
+        // Custom behavior (not the generic `RenderBehavior`) so `on_mount`
+        // mints + installs + registers the shrink cell and `build_into_views`
+        // builds from the published shrink state.
+        crate::element::ElementKind::RenderVariable(Box::new(PersistentHeaderElement::new(
+            self,
+            PersistentHeaderBehavior::new(),
+        )))
+    }
+
+    /// Skip when the delegate is the same instance, or when a distinct
+    /// delegate declares the swap unobservable — `should_rebuild`'s contract
+    /// obliges it to answer `true` if content *or extents* could differ, so
+    /// skipping on `false` also safely skips the extent refresh.
+    fn should_skip_rebuild(&self, previous: &Self) -> bool {
+        Rc::ptr_eq(&self.delegate, &previous.delegate)
+            || !self.delegate.should_rebuild(previous.delegate.as_ref())
+    }
+}
+
+impl<R: PersistentHeaderRenderObject> crate::element::RenderElementBase<Variable>
+    for PersistentHeaderElement<R>
+{
+}
+
+/// The concrete element type for one persistent-header variant.
+pub(crate) type PersistentHeaderElement<R> =
+    Element<PersistentHeaderView<R>, Variable, PersistentHeaderBehavior<R>>;
+
+// ============================================================================
+// BEHAVIOR
+// ============================================================================
+
+/// Element behavior for [`PersistentHeaderView`].
+///
+/// Wraps the generic [`RenderBehavior`] for render-object creation / disposal
+/// and adds the seam: cell mint + install + registry lifecycle, and a
+/// `build_into_views` that reads the published shrink state.
+pub(crate) struct PersistentHeaderBehavior<R: PersistentHeaderRenderObject> {
+    /// Handles render-object creation, attachment, and removal.
+    inner: RenderBehavior<PersistentHeaderView<R>>,
+    /// The mailbox shared with the render object. `None` until `on_mount`
+    /// mints it and installs it on the freshly created render object.
+    cell: Option<Arc<HeaderShrinkCell>>,
+}
+
+impl<R: PersistentHeaderRenderObject> std::fmt::Debug for PersistentHeaderBehavior<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PersistentHeaderBehavior")
+            .field("render_id", &self.inner.render_id)
+            .field("published", &self.cell.as_ref().and_then(|c| c.shrink()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<R: PersistentHeaderRenderObject> PersistentHeaderBehavior<R> {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: RenderBehavior::new(),
+            cell: None,
+        }
+    }
+}
+
+impl<R: PersistentHeaderRenderObject> ElementBehavior<PersistentHeaderView<R>, Variable>
+    for PersistentHeaderBehavior<R>
+{
+    fn debug_kind(&self) -> &'static str {
+        "PersistentHeaderElement"
+    }
+
+    fn render_id(&self) -> Option<flui_foundation::RenderId> {
+        self.inner.render_id
+    }
+
+    /// Build the child from the shrink state the render object published.
+    ///
+    /// Runs inside `BuildOwner::service_layout_builders`' `build_scope`, i.e.
+    /// *between* layout passes, with no pipeline lock and no arena borrow
+    /// held.
+    fn build_into_views(
+        &mut self,
+        core: &mut ElementCore<PersistentHeaderView<R>, Variable>,
+        owner: &mut ElementOwner<'_>,
+    ) -> Vec<Box<dyn View>> {
+        if !should_build_with_trace(core, "PersistentHeaderBehavior") {
+            return Vec::new();
+        }
+
+        // No layout pass has run yet, so no shrink state exists. Build no
+        // child rather than guessing `0.0`: the render object sizes from its
+        // extents alone for this single pass, publishes, and the fixpoint
+        // rebuilds us with the real pair before the frame paints.
+        let Some(shrink) = self.cell.as_ref().and_then(|cell| cell.shrink()) else {
+            tracing::debug!(
+                "PersistentHeaderBehavior: no shrink state published yet — deferring the \
+                 child to this frame's next fixpoint pass"
+            );
+            core.clear_dirty();
+            return Vec::new();
+        };
+
+        let ctx_choice = make_build_ctx(core, owner);
+        let ctx = ctx_choice.as_ctx();
+        let view = core.view().clone();
+        let child_view = build_or_recover(core, owner, "PersistentHeaderElement", move || {
+            // `BoxedView` is a newtype over `Box<dyn View>`; unwrap it for
+            // the reconciler, which speaks `Box<dyn View>`.
+            view.delegate
+                .build(ctx, shrink.shrink_offset, shrink.overlaps_content)
+                .0
+        });
+        single_child_views(core, child_view, "PersistentHeaderBehavior")
+    }
+
+    /// Create the render object, then mint the cell, install it, and register
+    /// it under the render id.
+    fn on_mount(
+        &mut self,
+        core: &mut ElementCore<PersistentHeaderView<R>, Variable>,
+        owner: &mut ElementOwner<'_>,
+    ) {
+        // Step 1: the inner behavior creates and inserts the render object.
+        self.inner.on_mount(core, owner);
+
+        let Some(render_id) = self.inner.render_id else {
+            tracing::warn!(
+                "PersistentHeaderBehavior::on_mount: no render object was created \
+                 (no PipelineOwner?) — the shrink seam is inert for this element"
+            );
+            return;
+        };
+
+        // Step 2: mint the mailbox and install it on the render object. The
+        // element mints (unlike `RenderLayoutBuilder`, whose constructor owns
+        // its cell) because the same `Arc` must also land in the registry
+        // below — one mailbox, two holders, minted where both are in reach.
+        let cell = Arc::new(HeaderShrinkCell::new());
+        let installed = core.pipeline_owner().is_some_and(|pipeline| {
+            pipeline.with_mut(|owner| {
+                owner
+                    .render_tree_mut()
+                    .get_mut(render_id)
+                    .and_then(|node| node.downcast_render_object_mut::<R>())
+                    .map(|render_object| {
+                        render_object.install_shrink_cell(Arc::clone(&cell));
+                    })
+                    .is_some()
+            })
+        });
+
+        if !installed {
+            tracing::warn!(
+                ?render_id,
+                "PersistentHeaderBehavior::on_mount: could not install the shrink cell \
+                 on the render object"
+            );
+            return;
+        }
+
+        // Step 3: register. `self_id` is stamped by `ElementTree::insert`
+        // before `on_mount` fires (same ordering `LayoutBuilderBehavior`
+        // relies on).
+        let Some(self_id) = core.self_id() else {
+            tracing::warn!(
+                ?render_id,
+                "PersistentHeaderBehavior::on_mount: no self_id stamped — cannot register"
+            );
+            return;
+        };
+
+        self.cell = Some(Arc::clone(&cell));
+        owner.register_layout_builder(render_id, self_id, cell);
+    }
+
+    /// Unregister before the render object is disposed.
+    ///
+    /// `service_layout_builders` also prunes entries whose element or render
+    /// node has vanished, but that is a safety net for reconcile races, not
+    /// the cleanup path.
+    fn on_unmount(
+        &mut self,
+        core: &mut ElementCore<PersistentHeaderView<R>, Variable>,
+        owner: &mut ElementOwner<'_>,
+    ) {
+        if let Some(render_id) = self.inner.render_id {
+            owner.unregister_layout_builder(render_id);
+        }
+        self.cell = None;
+        self.inner.on_unmount(core, owner);
+    }
+
+    fn on_update(
+        &mut self,
+        core: &ElementCore<PersistentHeaderView<R>, Variable>,
+        owner: &mut crate::ElementOwner<'_>,
+    ) {
+        self.inner.on_update(core, owner);
+    }
+}

--- a/crates/flui-view/src/owner/layout_builder.rs
+++ b/crates/flui-view/src/owner/layout_builder.rs
@@ -393,6 +393,15 @@ impl BuildOwner {
             drive_fixpoint(|| {
                 // Layout checked out…
                 pipeline.with_mut(|pipeline_owner| {
+                    // Channel-delivered dirty marks (a scroll position's
+                    // change notification, a background producer) must land
+                    // BEFORE this pass, exactly as `run_frame` drains before
+                    // its first phase. Without this, a mark sitting in the
+                    // channel is laid out only by the final `run_frame` —
+                    // after servicing has finished — so anything the layout
+                    // publishes (a header's shrink change) is serviced one
+                    // frame late, breaking the seam's same-frame promise.
+                    pipeline_owner.drain_pending_dirty();
                     let mut layout = std::mem::take(pipeline_owner).into_layout();
                     let result = layout.run_layout();
                     // Restore on the error path too: the owner always comes back.

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -208,7 +208,7 @@ pub use scroll::{
     SliverChildBuilderDelegate, SliverFillRemaining, SliverFillRemainingAndOverscroll,
     SliverFillRemainingWithScrollable, SliverFillViewport, SliverFixedExtentList, SliverGrid,
     SliverIgnorePointer, SliverList, SliverOffstage, SliverOpacity, SliverPadding,
-    SliverToBoxAdapter, Viewport,
+    SliverPersistentHeader, SliverPersistentHeaderDelegate, SliverToBoxAdapter, Viewport,
 };
 pub use semantics::{ExcludeSemantics, MergeSemantics, Semantics};
 pub use stack::{IndexedStack, Positioned, Stack};

--- a/crates/flui-widgets/src/scroll/mod.rs
+++ b/crates/flui-widgets/src/scroll/mod.rs
@@ -29,6 +29,7 @@ mod sliver_list;
 mod sliver_offstage;
 mod sliver_opacity;
 mod sliver_padding;
+mod sliver_persistent_header;
 mod sliver_to_box_adapter;
 mod viewport;
 
@@ -55,5 +56,9 @@ pub use sliver_list::{SliverChildBuilderDelegate, SliverList};
 pub use sliver_offstage::SliverOffstage;
 pub use sliver_opacity::SliverOpacity;
 pub use sliver_padding::SliverPadding;
+pub use sliver_persistent_header::SliverPersistentHeader;
+// The trait a header's content author implements; lives beside the element
+// half in flui-view, surfaced here so `use flui_widgets::...` is sufficient.
+pub use flui_view::element::SliverPersistentHeaderDelegate;
 pub use sliver_to_box_adapter::SliverToBoxAdapter;
 pub use viewport::{ShrinkWrappingViewport, Viewport};

--- a/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
+++ b/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
@@ -1,0 +1,98 @@
+//! [`SliverPersistentHeader`] — a sliver whose child is rebuilt as the header
+//! collapses, pinnable and floatable.
+
+use std::rc::Rc;
+
+use flui_view::element::{
+    FloatingPersistentHeaderView, FloatingPinnedPersistentHeaderView, PinnedPersistentHeaderView,
+    ScrollingPersistentHeaderView, SliverPersistentHeaderDelegate,
+};
+use flui_view::prelude::StatelessView;
+use flui_view::{BuildContext, IntoView, ViewExt};
+
+/// A sliver that keeps a header of delegate-controlled extent at the leading
+/// edge, rebuilding its content as the header collapses from
+/// [`max_extent`](SliverPersistentHeaderDelegate::max_extent) toward
+/// [`min_extent`](SliverPersistentHeaderDelegate::min_extent).
+///
+/// The [`SliverPersistentHeaderDelegate`]'s `build` receives the header's real
+/// published collapse state — `shrink_offset` and `overlaps_content` — every
+/// time it changes, in the same frame it changed (the build-during-layout
+/// fixpoint `LayoutBuilder` also rides). This is the foundation collapsing app
+/// bars sit on.
+///
+/// `pinned` keeps the collapsed header on screen; `floating` re-reveals it on
+/// any scroll toward the start. The four combinations map to four distinct
+/// render objects, so flipping a flag replaces the element rather than
+/// mutating it — exactly Flutter's shape, where each combination is its own
+/// internal widget.
+///
+/// # Deferred, deliberately
+///
+/// Snap (`FloatingHeaderSnapConfiguration`) and over-scroll stretch
+/// (`OverScrollHeaderStretchConfiguration`) are implemented at the render
+/// layer but not yet reachable from this widget: both need an
+/// `AnimationController` / vsync plumbed through the element, which is its
+/// own slice. Until then floating headers scroll freely and never snap.
+///
+/// Flutter parity: `widgets/sliver_persistent_header.dart`
+/// `SliverPersistentHeader`.
+#[derive(Clone, StatelessView)]
+pub struct SliverPersistentHeader {
+    delegate: Rc<dyn SliverPersistentHeaderDelegate>, // PORT-CHECK-OK-DYN: carries flui-view's SharedHeaderDelegate erasure (justified at its declaration) through the facade
+    pinned: bool,
+    floating: bool,
+}
+
+impl SliverPersistentHeader {
+    /// A scrolling (neither pinned nor floating) header over `delegate`.
+    pub fn new(delegate: impl SliverPersistentHeaderDelegate + 'static) -> Self {
+        Self {
+            delegate: Rc::new(delegate),
+            pinned: false,
+            floating: false,
+        }
+    }
+
+    /// Keep the collapsed header visible at the leading edge instead of
+    /// letting it scroll away.
+    #[must_use]
+    pub fn pinned(mut self, pinned: bool) -> Self {
+        self.pinned = pinned;
+        self
+    }
+
+    /// Re-reveal the header as soon as the user scrolls toward the start,
+    /// regardless of how far away it was.
+    #[must_use]
+    pub fn floating(mut self, floating: bool) -> Self {
+        self.floating = floating;
+        self
+    }
+}
+
+impl std::fmt::Debug for SliverPersistentHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SliverPersistentHeader")
+            .field("pinned", &self.pinned)
+            .field("floating", &self.floating)
+            .field("min_extent", &self.delegate.min_extent())
+            .field("max_extent", &self.delegate.max_extent())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatelessView for SliverPersistentHeader {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        let delegate = Rc::clone(&self.delegate);
+        // Four distinct view TYPES, not one view with flags: the reconciler
+        // answers a flag flip by replacing the element, which is the only
+        // correct answer when each variant owns a different render object.
+        match (self.pinned, self.floating) {
+            (false, false) => ScrollingPersistentHeaderView::new(delegate).boxed(),
+            (true, false) => PinnedPersistentHeaderView::new(delegate).boxed(),
+            (false, true) => FloatingPersistentHeaderView::new(delegate).boxed(),
+            (true, true) => FloatingPinnedPersistentHeaderView::new(delegate).boxed(),
+        }
+    }
+}

--- a/crates/flui-widgets/tests/main.rs
+++ b/crates/flui-widgets/tests/main.rs
@@ -104,6 +104,8 @@ mod shrink_wrapping_viewport;
 mod slide_transition;
 #[path = "sliver_opacity.rs"]
 mod sliver_opacity;
+#[path = "sliver_persistent_header.rs"]
+mod sliver_persistent_header;
 #[path = "spacer.rs"]
 mod spacer;
 #[path = "stack_positioned.rs"]

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -1,5 +1,5 @@
 //! Functional tests for [`SliverPersistentHeader`] — the widget half of the
-//! persistent-header build-during-layout seam (issue #689).
+//! persistent-header build-during-layout seam.
 //!
 //! What these pin, deliberately at the widget level (the four render objects
 //! already carry harness tests in `flui-objects`):
@@ -170,7 +170,7 @@ fn shrink_offset_is_clamped_to_max_extent() {
 
 /// All four variants mount and build through the seam. A variant whose
 /// element failed to register its cell would produce zero builds — silently
-/// static content, the exact pre-#689 state.
+/// static content, exactly the gap this widget existed to close.
 #[test]
 fn every_variant_builds_through_the_seam() {
     for (pinned, floating) in [(false, false), (true, false), (false, true), (true, true)] {
@@ -192,6 +192,56 @@ fn every_variant_builds_through_the_seam() {
              child through the seam exactly once on the first frame"
         );
     }
+}
+
+/// A delegate swap that SHRINKS `max_extent` while scrolled beyond it. The
+/// retained published pair (120) exceeds the new delegate's maximum (60),
+/// so a naive swap-time rebuild would hand the new delegate an out-of-range
+/// value — but an extent-changing swap routes through the layout seam: the
+/// extent setters mark the child update, layout republishes the freshly
+/// clamped pair, and the ONE rebuild the delegate sees carries it. Probed,
+/// not assumed: exactly one post-swap build, value 60, never 120.
+#[test]
+fn a_swap_that_shrinks_max_extent_never_hands_the_delegate_an_out_of_range_pair() {
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let header = |max_extent: f32, builds: &Rc<RefCell<Vec<(f32, bool)>>>| {
+        SliverPersistentHeader::new(RecordingDelegate {
+            min_extent: 30.0,
+            max_extent,
+            builds: Rc::clone(builds),
+        })
+        .pinned(true)
+    };
+
+    let mut laid = lay_out(
+        scroll_view_at(250.0, header(120.0, &builds)),
+        tight(300.0, 300.0),
+    );
+    let swap_point = builds.borrow().len();
+    assert_eq!(
+        builds.borrow().last().map(|(shrink, _)| *shrink),
+        Some(120.0),
+        "premise: scrolled far past the original maximum"
+    );
+
+    laid.pump_widget(scroll_view_at(250.0, header(60.0, &builds)));
+
+    let seen = builds.borrow().clone();
+    assert_eq!(
+        seen[swap_point..].len(),
+        1,
+        "an extent-changing swap rebuilds exactly once — a second entry \
+         means a swap-time rebuild ran with the stale retained pair; saw {seen:?}"
+    );
+    assert!(
+        seen[swap_point..].iter().all(|(shrink, _)| *shrink <= 60.0),
+        "no call after the swap may exceed the NEW delegate's max_extent —          the swap-triggered rebuild must clamp the retained pair; saw {seen:?}"
+    );
+    assert_eq!(
+        seen.last().map(|(shrink, _)| *shrink),
+        Some(60.0),
+        "the pair that sticks is the freshly published one, clamped by          layout itself; saw {seen:?}"
+    );
 }
 
 /// A delegate that delegates `should_rebuild` to a flag, counting builds.

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -1,0 +1,263 @@
+//! Functional tests for [`SliverPersistentHeader`] — the widget half of the
+//! persistent-header build-during-layout seam (issue #689).
+//!
+//! What these pin, deliberately at the widget level (the four render objects
+//! already carry harness tests in `flui-objects`):
+//!
+//! - the delegate's `build` receives the header's REAL published collapse
+//!   state, in the same frame layout produced it;
+//! - the child genuinely REBUILDS when the shrink state changes, and does
+//!   NOT rebuild when it hasn't — the edge-trigger the whole seam exists
+//!   for, and the test the issue's acceptance names ("fails if the hook is
+//!   re-stubbed to a no-op");
+//! - `should_rebuild` gates delegate swaps the way Flutter's contract says;
+//! - all four pinned × floating variants mount and build through the seam.
+//!
+//! The 22-case Flutter oracle
+//! (`test/widgets/sliver_persistent_header_test.dart`) is a follow-up parity
+//! unit — those cases lean on stretch/snap configurations and `SliverAppBar`
+//! scaffolding this widget defers; porting them rides the parity-file
+//! conventions (content sweep, per-case ledger) that deserve their own
+//! change rather than an appendix to this one.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::common::{lay_out, tight};
+use flui_view::BoxedView;
+use flui_view::IntoView;
+use flui_view::view::ViewExt;
+use flui_widgets::{
+    ColoredBox, CustomScrollView, SizedBox, SliverPersistentHeader, SliverPersistentHeaderDelegate,
+    SliverToBoxAdapter,
+};
+
+use flui_types::Color;
+
+/// A delegate that records every `(shrink_offset, overlaps_content)` pair its
+/// `build` was called with.
+struct RecordingDelegate {
+    min_extent: f32,
+    max_extent: f32,
+    builds: Rc<RefCell<Vec<(f32, bool)>>>,
+}
+
+impl SliverPersistentHeaderDelegate for RecordingDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        shrink_offset: f32,
+        overlaps_content: bool,
+    ) -> BoxedView {
+        self.builds
+            .borrow_mut()
+            .push((shrink_offset, overlaps_content));
+        ColoredBox::new(Color::rgb(51, 102, 204))
+            .child(SizedBox::shrink())
+            .into_view()
+            .boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        self.min_extent
+    }
+
+    fn max_extent(&self) -> f32 {
+        self.max_extent
+    }
+}
+
+/// Some scrollable content after the header, so scrolling has somewhere to go
+/// and `overlaps_content` has something to overlap.
+fn trailing_content() -> BoxedView {
+    SliverToBoxAdapter::new()
+        .child(SizedBox::new(400.0, 400.0))
+        .into_view()
+        .boxed()
+}
+
+fn scroll_view_at(offset: f32, header: SliverPersistentHeader) -> CustomScrollView {
+    CustomScrollView::new((header, trailing_content())).offset(offset)
+}
+
+/// The first frame builds the child with the header fully expanded —
+/// `shrink_offset == 0.0` — and with the real published pair, never a guess:
+/// the build happens in the same frame's fixpoint, after layout published.
+#[test]
+fn first_frame_builds_with_the_published_expanded_state() {
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let header = SliverPersistentHeader::new(RecordingDelegate {
+        min_extent: 40.0,
+        max_extent: 120.0,
+        builds: Rc::clone(&builds),
+    });
+
+    lay_out(scroll_view_at(0.0, header), tight(300.0, 300.0));
+
+    assert_eq!(
+        builds.borrow().as_slice(),
+        &[(0.0, false)],
+        "one build, with the real expanded pair — a seam that guesses or \
+         never fires produces zero or different entries"
+    );
+}
+
+/// Scrolling changes the shrink offset, and the delegate rebuilds with the
+/// new pair; pumping again WITHOUT a change must not rebuild — the cell is
+/// edge-triggered, and a level-triggered regression would rebuild the header
+/// every frame forever.
+#[test]
+fn the_child_rebuilds_on_shrink_change_and_only_then() {
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let delegate = |builds: &Rc<RefCell<Vec<(f32, bool)>>>| RecordingDelegate {
+        min_extent: 40.0,
+        max_extent: 120.0,
+        builds: Rc::clone(builds),
+    };
+
+    let mut laid = lay_out(
+        scroll_view_at(0.0, SliverPersistentHeader::new(delegate(&builds))),
+        tight(300.0, 300.0),
+    );
+    assert_eq!(builds.borrow().len(), 1, "premise: one initial build");
+
+    // Same widget shape, new offset: the header shrinks by 50.
+    laid.pump_widget(scroll_view_at(
+        50.0,
+        SliverPersistentHeader::new(delegate(&builds)),
+    ));
+    let after_scroll = builds.borrow().clone();
+    assert_eq!(
+        after_scroll.last(),
+        Some(&(50.0, false)),
+        "the rebuild carries the new published pair IN THE SAME FRAME as the \
+         scroll — the fixpoint drains channel-delivered dirty marks before \
+         each pass, so the offset-triggered layout publishes before \
+         servicing runs, not one frame later; saw {after_scroll:?}"
+    );
+
+    let count_after_scroll = builds.borrow().len();
+    laid.pump();
+    assert_eq!(
+        builds.borrow().len(),
+        count_after_scroll,
+        "an unchanged frame must not rebuild the header — the seam is \
+         edge-triggered on the published pair"
+    );
+}
+
+/// A shrink offset past `max_extent` is clamped: the delegate never sees a
+/// shrink larger than the header can actually collapse.
+#[test]
+fn shrink_offset_is_clamped_to_max_extent() {
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let header = SliverPersistentHeader::new(RecordingDelegate {
+        min_extent: 40.0,
+        max_extent: 120.0,
+        builds: Rc::clone(&builds),
+    })
+    .pinned(true);
+
+    lay_out(scroll_view_at(250.0, header), tight(300.0, 300.0));
+
+    let seen = builds.borrow().clone();
+    assert_eq!(
+        seen.last().map(|(shrink, _)| *shrink),
+        Some(120.0),
+        "shrink_offset = min(scroll_offset, max_extent); saw {seen:?}"
+    );
+}
+
+/// All four variants mount and build through the seam. A variant whose
+/// element failed to register its cell would produce zero builds — silently
+/// static content, the exact pre-#689 state.
+#[test]
+fn every_variant_builds_through_the_seam() {
+    for (pinned, floating) in [(false, false), (true, false), (false, true), (true, true)] {
+        let builds = Rc::new(RefCell::new(Vec::new()));
+        let header = SliverPersistentHeader::new(RecordingDelegate {
+            min_extent: 40.0,
+            max_extent: 120.0,
+            builds: Rc::clone(&builds),
+        })
+        .pinned(pinned)
+        .floating(floating);
+
+        lay_out(scroll_view_at(0.0, header), tight(300.0, 300.0));
+
+        assert_eq!(
+            builds.borrow().len(),
+            1,
+            "variant (pinned={pinned}, floating={floating}) must build its \
+             child through the seam exactly once on the first frame"
+        );
+    }
+}
+
+/// A delegate that delegates `should_rebuild` to a flag, counting builds.
+struct GatedDelegate {
+    rebuild: bool,
+    builds: Rc<RefCell<Vec<(f32, bool)>>>,
+}
+
+impl SliverPersistentHeaderDelegate for GatedDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        shrink_offset: f32,
+        overlaps_content: bool,
+    ) -> BoxedView {
+        self.builds
+            .borrow_mut()
+            .push((shrink_offset, overlaps_content));
+        SizedBox::new(10.0, 10.0).into_view().boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        40.0
+    }
+
+    fn max_extent(&self) -> f32 {
+        120.0
+    }
+
+    fn should_rebuild(&self, _old: &dyn SliverPersistentHeaderDelegate) -> bool {
+        self.rebuild
+    }
+}
+
+/// Swapping in a distinct delegate asks the NEW delegate whether the swap is
+/// observable — `false` keeps the existing child, `true` rebuilds. Flutter's
+/// `SliverPersistentHeaderDelegate.shouldRebuild` contract.
+#[test]
+fn a_delegate_swap_rebuilds_only_when_should_rebuild_says_so() {
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let header = |rebuild: bool, builds: &Rc<RefCell<Vec<(f32, bool)>>>| {
+        SliverPersistentHeader::new(GatedDelegate {
+            rebuild,
+            builds: Rc::clone(builds),
+        })
+    };
+
+    let mut laid = lay_out(
+        scroll_view_at(0.0, header(false, &builds)),
+        tight(300.0, 300.0),
+    );
+    assert_eq!(builds.borrow().len(), 1, "premise: one initial build");
+
+    // A distinct delegate that declares the swap unobservable: no rebuild.
+    laid.pump_widget(scroll_view_at(0.0, header(false, &builds)));
+    assert_eq!(
+        builds.borrow().len(),
+        1,
+        "should_rebuild == false must keep the existing child"
+    );
+
+    // A distinct delegate that declares it observable: rebuild.
+    laid.pump_widget(scroll_view_at(0.0, header(true, &builds)));
+    assert_eq!(
+        builds.borrow().len(),
+        2,
+        "should_rebuild == true must rebuild the child"
+    );
+}


### PR DESCRIPTION
Closes the gap #689 names: all four persistent-header render objects existed and were harness-tested, the shrink-publish seam existed (#692), the servicing loop existed (#693) — but every `perform_layout` fed the rebuild hook a no-op, so a header's content was static however far it collapsed. This PR adds the element that consumes the seam, the delegate, and the widget. Collapsing app bars now have their foundation.

## The element mirrors `LayoutBuilder`, deliberately

`PersistentHeaderElement` is the registry's second consumer, shaped exactly like its first: mount mints the `HeaderShrinkCell`, installs it on the render object, and registers `RenderId → (ElementId, cell)`; between layout passes the service loop rebuilds the child from the *published* `(shrink_offset, overlaps_content)`; unmount unregisters before disposal. The first build has no shrink state and builds **no child** rather than guessing `0.0` — same rule, same reason, as `LayoutBuilder`'s constraints (ADR-0017).

One behavior serves all four render variants through a small `PersistentHeaderRenderObject` trait (construct from extents, install cell, refresh extents) — the pinned/floating differences stay entirely in the render layer.

## The widget matches Flutter's shape

`SliverPersistentHeader { delegate, pinned, floating }` is a stateless facade whose build picks one of four distinct view *types*. That is Flutter's own structure, and it is what makes flipping a flag a reconcile-by-replacement — an in-place update could never migrate a pinned render object into a floating one.

`SliverPersistentHeaderDelegate` carries Flutter's contract: `build(ctx, shrink_offset, overlaps_content)`, `min_extent`, `max_extent`, and `should_rebuild(old)` — with the documented obligation that a delegate answering `false` freezes both content and extents.

## The bug this surfaced in the shared fixpoint

The rebuild arrived **one frame late** when the scroll offset changed: a viewport offset rides the scroll position's change notification into the pipeline's dirty *channel*, and the fixpoint called `into_layout().run_layout()` directly — without the `drain_pending_dirty()` that `run_frame` always performs first. So the offset-triggered layout ran only in the final `run_frame`, after servicing had finished, and the shrink change was serviced next frame. The fix drains before each fixpoint pass, restoring the seam's same-frame promise for *any* channel-delivered mark — this affected `LayoutBuilder` the same way for channel-marked relayouts. Red-verified: removing the drain fails `the_child_rebuilds_on_shrink_change_and_only_then`.

## Tests

| test | red evidence |
|---|---|
| `first_frame_builds_with_the_published_expanded_state` | registration unplugged → 0 builds |
| `the_child_rebuilds_on_shrink_change_and_only_then` | drain removed → one frame late; also pins the edge-trigger (no rebuild on an unchanged frame) |
| `shrink_offset_is_clamped_to_max_extent` | published pair oracle |
| `every_variant_builds_through_the_seam` | registration unplugged → 0 builds, per variant |
| `a_delegate_swap_rebuilds_only_when_should_rebuild_says_so` | Flutter `shouldRebuild` contract |

## Scope, honestly

- **Snap and stretch configurations are implemented at the render layer but not reachable from this widget** — both need an `AnimationController`/vsync plumbed through the element; documented on the widget as its own slice. Floating headers scroll freely and never snap until then.
- **The 22-case Flutter oracle** (`sliver_persistent_header_test.dart`) is a follow-up parity unit: most cases lean on the stretch/snap configurations above and `SliverAppBar` scaffolding, and the parity-file conventions (content sweep, per-case ledger) deserve their own change. The functional tests here pin the seam itself.
- `SliverAppBar` sits directly on top of this and is now unblocked.

Refs #689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
