### PR TITLE
feat(material): SliverAppBar — the collapsing app bar

### DIFF
--- a/crates/flui-material/src/app_bar.rs
+++ b/crates/flui-material/src/app_bar.rs
@@ -161,8 +161,8 @@ use flui_types::{Alignment, Pixels, Size};
 use flui_view::prelude::*;
 use flui_widgets::{
     Align, Center, Column, ConstrainedBox, CrossAxisAlignment, DefaultTextStyle, Expanded,
-    Flexible, IconTheme, IconThemeData, MainAxisAlignment, NavigatorHandle, PreferredSizeView, Row,
-    SafeArea, SizedBox,
+    Flexible, IconTheme, IconThemeData, MainAxisAlignment, NavigatorHandle, Positioned,
+    PreferredSizeView, Row, SafeArea, SizedBox, Stack,
 };
 
 use crate::back_button::BackButton;
@@ -209,6 +209,11 @@ pub struct AppBar {
     foreground_color: Option<Color>,
     elevation: Option<f32>,
     bottom: Option<BoxedView>,
+    /// A widget painted behind the toolbar and above this bar's own
+    /// [`Material`] — Flutter's `AppBar.flexibleSpace` slot. Inert at the
+    /// bar's own preferred size; it earns its name inside a `SliverAppBar`,
+    /// where the bar's box expands and collapses around it.
+    flexible_space: Option<BoxedView>,
     /// `bottom`'s [`preferred_size`](PreferredSizeView::preferred_size)
     /// height, snapshotted at [`Self::bottom`]-builder time — see that
     /// method's doc comment and [`PreferredSizeView`]'s own "Named
@@ -233,6 +238,7 @@ impl AppBar {
             foreground_color: None,
             elevation: None,
             bottom: None,
+            flexible_space: None,
             bottom_preferred_height: 0.0,
         }
     }
@@ -312,6 +318,15 @@ impl AppBar {
     pub fn bottom(mut self, bottom: impl PreferredSizeView) -> Self {
         self.bottom_preferred_height = bottom.preferred_size().height.get();
         self.bottom = Some(bottom.boxed());
+        self
+    }
+
+    /// Sets the widget painted behind the toolbar, above this bar's own
+    /// [`Material`] — Flutter's `AppBar.flexibleSpace`. Mostly useful
+    /// through `SliverAppBar`, where the bar's box expands around it.
+    #[must_use]
+    pub fn flexible_space(mut self, flexible_space: impl IntoView) -> Self {
+        self.flexible_space = Some(flexible_space.into_view().boxed());
         self
     }
 }
@@ -572,9 +587,21 @@ impl StatelessView for AppBar {
         // module docs' "consumes the top inset itself" section.
         let safe_toolbar = SafeArea::new().bottom(false).child(toolbar_and_bottom);
 
+        // The flexible space paints ABOVE this bar's own Material and BELOW
+        // the toolbar — `app_bar.dart`'s trailing Stack when
+        // `widget.flexibleSpace != null`. Outside that slot order the bar's
+        // opaque surface either hides the flexible content or fails to back
+        // it.
+        let surface_content: BoxedView = match &self.flexible_space {
+            Some(flexible_space) => {
+                Stack::new((Positioned::fill(flexible_space.clone()), safe_toolbar)).boxed()
+            }
+            None => safe_toolbar.boxed(),
+        };
+
         Material::new(background_color)
             .elevation(elevation)
-            .child(safe_toolbar)
+            .child(surface_content)
     }
 }
 

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -92,6 +92,7 @@ pub mod radio;
 pub mod scaffold;
 pub mod scaffold_messenger;
 pub mod shape;
+pub mod sliver_app_bar;
 pub mod snack_bar;
 mod state_color;
 pub mod switch;
@@ -133,6 +134,7 @@ pub use scaffold_messenger::{
     SnackBarClosedReason, SnackBarController,
 };
 pub use shape::MaterialShape;
+pub use sliver_app_bar::SliverAppBar;
 pub use snack_bar::{SnackBar, SnackBarAction, SnackBarActionState};
 pub use switch::{Switch, SwitchState};
 pub use tab_bar_view::{TabBarView, TabBarViewState};

--- a/crates/flui-material/src/sliver_app_bar.rs
+++ b/crates/flui-material/src/sliver_app_bar.rs
@@ -35,9 +35,7 @@ use flui_types::Color;
 use flui_view::prelude::StatelessView;
 use flui_view::{BoxedView, BuildContext, IntoView, ViewExt};
 use flui_widgets::layout::PreferredSizeView;
-use flui_widgets::{
-    MediaQuery, Positioned, SizedBox, SliverPersistentHeader, SliverPersistentHeaderDelegate, Stack,
-};
+use flui_widgets::{MediaQuery, SizedBox, SliverPersistentHeader, SliverPersistentHeaderDelegate};
 
 use crate::AppBar;
 
@@ -72,7 +70,6 @@ pub struct SliverAppBar {
     has_bottom: bool,
     expanded_height: Option<f32>,
     collapsed_height: Option<f32>,
-    flexible_space: Option<BoxedView>,
     pinned: bool,
     floating: bool,
 }
@@ -89,7 +86,6 @@ impl SliverAppBar {
             has_bottom: false,
             expanded_height: None,
             collapsed_height: None,
-            flexible_space: None,
             pinned: false,
             floating: false,
         }
@@ -163,7 +159,10 @@ impl SliverAppBar {
         self
     }
 
-    /// The height this app bar expands to when fully scrolled to the top.
+    /// The height this app bar expands to when fully scrolled to the top,
+    /// EXCLUDING the top safe-area inset — the ambient inset is added on
+    /// top when the extents are computed, so a caller must not fold it in
+    /// (that would double-count it).
     ///
     /// `None` (the default) means the bar is its toolbar (plus `bottom`) and
     /// never expands.
@@ -173,19 +172,22 @@ impl SliverAppBar {
         self
     }
 
-    /// Overrides the height the bar collapses to. Defaults to the toolbar
-    /// height (plus `bottom` and the top inset).
+    /// Overrides the height the bar collapses to, EXCLUDING the top
+    /// safe-area inset and `bottom` — both are added on top when the
+    /// extents are computed. Defaults to the toolbar height.
     #[must_use]
     pub fn collapsed_height(mut self, collapsed_height: f32) -> Self {
         self.collapsed_height = Some(collapsed_height);
         self
     }
 
-    /// A widget painted behind the toolbar, filling the bar's current
-    /// extent — the canvas a cover image or gradient collapses with.
+    /// A widget painted behind the toolbar — above the bar's own
+    /// [`Material`](crate::Material) surface, below its content, filling
+    /// the bar's current extent: the canvas a cover image or gradient
+    /// collapses with. Forwards to [`AppBar::flexible_space`].
     #[must_use]
     pub fn flexible_space(mut self, flexible_space: impl IntoView) -> Self {
-        self.flexible_space = Some(flexible_space.into_view().boxed());
+        self.app_bar = self.app_bar.flexible_space(flexible_space);
         self
     }
 
@@ -263,7 +265,6 @@ fn extents(inputs: &ExtentInputs) -> (f32, f32) {
 /// context-free, so Flutter snapshots `topPadding` the same way).
 struct SliverAppBarDelegate {
     app_bar: AppBar,
-    flexible_space: Option<BoxedView>,
     min_extent: f32,
     max_extent: f32,
 }
@@ -275,18 +276,15 @@ impl SliverPersistentHeaderDelegate for SliverAppBarDelegate {
         _shrink_offset: f32,
         _overlaps_content: bool,
     ) -> BoxedView {
-        // Expand to the header's current box: the bar's surface covers the
+        // Expand to the header's current box: the bar's Material covers the
         // whole expanded area (Flutter's SliverAppBar paints its background
-        // across it), the flexible space fills behind, and the toolbar lays
-        // out at the top within the AppBar's own composition.
-        let toolbar: BoxedView = self.app_bar.clone().into_view().boxed();
-        let layered: BoxedView = match &self.flexible_space {
-            Some(flexible_space) => Stack::new((Positioned::fill(flexible_space.clone()), toolbar))
-                .into_view()
-                .boxed(),
-            None => toolbar,
-        };
-        SizedBox::expand().child(layered).into_view().boxed()
+        // across it), with the flexible space and toolbar layered INSIDE
+        // that surface by the AppBar itself — the slot order that keeps the
+        // opaque background behind the flexible content, never over it.
+        SizedBox::expand()
+            .child(self.app_bar.clone())
+            .into_view()
+            .boxed()
     }
 
     fn min_extent(&self) -> f32 {
@@ -316,7 +314,6 @@ impl StatelessView for SliverAppBar {
 
         SliverPersistentHeader::new(SliverAppBarDelegate {
             app_bar: self.app_bar.clone(),
-            flexible_space: self.flexible_space.clone(),
             min_extent,
             max_extent,
         })

--- a/crates/flui-material/src/sliver_app_bar.rs
+++ b/crates/flui-material/src/sliver_app_bar.rs
@@ -1,0 +1,422 @@
+//! [`SliverAppBar`] — a Material app bar that lives in a
+//! [`CustomScrollView`](flui_widgets::CustomScrollView) and collapses,
+//! pins, or floats as the user scrolls.
+//!
+//! # What this composes, and what it owns
+//!
+//! The toolbar itself — leading / title / actions / bottom, theming, and the
+//! top safe-area inset — is [`AppBar`], reused whole. The scrolling box —
+//! extent interpolation, pinning, floating re-reveal — is
+//! [`SliverPersistentHeader`] over the four persistent-header render
+//! objects. What this widget owns is exactly what Flutter's
+//! `_SliverAppBarDelegate` owns: the extent arithmetic joining the two, and
+//! the layering of `flexible_space` behind the toolbar.
+//!
+//! Flutter parity: `material/app_bar.dart` `SliverAppBar` /
+//! `_SliverAppBarDelegate` (extent formulas cross-checked at
+//! `app_bar.dart:1339-1345` and `:2092-2094`).
+//!
+//! # Deferred, deliberately
+//!
+//! - **Snap** — starting a snap animation needs a scroll-end trigger from
+//!   the enclosing scrollable, which does not exist yet; see the
+//!   persistent-header widget's own note. A `snap` flag here today would do
+//!   nothing.
+//! - **Stretch and `FlexibleSpaceBar`** — over-scroll stretch is reachable
+//!   through a custom [`SliverPersistentHeaderDelegate`]'s
+//!   `stretch_configuration`; surfacing it here without a
+//!   `FlexibleSpaceBar` to consume the stretched box would stretch a blank
+//!   region.
+//! - **Title fade / collapse interpolation** — the collapse fraction is
+//!   available to a delegate as `shrink_offset`; the `FlexibleSpaceBar`
+//!   treatment of it is its own widget.
+
+use flui_types::Color;
+use flui_view::prelude::StatelessView;
+use flui_view::{BoxedView, BuildContext, IntoView, ViewExt};
+use flui_widgets::layout::PreferredSizeView;
+use flui_widgets::{
+    MediaQuery, Positioned, SizedBox, SliverPersistentHeader, SliverPersistentHeaderDelegate, Stack,
+};
+
+use crate::AppBar;
+
+/// A Material app bar for a scroll view: collapses from
+/// [`expanded_height`](Self::expanded_height) to its toolbar as the user
+/// scrolls, optionally [`pinned`](Self::pinned) at the top edge and/or
+/// [`floating`](Self::floating) back into view on any upward scroll.
+///
+/// The toolbar slots (`leading`, `title`, `actions`, `bottom`, colors,
+/// elevation) forward to an inner [`AppBar`] and behave identically to the
+/// standalone widget, including its "consumes the top inset itself"
+/// contract.
+///
+/// # Examples
+///
+/// ```rust
+/// use flui_material::SliverAppBar;
+/// use flui_widgets::Text;
+///
+/// let _bar = SliverAppBar::new()
+///     .title(Text::new("FLUI"))
+///     .expanded_height(200.0)
+///     .pinned(true);
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct SliverAppBar {
+    app_bar: AppBar,
+    /// Mirrors of the inner app bar's height inputs, kept here because the
+    /// extent arithmetic needs them and [`AppBar`] does not expose getters.
+    toolbar_height: f32,
+    bottom_height: f32,
+    has_bottom: bool,
+    expanded_height: Option<f32>,
+    collapsed_height: Option<f32>,
+    flexible_space: Option<BoxedView>,
+    pinned: bool,
+    floating: bool,
+}
+
+impl SliverAppBar {
+    /// A sliver app bar with an empty toolbar, no expansion, neither pinned
+    /// nor floating.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            app_bar: AppBar::new(),
+            toolbar_height: crate::app_bar::DEFAULT_TOOLBAR_HEIGHT,
+            bottom_height: 0.0,
+            has_bottom: false,
+            expanded_height: None,
+            collapsed_height: None,
+            flexible_space: None,
+            pinned: false,
+            floating: false,
+        }
+    }
+
+    /// Sets the widget in the leading slot. See [`AppBar::leading`].
+    #[must_use]
+    pub fn leading(mut self, leading: impl IntoView) -> Self {
+        self.app_bar = self.app_bar.leading(leading);
+        self
+    }
+
+    /// See [`AppBar::automatically_imply_leading`].
+    #[must_use]
+    pub fn automatically_imply_leading(mut self, imply: bool) -> Self {
+        self.app_bar = self.app_bar.automatically_imply_leading(imply);
+        self
+    }
+
+    /// Sets the title. See [`AppBar::title`].
+    #[must_use]
+    pub fn title(mut self, title: impl IntoView) -> Self {
+        self.app_bar = self.app_bar.title(title);
+        self
+    }
+
+    /// Sets the trailing actions. See [`AppBar::actions`].
+    #[must_use]
+    pub fn actions(mut self, actions: Vec<BoxedView>) -> Self {
+        self.app_bar = self.app_bar.actions(actions);
+        self
+    }
+
+    /// Sets the toolbar height. See [`AppBar::toolbar_height`].
+    #[must_use]
+    pub fn toolbar_height(mut self, toolbar_height: f32) -> Self {
+        self.toolbar_height = toolbar_height;
+        self.app_bar = self.app_bar.toolbar_height(toolbar_height);
+        self
+    }
+
+    /// Sets the background color. See [`AppBar::background_color`].
+    #[must_use]
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.app_bar = self.app_bar.background_color(color);
+        self
+    }
+
+    /// Sets the foreground color. See [`AppBar::foreground_color`].
+    #[must_use]
+    pub fn foreground_color(mut self, color: Color) -> Self {
+        self.app_bar = self.app_bar.foreground_color(color);
+        self
+    }
+
+    /// Sets the elevation. See [`AppBar::elevation`].
+    #[must_use]
+    pub fn elevation(mut self, elevation: f32) -> Self {
+        self.app_bar = self.app_bar.elevation(elevation);
+        self
+    }
+
+    /// Sets the bottom widget (a tab bar, say). See [`AppBar::bottom`]; its
+    /// preferred height joins the extent arithmetic exactly as Flutter's
+    /// `_bottomHeight` does.
+    #[must_use]
+    pub fn bottom(mut self, bottom: impl PreferredSizeView) -> Self {
+        self.bottom_height = bottom.preferred_size().height.get();
+        self.has_bottom = true;
+        self.app_bar = self.app_bar.bottom(bottom);
+        self
+    }
+
+    /// The height this app bar expands to when fully scrolled to the top.
+    ///
+    /// `None` (the default) means the bar is its toolbar (plus `bottom`) and
+    /// never expands.
+    #[must_use]
+    pub fn expanded_height(mut self, expanded_height: f32) -> Self {
+        self.expanded_height = Some(expanded_height);
+        self
+    }
+
+    /// Overrides the height the bar collapses to. Defaults to the toolbar
+    /// height (plus `bottom` and the top inset).
+    #[must_use]
+    pub fn collapsed_height(mut self, collapsed_height: f32) -> Self {
+        self.collapsed_height = Some(collapsed_height);
+        self
+    }
+
+    /// A widget painted behind the toolbar, filling the bar's current
+    /// extent — the canvas a cover image or gradient collapses with.
+    #[must_use]
+    pub fn flexible_space(mut self, flexible_space: impl IntoView) -> Self {
+        self.flexible_space = Some(flexible_space.into_view().boxed());
+        self
+    }
+
+    /// Keep the collapsed bar visible at the top edge instead of letting it
+    /// scroll away.
+    #[must_use]
+    pub fn pinned(mut self, pinned: bool) -> Self {
+        self.pinned = pinned;
+        self
+    }
+
+    /// Re-reveal the bar as soon as the user scrolls toward the start.
+    #[must_use]
+    pub fn floating(mut self, floating: bool) -> Self {
+        self.floating = floating;
+        self
+    }
+}
+
+impl Default for SliverAppBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for SliverAppBar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SliverAppBar")
+            .field("toolbar_height", &self.toolbar_height)
+            .field("expanded_height", &self.expanded_height)
+            .field("pinned", &self.pinned)
+            .field("floating", &self.floating)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The extent pair for a sliver app bar, in Flutter's own formulas.
+///
+/// `app_bar.dart:2092-2094`: collapsed = (collapsedHeight ?? toolbarHeight)
+/// plus bottomHeight plus topPadding — except pinned + floating + a bottom,
+/// where the toolbar contribution drops to `collapsedHeight ?? 0.0` (the
+/// toolbar floats away and only the bottom stays pinned).
+/// `app_bar.dart:1339-1345`: min = collapsed; max = max(topPadding +
+/// (expandedHeight ?? toolbar + bottom), min).
+struct ExtentInputs {
+    toolbar_height: f32,
+    bottom_height: f32,
+    has_bottom: bool,
+    expanded_height: Option<f32>,
+    collapsed_height: Option<f32>,
+    pinned: bool,
+    floating: bool,
+    top_padding: f32,
+}
+
+fn extents(inputs: &ExtentInputs) -> (f32, f32) {
+    let collapsed = if inputs.pinned && inputs.floating && inputs.has_bottom {
+        inputs.collapsed_height.unwrap_or(0.0) + inputs.bottom_height + inputs.top_padding
+    } else {
+        inputs.collapsed_height.unwrap_or(inputs.toolbar_height)
+            + inputs.bottom_height
+            + inputs.top_padding
+    };
+    let expanded = inputs.top_padding
+        + inputs
+            .expanded_height
+            .unwrap_or(inputs.toolbar_height + inputs.bottom_height);
+    (collapsed, expanded.max(collapsed))
+}
+
+/// The [`SliverPersistentHeaderDelegate`] a [`SliverAppBar`] resolves to.
+///
+/// Extents are resolved numbers by the time this exists — the top inset is
+/// read at widget build time (the delegate's extent getters are
+/// context-free, so Flutter snapshots `topPadding` the same way).
+struct SliverAppBarDelegate {
+    app_bar: AppBar,
+    flexible_space: Option<BoxedView>,
+    min_extent: f32,
+    max_extent: f32,
+}
+
+impl SliverPersistentHeaderDelegate for SliverAppBarDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn BuildContext,
+        _shrink_offset: f32,
+        _overlaps_content: bool,
+    ) -> BoxedView {
+        // Expand to the header's current box: the bar's surface covers the
+        // whole expanded area (Flutter's SliverAppBar paints its background
+        // across it), the flexible space fills behind, and the toolbar lays
+        // out at the top within the AppBar's own composition.
+        let toolbar: BoxedView = self.app_bar.clone().into_view().boxed();
+        let layered: BoxedView = match &self.flexible_space {
+            Some(flexible_space) => Stack::new((Positioned::fill(flexible_space.clone()), toolbar))
+                .into_view()
+                .boxed(),
+            None => toolbar,
+        };
+        SizedBox::expand().child(layered).into_view().boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        self.min_extent
+    }
+
+    fn max_extent(&self) -> f32 {
+        self.max_extent
+    }
+}
+
+impl StatelessView for SliverAppBar {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        // Snapshot the inset at build time — the delegate's extent getters
+        // are context-free, exactly why Flutter passes `topPadding` in.
+        let top_padding = MediaQuery::maybe_of(ctx).map_or(0.0, |data| data.padding.top.get());
+        let (min_extent, max_extent) = extents(&ExtentInputs {
+            toolbar_height: self.toolbar_height,
+            bottom_height: self.bottom_height,
+            has_bottom: self.has_bottom,
+            expanded_height: self.expanded_height,
+            collapsed_height: self.collapsed_height,
+            pinned: self.pinned,
+            floating: self.floating,
+            top_padding,
+        });
+
+        SliverPersistentHeader::new(SliverAppBarDelegate {
+            app_bar: self.app_bar.clone(),
+            flexible_space: self.flexible_space.clone(),
+            min_extent,
+            max_extent,
+        })
+        .pinned(self.pinned)
+        .floating(self.floating)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Flutter's default-shape oracle: no expansion, no bottom, no inset —
+    /// the bar is its toolbar in both extents.
+    #[test]
+    fn extents_default_to_the_toolbar() {
+        assert_eq!(
+            extents(&ExtentInputs {
+                toolbar_height: 56.0,
+                bottom_height: 0.0,
+                has_bottom: false,
+                expanded_height: None,
+                collapsed_height: None,
+                pinned: false,
+                floating: false,
+                top_padding: 0.0
+            }),
+            (56.0, 56.0)
+        );
+    }
+
+    /// `maxExtent = max(topPadding + expandedHeight, minExtent)` — an
+    /// expanded height below the collapsed height must not invert the range.
+    #[test]
+    fn a_too_small_expanded_height_clamps_to_collapsed() {
+        assert_eq!(
+            extents(&ExtentInputs {
+                toolbar_height: 56.0,
+                bottom_height: 48.0,
+                has_bottom: true,
+                expanded_height: Some(80.0),
+                collapsed_height: None,
+                pinned: true,
+                floating: false,
+                top_padding: 0.0
+            }),
+            (104.0, 104.0)
+        );
+    }
+
+    /// The pinned + floating + bottom special case: the toolbar floats away
+    /// and only the bottom (plus any explicit collapsed height) stays —
+    /// `app_bar.dart:2092-2093`.
+    #[test]
+    fn pinned_floating_with_bottom_drops_the_toolbar_from_collapsed() {
+        assert_eq!(
+            extents(&ExtentInputs {
+                toolbar_height: 56.0,
+                bottom_height: 48.0,
+                has_bottom: true,
+                expanded_height: Some(200.0),
+                collapsed_height: None,
+                pinned: true,
+                floating: true,
+                top_padding: 0.0
+            }),
+            (48.0, 200.0)
+        );
+        // ...and the ordinary pinned case keeps it.
+        assert_eq!(
+            extents(&ExtentInputs {
+                toolbar_height: 56.0,
+                bottom_height: 48.0,
+                has_bottom: true,
+                expanded_height: Some(200.0),
+                collapsed_height: None,
+                pinned: true,
+                floating: false,
+                top_padding: 0.0
+            }),
+            (104.0, 200.0)
+        );
+    }
+
+    /// The top inset joins BOTH extents — a bar under a status bar is taller
+    /// collapsed and taller expanded by the same amount.
+    #[test]
+    fn top_padding_raises_both_extents() {
+        assert_eq!(
+            extents(&ExtentInputs {
+                toolbar_height: 56.0,
+                bottom_height: 0.0,
+                has_bottom: false,
+                expanded_height: Some(200.0),
+                collapsed_height: None,
+                pinned: true,
+                floating: false,
+                top_padding: 24.0
+            }),
+            (80.0, 224.0)
+        );
+    }
+}

--- a/crates/flui-material/tests/sliver_app_bar.rs
+++ b/crates/flui-material/tests/sliver_app_bar.rs
@@ -111,26 +111,58 @@ fn an_unpinned_bar_uses_the_scrolling_variant() {
     );
 }
 
-/// `flexible_space` fills the bar's box behind the toolbar.
+/// `flexible_space` fills the bar's expanded box AND paints inside the
+/// bar's own Material surface — behind the toolbar, above the background.
+/// The wrong-but-plausible composition (stacking the flexible content as a
+/// SIBLING under the whole AppBar) hides it beneath the opaque surface and
+/// leaves the Material sized to the toolbar strip instead of the box.
 #[test]
-fn flexible_space_fills_the_expanded_box() {
+fn flexible_space_fills_the_expanded_box_inside_the_material_surface() {
     let bar = SliverAppBar::new()
         .title(Text::new("FLUI"))
         .expanded_height(180.0)
         .pinned(true)
-        .flexible_space(SizedBox::expand());
+        .flexible_space(flui_widgets::ColoredBox::new(flui_types::Color::rgb(
+            10, 20, 30,
+        )));
 
     let laid = lay_out(scroll_view_at(0.0, bar), tight(400.0, 600.0));
 
-    let header = laid
-        .find_by_render_type("RenderSliverPinnedPersistentHeader")
-        .expect("header in tree");
-    // The delegate's child is the Stack; its first child is the fill.
-    let stack = laid.only_child(header);
-    let fill = laid.child(stack, 0);
+    let fill = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("the flexible space's render object is in the tree");
     assert_eq!(
         laid.size(fill).height.get(),
         180.0,
         "the flexible space must fill the bar's current extent"
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("the bar's Material surface is in the tree");
+    assert_eq!(
+        laid.size(material).height.get(),
+        180.0,
+        "the Material surface must cover the whole expanded box, not just          the toolbar strip"
+    );
+
+    // Structural pin of the paint order: the flexible space is a DESCENDANT
+    // of the Material, so the opaque background is behind it by
+    // construction. A sibling composition (the bug) fails this.
+    fn subtree_contains(
+        laid: &common::LaidOut,
+        root: flui_foundation::RenderId,
+        needle: flui_foundation::RenderId,
+    ) -> bool {
+        if root == needle {
+            return true;
+        }
+        laid.children(root)
+            .into_iter()
+            .any(|child| subtree_contains(laid, child, needle))
+    }
+    assert!(
+        subtree_contains(&laid, material, fill),
+        "the flexible space must paint INSIDE the bar's Material surface"
     );
 }

--- a/crates/flui-material/tests/sliver_app_bar.rs
+++ b/crates/flui-material/tests/sliver_app_bar.rs
@@ -1,0 +1,136 @@
+//! `SliverAppBar` widget-level integration coverage — mounts a real
+//! collapsing app bar through the full render pipeline (`tests/common/
+//! mod.rs`, matching `tests/app_bar.rs`'s established pattern).
+//!
+//! The extent arithmetic is unit-tested against Flutter's formulas in
+//! `sliver_app_bar.rs` itself; what only a mount can prove is the
+//! composition: the delegate builds the real `AppBar` through the
+//! build-during-layout seam, the header's box tracks the computed extents
+//! as the scroll offset changes, and `pinned` actually holds the collapsed
+//! bar on screen.
+
+mod common;
+use common::{lay_out, tight};
+use flui_material::{SliverAppBar, Theme, ThemeData};
+use flui_view::BoxedView;
+use flui_view::IntoView;
+use flui_view::view::ViewExt;
+use flui_widgets::{
+    CustomScrollView, MediaQuery, MediaQueryData, SizedBox, SliverToBoxAdapter, Text,
+};
+
+fn trailing_content() -> BoxedView {
+    SliverToBoxAdapter::new()
+        .child(SizedBox::new(400.0, 800.0))
+        .into_view()
+        .boxed()
+}
+
+/// The `AppBar` inside the delegate resolves `Theme::of` and (via
+/// `SafeArea`) `MediaQuery::of`, both of which panic with no ancestor —
+/// same provisioning as `tests/app_bar.rs`, with a zero-inset media query
+/// so the extent numbers stay the bare formulas.
+fn scroll_view_at(offset: f32, bar: SliverAppBar) -> Theme {
+    Theme::new(
+        ThemeData::light(),
+        MediaQuery::new(
+            MediaQueryData::default(),
+            CustomScrollView::new((bar, trailing_content())).offset(offset),
+        ),
+    )
+}
+
+/// The header's current main-axis box, read from the delegate-built child
+/// (the child is laid out to the header's layout extent every pass).
+fn header_child_height(laid: &common::LaidOut, render_type: &str) -> f32 {
+    let header = laid
+        .find_by_render_type(render_type)
+        .unwrap_or_else(|| panic!("a {render_type} must be in the tree"));
+    laid.size(laid.only_child(header)).height.get()
+}
+
+/// Fully scrolled to the top, an expanded bar's box is its max extent — and
+/// the real `AppBar` toolbar was built through the seam, in the same frame.
+#[test]
+fn an_expanded_bar_opens_at_its_expanded_height() {
+    let bar = SliverAppBar::new()
+        .title(Text::new("FLUI"))
+        .expanded_height(200.0)
+        .pinned(true);
+
+    let mut laid = lay_out(scroll_view_at(0.0, bar), tight(400.0, 600.0));
+
+    assert_eq!(
+        header_child_height(&laid, "RenderSliverPinnedPersistentHeader"),
+        200.0,
+        "at scroll offset 0 the bar fills its expanded height"
+    );
+    assert_eq!(
+        laid.count_elements_by_view_type::<flui_material::AppBar>(),
+        1,
+        "the delegate must have built the real AppBar through the seam"
+    );
+}
+
+/// Scrolled deep, a pinned bar collapses to — and holds — its collapsed
+/// extent (the toolbar height, with no bottom and no inset).
+#[test]
+fn a_pinned_bar_holds_its_collapsed_height_at_deep_scroll() {
+    let bar = SliverAppBar::new()
+        .title(Text::new("FLUI"))
+        .expanded_height(200.0)
+        .pinned(true);
+
+    let mut laid = lay_out(scroll_view_at(0.0, bar.clone()), tight(400.0, 600.0));
+    laid.pump_widget(scroll_view_at(500.0, bar));
+
+    assert_eq!(
+        header_child_height(&laid, "RenderSliverPinnedPersistentHeader"),
+        56.0,
+        "a pinned bar's box collapses to the toolbar height and stays"
+    );
+}
+
+/// The un-pinned variant maps to the scrolling render object and scrolls
+/// away entirely — the flag choice reaches the render layer.
+#[test]
+fn an_unpinned_bar_uses_the_scrolling_variant() {
+    let bar = SliverAppBar::new().title(Text::new("FLUI"));
+
+    let laid = lay_out(scroll_view_at(0.0, bar), tight(400.0, 600.0));
+
+    assert!(
+        laid.find_by_render_type("RenderSliverScrollingPersistentHeader")
+            .is_some(),
+        "pinned(false)/floating(false) must select the scrolling variant"
+    );
+    assert!(
+        laid.find_by_render_type("RenderSliverPinnedPersistentHeader")
+            .is_none(),
+        "no pinned render object may exist for an unpinned bar"
+    );
+}
+
+/// `flexible_space` fills the bar's box behind the toolbar.
+#[test]
+fn flexible_space_fills_the_expanded_box() {
+    let bar = SliverAppBar::new()
+        .title(Text::new("FLUI"))
+        .expanded_height(180.0)
+        .pinned(true)
+        .flexible_space(SizedBox::expand());
+
+    let laid = lay_out(scroll_view_at(0.0, bar), tight(400.0, 600.0));
+
+    let header = laid
+        .find_by_render_type("RenderSliverPinnedPersistentHeader")
+        .expect("header in tree");
+    // The delegate's child is the Stack; its first child is the fill.
+    let stack = laid.only_child(header);
+    let fill = laid.child(stack, 0);
+    assert_eq!(
+        laid.size(fill).height.get(),
+        180.0,
+        "the flexible space must fill the bar's current extent"
+    );
+}


### PR DESCRIPTION
The composition today's whole persistent-header stack (#697, #700) was built for — and one of the most visible things a UI toolkit either has or does not.

## What it owns, and what it reuses

The toolbar is the existing [`AppBar`] reused whole — leading/title/actions/bottom, M3 theming, the "consumes the top inset itself" contract. The scrolling box is `SliverPersistentHeader` over the four render variants. This widget owns exactly what Flutter's `_SliverAppBarDelegate` owns: the extent arithmetic joining the two, and layering `flexible_space` behind the toolbar.

## Extent math is Flutter's, value-exact

Cross-checked at `app_bar.dart:1339-1345` and `:2092-2094`, including:
- the **pinned+floating+bottom special case** — the toolbar drops out of the collapsed height (it floats away; only the bottom stays pinned);
- the `max(expanded, collapsed)` clamp;
- the top inset raising **both** extents, snapshotted at widget build time because the delegate's extent getters are context-free — the same reason Flutter passes `topPadding` in.

## The one non-obvious composition decision

The delegate's child **expands to the header's current box**. A bare `AppBar` sizes to its toolbar under the header's loose constraints, leaving the expanded region unpainted and `flexible_space` nothing to fill — the geometry tests caught exactly that state before the fix. Flutter's bar paints across its whole expanded area; now so does this one.

## Tests

Unit (4, value-exact against the oracle formulas) + integration (4, mounted through the full pipeline): expanded box at offset 0, pinned collapse held at deep scroll, variant selection reaching the render layer, `flexible_space` filling the extent. The integration debugging also documented two provisioning facts for future material-sliver tests: `Theme::of` and `MediaQuery::of` both panic without ancestors, and the delegate builds inside the layout-service seam where those panics surface as a silently childless header.

## Deferred, with reasons on the widget doc

- **snap** — needs the scroll-end trigger from `Scrollable` (#699); a snap flag today would do nothing
- **stretch / FlexibleSpaceBar** — reachable via a custom delegate's `stretch_configuration`; surfacing it here without a `FlexibleSpaceBar` would stretch a blank region
- **title collapse interpolation** — `FlexibleSpaceBar`'s own widget

`just ci` green (log-verified exit 0); typos/taplo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM