### PR TITLE
feat(semantics): translate accessibility action payloads (#698)

### DIFF
--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -31,7 +31,8 @@ use flui_scheduler::{
     input_to_present_histogram, produce_to_present_histogram,
 };
 use flui_semantics::{
-    AccessibilityNodeId, SemanticsActionError, SemanticsActionRequest, semantics_action_for,
+    AccessibilityNodeId, SemanticsActionError, SemanticsActionRequest, semantics_action_args_for,
+    semantics_action_for,
 };
 use flui_types::HapticFeedback;
 use flui_view::{GlobalKeyScope, WidgetsBinding};
@@ -323,9 +324,10 @@ impl PresentationState {
     ///   zero node id, an action with no counterpart, a full inbox) are
     ///   traced drops, mirroring how Flutter tolerates screen readers
     ///   acting on a stale snapshot. Typed action payloads
-    ///   (`accesskit::ActionData` — a value to set, a scroll target) are
-    ///   not yet translated: requests resolve argument-free, so a handler
-    ///   that requires arguments sees `None` until that slice lands.
+    ///   (`accesskit::ActionData`) translate via
+    ///   [`semantics_action_args_for`]; a payload kind FLUI cannot express
+    ///   routes the action argument-free with a trace rather than killing
+    ///   the whole request.
     ///
     /// A window without the capability (`accessibility()` → `None`) wires
     /// nothing: the pipeline keeps its documented publish-nowhere
@@ -385,9 +387,23 @@ impl PresentationState {
                 );
                 return;
             };
-            if let Err(error) =
-                command_sender.send_semantics_action(SemanticsActionRequest::new(node_id, action))
-            {
+            let arguments = request.data.as_ref().and_then(|data| {
+                let translated = semantics_action_args_for(data, request.target_node);
+                if translated.is_none() {
+                    // The action still routes; only its payload is lost.
+                    // Traced because a SetValue without its value reaches a
+                    // handler as a no-op edit, which is otherwise invisible.
+                    tracing::trace!(
+                        action = ?request.action,
+                        "accessibility action payload has no FLUI argument shape; \
+                         routing the action argument-free"
+                    );
+                }
+                translated
+            });
+            let mut semantics_request = SemanticsActionRequest::new(node_id, action);
+            semantics_request.arguments = arguments;
+            if let Err(error) = command_sender.send_semantics_action(semantics_request) {
                 tracing::warn!(
                     ?error,
                     "dropping accessibility action: the realm inbox is full or gone"

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -393,10 +393,13 @@ impl PresentationState {
                     // The action still routes; only its payload is lost.
                     // Traced because a SetValue without its value reaches a
                     // handler as a no-op edit, which is otherwise invisible.
+                    // Two cases share this branch: a payload kind FLUI has no
+                    // argument shape for, and a payload untranslatable for
+                    // THIS request (a cross-node text selection).
                     tracing::trace!(
                         action = ?request.action,
-                        "accessibility action payload has no FLUI argument shape; \
-                         routing the action argument-free"
+                        "accessibility action payload not translatable (unsupported kind, or \
+                         invalid for this target); routing the action argument-free"
                     );
                 }
                 translated

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -3542,6 +3542,55 @@ mod tests {
         assert_eq!(invoked.load(Ordering::SeqCst), 1);
     }
 
+    /// A typed payload crosses the whole wire: a SetValue request carrying
+    /// its text arrives at the node's SetText handler WITH that text. A
+    /// payload lost anywhere along the seam turns a screen-reader edit into
+    /// an argument-free no-op, which no other test would notice.
+    #[test]
+    fn platform_action_payload_reaches_the_handler_with_its_arguments() {
+        let fake = Arc::new(flui_platform::FakeAccessibility::new());
+        let window =
+            crate::app::presentation::test_platform_window_with_accessibility(Arc::clone(&fake));
+        let realm = UiRealm::new(noop_wake(), window, 1.0, Arc::new(AtomicBool::new(false)))
+            .expect("realm");
+
+        let render_id = RenderId::new(7);
+        let target = AccessibilityNodeId::from(render_id);
+        let received = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&received);
+        let mut node = SemanticsNode::new().with_source_render_id(render_id);
+        node.config_mut().add_action(
+            SemanticsAction::SetText,
+            Arc::new(move |_action, arguments| {
+                sink.lock().push(arguments);
+            }),
+        );
+        let mut semantics_owner = SemanticsOwner::new(Arc::new(|_| {}));
+        let root = semantics_owner.insert(node);
+        semantics_owner.set_root(Some(root));
+        realm
+            .pipeline_for_test()
+            .with_mut(|owner| owner.set_semantics_owner(Some(semantics_owner)));
+
+        fake.set_active(true);
+        fake.request_action(accesskit::ActionRequest {
+            action: accesskit::Action::SetValue,
+            target_tree: accesskit::TreeId::ROOT,
+            target_node: accesskit::NodeId(target.as_u64()),
+            data: Some(accesskit::ActionData::Value("hello".into())),
+        });
+
+        let report = realm.drain_commands();
+        assert_eq!(report.invoked, 1);
+        assert_eq!(
+            received.lock().as_slice(),
+            &[Some(flui_semantics::ActionArgs::SetText {
+                text: "hello".to_string()
+            })],
+            "the handler must receive the platform's payload, translated"
+        );
+    }
+
     /// Requests the listener cannot route never reach the inbox at all: an
     /// action FLUI has no counterpart for, and the zero node id no
     /// published tree ever exports. Both are traced drops at the platform

--- a/crates/flui-semantics/src/accesskit_translation.rs
+++ b/crates/flui-semantics/src/accesskit_translation.rs
@@ -276,6 +276,49 @@ pub fn semantics_action_for(action: accesskit::Action) -> Option<SemanticsAction
     }
 }
 
+/// Translate an inbound AccessKit action payload into the FLUI argument space.
+///
+/// The payload companion to [`semantics_action_for`] — keep the two adjacent,
+/// because a payload that silently fails to cross this seam turns a
+/// screen-reader edit into a no-op with no diagnostic.
+///
+/// `target` is the node the enclosing request addresses: a text selection
+/// whose positions live on a *different* node (AccessKit expresses
+/// cross-run selections; FLUI's `SetSelection` is offsets within one node)
+/// is unroutable and returns `None`, as does any payload kind FLUI has no
+/// argument shape for (`NumericValue`, `ScrollUnit`, `ScrollHint`,
+/// `ScrollToPoint`). The caller routes the action WITHOUT arguments and
+/// traces the drop — the action itself is still meaningful argument-free
+/// for some handlers, and swallowing the whole request would turn a lossy
+/// payload into a dead control.
+#[must_use]
+pub fn semantics_action_args_for(
+    data: &accesskit::ActionData,
+    target: NodeId,
+) -> Option<crate::ActionArgs> {
+    match data {
+        accesskit::ActionData::Value(text) => Some(crate::ActionArgs::SetText {
+            text: text.to_string(),
+        }),
+        accesskit::ActionData::CustomAction(action_id) => Some(crate::ActionArgs::CustomAction {
+            action_id: *action_id,
+        }),
+        accesskit::ActionData::SetScrollOffset(point) => Some(crate::ActionArgs::ScrollToOffset {
+            x: point.x,
+            y: point.y,
+        }),
+        accesskit::ActionData::SetTextSelection(selection) => {
+            if selection.anchor.node != target || selection.focus.node != target {
+                return None;
+            }
+            let base = i32::try_from(selection.anchor.character_index).ok()?;
+            let extent = i32::try_from(selection.focus.character_index).ok()?;
+            Some(crate::ActionArgs::SetSelection { base, extent })
+        }
+        _ => None,
+    }
+}
+
 /// Translate one FLUI semantics node into an AccessKit node.
 ///
 /// `children` are the caller's already-resolved AccessKit ids. They are NOT
@@ -485,6 +528,75 @@ mod tests {
 
         assert_eq!(node.role(), Role::Button);
         assert_eq!(node.label(), Some("Save"));
+    }
+
+    /// Every payload kind with an FLUI argument shape crosses the seam with
+    /// its data intact; every kind without one returns `None` (the caller
+    /// routes argument-free). A payload silently mistranslated here turns a
+    /// screen-reader edit into the wrong edit, which is worse than a drop.
+    #[test]
+    fn action_payloads_translate_or_decline_honestly() {
+        let target = NodeId(7);
+
+        assert_eq!(
+            semantics_action_args_for(&accesskit::ActionData::Value("hello".into()), target),
+            Some(crate::ActionArgs::SetText {
+                text: "hello".to_string()
+            }),
+        );
+        assert_eq!(
+            semantics_action_args_for(&accesskit::ActionData::CustomAction(42), target),
+            Some(crate::ActionArgs::CustomAction { action_id: 42 }),
+        );
+        assert_eq!(
+            semantics_action_args_for(
+                &accesskit::ActionData::SetScrollOffset(accesskit::Point { x: 3.0, y: -4.5 }),
+                target,
+            ),
+            Some(crate::ActionArgs::ScrollToOffset { x: 3.0, y: -4.5 }),
+        );
+        assert_eq!(
+            semantics_action_args_for(
+                &accesskit::ActionData::SetTextSelection(accesskit::TextSelection {
+                    anchor: accesskit::TextPosition {
+                        node: target,
+                        character_index: 2,
+                    },
+                    focus: accesskit::TextPosition {
+                        node: target,
+                        character_index: 9,
+                    },
+                }),
+                target,
+            ),
+            Some(crate::ActionArgs::SetSelection { base: 2, extent: 9 }),
+        );
+
+        // Kinds FLUI has no argument shape for decline rather than guess.
+        assert_eq!(
+            semantics_action_args_for(&accesskit::ActionData::NumericValue(0.5), target),
+            None,
+        );
+    }
+
+    /// A selection whose positions live on a different node than the request
+    /// targets cannot be expressed as FLUI's within-one-node offsets —
+    /// mapping it anyway would apply another run's indices to this node's
+    /// text.
+    #[test]
+    fn a_cross_node_text_selection_declines() {
+        let target = NodeId(7);
+        let selection = accesskit::ActionData::SetTextSelection(accesskit::TextSelection {
+            anchor: accesskit::TextPosition {
+                node: NodeId(8),
+                character_index: 0,
+            },
+            focus: accesskit::TextPosition {
+                node: target,
+                character_index: 3,
+            },
+        });
+        assert_eq!(semantics_action_args_for(&selection, target), None);
     }
 
     /// The two action tables' agreement, checked as a composition: every

--- a/crates/flui-semantics/src/lib.rs
+++ b/crates/flui-semantics/src/lib.rs
@@ -93,7 +93,7 @@ pub use accessibility::AccessibilityFeatures;
 // ============================================================================
 // RE-EXPORTS - AccessKit Translation
 // ============================================================================
-pub use accesskit_translation::{semantics_action_for, tree_to_update};
+pub use accesskit_translation::{semantics_action_args_for, semantics_action_for, tree_to_update};
 // `SemanticsUpdateCallback` names `TreeUpdate` in its signature, so a consumer
 // implementing that callback must be able to name it without adding accesskit
 // itself at a version that must match ours. `NodeId` comes along because


### PR DESCRIPTION
Completes the a11y action wire: typed payloads now cross it. `SetValue` carries its text, `SetTextSelection` its offsets, `SetScrollOffset` its point, `CustomAction` its id.

## Shape

`semantics_action_args_for(data, target)` sits beside `semantics_action_for` in the translation module — the payload companion to the action table, kept adjacent for the same reason: a payload that silently fails this seam turns a screen-reader edit into an argument-free no-op with no diagnostic anywhere.

## Deliberate declines, each traced

- **Payload kinds FLUI has no argument shape for** — `NumericValue`, `ScrollUnit`, `ScrollHint`, `ScrollToPoint` — return `None`.
- **Cross-node text selections**: AccessKit expresses selections across text runs; FLUI's `SetSelection` is character offsets within one node. Mapping a cross-node selection anyway would apply another run's indices to this node's text — a *wrong* edit, which is worse than a dropped one.

In every declined case the **action still routes argument-free** with a trace. Killing the whole request would turn a lossy payload into a dead control; some handlers are meaningful without arguments.

## Tests

| test | red evidence |
|---|---|
| `platform_action_payload_reaches_the_handler_with_its_arguments` (flui-app, end-to-end through `FakeAccessibility`) | unplugging the single assignment that carries arguments → handler sees `None` |
| `action_payloads_translate_or_decline_honestly` (unit, all four mappings + a decline) | value-exact assertions |
| `a_cross_node_text_selection_declines` (unit) | pins the wrong-edit guard |

`just ci` green (log-verified exit 0), typos clean.

Closes #698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM