### PR TITLE
feat(widgets): over-scroll stretch through the persistent-header delegate

### DIFF
--- a/crates/flui-view/src/element/sliver_persistent_header.rs
+++ b/crates/flui-view/src/element/sliver_persistent_header.rs
@@ -56,7 +56,7 @@
 use std::{marker::PhantomData, rc::Rc, sync::Arc};
 
 use flui_objects::{
-    HeaderShrinkCell, RenderSliverFloatingPersistentHeader,
+    HeaderShrinkCell, OverScrollHeaderStretchConfiguration, RenderSliverFloatingPersistentHeader,
     RenderSliverFloatingPinnedPersistentHeader, RenderSliverPinnedPersistentHeader,
     RenderSliverScrollingPersistentHeader,
 };
@@ -117,6 +117,20 @@ pub trait SliverPersistentHeaderDelegate {
     /// The extent the header expands to.
     fn max_extent(&self) -> f32;
 
+    /// The over-scroll stretch behavior for this header, if any.
+    ///
+    /// `Some` makes the header stretch beyond [`max_extent`](Self::max_extent)
+    /// when the scroll view over-scrolls at the start, and reports trigger
+    /// crossings through the configuration's `StretchTriggerSignal`. Read on
+    /// every widget update (same path as the extents), so swapping a delegate
+    /// can turn stretching on or off — subject to the same
+    /// [`should_rebuild`](Self::should_rebuild) obligation.
+    ///
+    /// Flutter parity: `SliverPersistentHeaderDelegate.stretchConfiguration`.
+    fn stretch_configuration(&self) -> Option<OverScrollHeaderStretchConfiguration> {
+        None
+    }
+
     /// Whether replacing `old` with `self` is observable. See the trait doc
     /// for the obligation this carries.
     fn should_rebuild(
@@ -162,6 +176,12 @@ pub trait PersistentHeaderRenderObject:
         min_extent: f32,
         max_extent: f32,
     ) -> flui_rendering::RenderUpdateImpact;
+
+    /// Refresh the over-scroll stretch behavior from a rebuilt delegate.
+    fn update_stretch(
+        &mut self,
+        stretch: Option<OverScrollHeaderStretchConfiguration>,
+    ) -> flui_rendering::RenderUpdateImpact;
 }
 
 impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
@@ -180,6 +200,13 @@ impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
     }
+
+    fn update_stretch(
+        &mut self,
+        stretch: Option<OverScrollHeaderStretchConfiguration>,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_stretch_configuration(stretch)
+    }
 }
 
 impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
@@ -197,6 +224,13 @@ impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
         max_extent: f32,
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
+    }
+
+    fn update_stretch(
+        &mut self,
+        stretch: Option<OverScrollHeaderStretchConfiguration>,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_stretch_configuration(stretch)
     }
 }
 
@@ -218,6 +252,13 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPersistentHeader {
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
     }
+
+    fn update_stretch(
+        &mut self,
+        stretch: Option<OverScrollHeaderStretchConfiguration>,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_stretch_configuration(stretch)
+    }
 }
 
 impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader {
@@ -235,6 +276,13 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader
         max_extent: f32,
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_min_extent(min_extent) | self.set_max_extent(max_extent)
+    }
+
+    fn update_stretch(
+        &mut self,
+        stretch: Option<OverScrollHeaderStretchConfiguration>,
+    ) -> flui_rendering::RenderUpdateImpact {
+        self.set_stretch_configuration(stretch)
     }
 }
 
@@ -300,7 +348,11 @@ impl<R: PersistentHeaderRenderObject> RenderView for PersistentHeaderView<R> {
     type RenderObject = R;
 
     fn create_render_object(&self, _ctx: &crate::RenderObjectContext<'_>) -> Self::RenderObject {
-        R::create(self.delegate.min_extent(), self.delegate.max_extent())
+        let mut render_object = R::create(self.delegate.min_extent(), self.delegate.max_extent());
+        // Impact is irrelevant on a freshly created object — it has never
+        // been laid out, so there is nothing to invalidate yet.
+        let _ = render_object.update_stretch(self.delegate.stretch_configuration());
+        render_object
     }
 
     /// Refresh the extents; the child is rebuilt by `build_into_views`, and
@@ -312,6 +364,7 @@ impl<R: PersistentHeaderRenderObject> RenderView for PersistentHeaderView<R> {
         render_object: &mut Self::RenderObject,
     ) -> flui_rendering::RenderUpdateImpact {
         render_object.update_extents(self.delegate.min_extent(), self.delegate.max_extent())
+            | render_object.update_stretch(self.delegate.stretch_configuration())
     }
 
     /// The child is produced by `build_into_views` from the published shrink

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -202,13 +202,14 @@ pub use paint::{ColoredBox, CustomPaint, DecoratedBox, Opacity, RepaintBoundary}
 pub use physical_model::{PhysicalModel, PhysicalShape};
 pub use scroll::{
     BouncingScrollPhysics, ClampingScrollPhysics, CustomScrollView, GridView, ListView,
-    PageController, PageScrollPhysics, PageView, PageViewState, RefreshController,
-    RefreshIndicator, RefreshIndicatorState, ScrollController, ScrollMetrics, ScrollPhysics,
-    Scrollable, Scrollbar, SharedScrollPhysics, ShrinkWrappingViewport, SingleChildScrollView,
-    SliverChildBuilderDelegate, SliverFillRemaining, SliverFillRemainingAndOverscroll,
-    SliverFillRemainingWithScrollable, SliverFillViewport, SliverFixedExtentList, SliverGrid,
-    SliverIgnorePointer, SliverList, SliverOffstage, SliverOpacity, SliverPadding,
-    SliverPersistentHeader, SliverPersistentHeaderDelegate, SliverToBoxAdapter, Viewport,
+    OverScrollHeaderStretchConfiguration, PageController, PageScrollPhysics, PageView,
+    PageViewState, RefreshController, RefreshIndicator, RefreshIndicatorState, ScrollController,
+    ScrollMetrics, ScrollPhysics, Scrollable, Scrollbar, SharedScrollPhysics,
+    ShrinkWrappingViewport, SingleChildScrollView, SliverChildBuilderDelegate, SliverFillRemaining,
+    SliverFillRemainingAndOverscroll, SliverFillRemainingWithScrollable, SliverFillViewport,
+    SliverFixedExtentList, SliverGrid, SliverIgnorePointer, SliverList, SliverOffstage,
+    SliverOpacity, SliverPadding, SliverPersistentHeader, SliverPersistentHeaderDelegate,
+    SliverToBoxAdapter, StretchTriggerSignal, Viewport,
 };
 pub use semantics::{ExcludeSemantics, MergeSemantics, Semantics};
 pub use stack::{IndexedStack, Positioned, Stack};

--- a/crates/flui-widgets/src/scroll/mod.rs
+++ b/crates/flui-widgets/src/scroll/mod.rs
@@ -60,5 +60,8 @@ pub use sliver_persistent_header::SliverPersistentHeader;
 // The trait a header's content author implements; lives beside the element
 // half in flui-view, surfaced here so `use flui_widgets::...` is sufficient.
 pub use flui_view::element::SliverPersistentHeaderDelegate;
+// What a delegate's `stretch_configuration` returns — surfaced with the
+// trait for the same reason.
+pub use flui_objects::{OverScrollHeaderStretchConfiguration, StretchTriggerSignal};
 pub use sliver_to_box_adapter::SliverToBoxAdapter;
 pub use viewport::{ShrinkWrappingViewport, Viewport};

--- a/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
+++ b/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
@@ -27,13 +27,15 @@ use flui_view::{BuildContext, IntoView, ViewExt};
 /// mutating it — exactly Flutter's shape, where each combination is its own
 /// internal widget.
 ///
-/// # Deferred, deliberately
+/// # Stretch is on the delegate; snap is deferred, deliberately
 ///
-/// Snap (`FloatingHeaderSnapConfiguration`) and over-scroll stretch
-/// (`OverScrollHeaderStretchConfiguration`) are implemented at the render
-/// layer but not yet reachable from this widget: both need an
-/// `AnimationController` / vsync plumbed through the element, which is its
-/// own slice. Until then floating headers scroll freely and never snap.
+/// Over-scroll stretch is configured per delegate —
+/// [`SliverPersistentHeaderDelegate::stretch_configuration`] — matching
+/// Flutter's placement, so this widget carries no stretch knob of its own.
+/// Snap (`FloatingHeaderSnapConfiguration`) remains unreachable: starting a
+/// snap needs a scroll-end trigger from the enclosing scrollable, which is
+/// the `SliverAppBar` integration seam. Until that lands, floating headers
+/// scroll freely and never snap.
 ///
 /// Flutter parity: `widgets/sliver_persistent_header.dart`
 /// `SliverPersistentHeader`.

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -244,6 +244,65 @@ fn a_swap_that_shrinks_max_extent_never_hands_the_delegate_an_out_of_range_pair(
     );
 }
 
+/// A delegate carrying an over-scroll stretch configuration.
+struct StretchingDelegate {
+    signal: flui_objects::StretchTriggerSignal,
+}
+
+impl SliverPersistentHeaderDelegate for StretchingDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        _shrink_offset: f32,
+        _overlaps_content: bool,
+    ) -> BoxedView {
+        SizedBox::new(10.0, 10.0).into_view().boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        40.0
+    }
+
+    fn max_extent(&self) -> f32 {
+        120.0
+    }
+
+    fn stretch_configuration(&self) -> Option<flui_objects::OverScrollHeaderStretchConfiguration> {
+        Some(flui_objects::OverScrollHeaderStretchConfiguration::new(
+            20.0,
+            Some(self.signal.clone()),
+        ))
+    }
+}
+
+/// The delegate's stretch configuration reaches the render object and fires
+/// its trigger when the scroll view over-scrolls past the trigger offset —
+/// the whole point of plumbing the configuration through the delegate.
+#[test]
+fn the_delegates_stretch_configuration_fires_its_trigger_on_over_scroll() {
+    let signal = flui_objects::StretchTriggerSignal::new();
+    let header = SliverPersistentHeader::new(StretchingDelegate {
+        signal: signal.clone(),
+    });
+
+    let mut laid = lay_out(scroll_view_at(0.0, header), tight(300.0, 300.0));
+    assert_eq!(signal.count(), 0, "premise: no over-scroll yet");
+
+    // Over-scroll past the 20px trigger.
+    laid.pump_widget(scroll_view_at(
+        -40.0,
+        SliverPersistentHeader::new(StretchingDelegate {
+            signal: signal.clone(),
+        }),
+    ));
+
+    assert!(
+        signal.count() >= 1,
+        "over-scrolling past the trigger offset must fire the delegate's          stretch trigger signal; count = {}",
+        signal.count()
+    );
+}
+
 /// A delegate that delegates `should_rebuild` to a flag, counting builds.
 struct GatedDelegate {
     rebuild: bool,

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -296,10 +296,11 @@ fn the_delegates_stretch_configuration_fires_its_trigger_on_over_scroll() {
         }),
     ));
 
+    let crossings = signal.count();
     assert!(
-        signal.count() >= 1,
-        "over-scrolling past the trigger offset must fire the delegate's          stretch trigger signal; count = {}",
-        signal.count()
+        crossings >= 1,
+        "over-scrolling past the trigger offset must fire the delegate's \
+         stretch trigger signal; count = {crossings}"
     );
 }
 


### PR DESCRIPTION
The stretch half of #699 item 1 (snap stays deferred — see below).

`SliverPersistentHeaderDelegate` gains `stretch_configuration()` (default `None`) — Flutter's own placement for this configuration — and the element pushes it to the render object at create and on every update, on the same path as the extents. All four variants already carried live `set_stretch_configuration` setters from the render-layer slice; this makes them reachable, so a header can stretch beyond `max_extent` on start-edge over-scroll and report trigger crossings through its `StretchTriggerSignal`. Both config types are re-exported beside the delegate trait.

**Snap is deliberately not plumbed.** `maybe_start_snap_animation` has no internal caller by design — it waits on a scroll-end trigger from `Scrollable`, which is the `SliverAppBar` integration seam (#699). Exposing a `snap_configuration` today would be a knob that does nothing.

**Test**: a delegate with a 20px trigger fires its signal when the scroll view over-scrolls past it — a real over-scrolled harness frame through `CustomScrollView`, not a hand-fed constraint. Red-verified by unplugging the `update_stretch` plumbing (element compiles, config never arrives, signal stays silent — the exact silent-gap failure mode).

`just ci` green (log-verified exit 0); typos/taplo clean.

Refs #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM