### PR TITLE
feat(widgets): scroll-activity signal on the shared ScrollPosition

### DIFF
--- a/crates/flui-rendering/src/view/scroll_position.rs
+++ b/crates/flui-rendering/src/view/scroll_position.rs
@@ -616,9 +616,17 @@ impl ScrollPosition {
     }
 
     /// Records the user's scroll direction. Listeners fire on change only.
+    ///
+    /// A non-`Idle` direction is only recordable while
+    /// [`Self::is_scrolling`] — outside an active scroll the write is
+    /// ignored, keeping the documented invariant ("`Idle` when none is
+    /// underway") true by construction instead of by caller discipline.
     pub fn set_user_scroll_direction(&self, direction: super::ScrollDirection) {
         let changed = {
             let mut activity = self.inner.activity.lock();
+            if !activity.is_scrolling && direction != super::ScrollDirection::Idle {
+                return;
+            }
             let changed = activity.user_scroll_direction != direction;
             activity.user_scroll_direction = direction;
             changed
@@ -888,11 +896,12 @@ impl ViewportOffset for ScrollPosition {
     }
 
     fn user_scroll_direction(&self) -> ScrollDirection {
-        // Direction tracking is out of scope for this type (see module docs
-        // of the feature this shipped with); `Idle` is the same default
-        // `ScrollableViewportOffset` starts from and never updates without a
-        // setter either.
-        ScrollDirection::Idle
+        // The activity state IS the tracked direction — the render layer
+        // (`RenderViewport::layout_child_sequence` reading this through
+        // `dyn ViewportOffset`) must see the same answer the widget layer
+        // sees, or direction-dependent sliver behavior (a floating header's
+        // reveal) runs on a permanently-Idle constraint.
+        Self::user_scroll_direction(self)
     }
 
     fn allow_implicit_scrolling(&self) -> bool {
@@ -937,6 +946,38 @@ mod tests {
 
         position.set_is_scrolling(false);
         assert_eq!(fired.load(Ordering::SeqCst), 3);
+    }
+
+    /// The render layer reads direction through `dyn ViewportOffset`
+    /// (`RenderViewport::layout_child_sequence`) — it must see the SAME
+    /// tracked value the widget layer sees, not a hardwired `Idle` that
+    /// leaves direction-dependent sliver behavior permanently inert.
+    #[test]
+    fn the_viewport_offset_view_reports_the_tracked_direction() {
+        let position = ScrollPosition::zero();
+        position.set_is_scrolling(true);
+        position.set_user_scroll_direction(super::super::ScrollDirection::Reverse);
+
+        let through_trait: &dyn super::super::ViewportOffset = &position; // PORT-CHECK-OK-DYN: the test's whole point is the TRAIT-OBJECT view — RenderViewport holds exactly this erasure, and the bug being pinned was visible only through it
+        assert_eq!(
+            through_trait.user_scroll_direction(),
+            super::super::ScrollDirection::Reverse,
+            "the trait view must not shadow the tracked direction"
+        );
+    }
+
+    /// A non-Idle direction while nothing is scrolling would violate the
+    /// documented invariant — the write is ignored, so the invariant holds
+    /// by construction rather than by caller discipline.
+    #[test]
+    fn a_direction_written_outside_a_scroll_is_ignored() {
+        let position = ScrollPosition::zero();
+        position.set_user_scroll_direction(super::super::ScrollDirection::Forward);
+        assert_eq!(
+            position.user_scroll_direction(),
+            super::super::ScrollDirection::Idle,
+            "no scroll is underway, so the direction must stay Idle"
+        );
     }
 
     /// Ending a scroll resets the user direction to Idle — Flutter's

--- a/crates/flui-rendering/src/view/scroll_position.rs
+++ b/crates/flui-rendering/src/view/scroll_position.rs
@@ -243,6 +243,23 @@ struct Inner {
     /// (`Arc::ptr_eq` removal, not a `ListenerId`).
     offset_listeners: Mutex<Vec<Arc<dyn Fn() + Send + Sync>>>,
     flush: Mutex<FlushState>,
+    /// Scroll-activity state — whether a user drag or ballistic fling is
+    /// underway, and which way the user last scrolled. Kept apart from
+    /// `state` (which is pixel geometry) and notified through its own
+    /// sink: activity subscribers (a floating header's snap trigger) must
+    /// not be woken by every pixel change, and pixel subscribers must not
+    /// be woken by drag start/stop.
+    activity: Mutex<ActivityState>,
+    /// Notified on every [`ActivityState`] transition — Flutter's
+    /// `isScrollingNotifier` + `UserScrollNotification`, fused into one
+    /// sink because every known consumer (snap) wants both.
+    activity_notifier: ChangeNotifier,
+}
+
+#[derive(Default)]
+struct ActivityState {
+    is_scrolling: bool,
+    user_scroll_direction: super::ScrollDirection,
 }
 
 impl Inner {
@@ -379,6 +396,8 @@ impl ScrollPosition {
                 notifier: ChangeNotifier::new(),
                 offset_listeners: Mutex::new(Vec::new()),
                 flush: Mutex::new(FlushState::new()),
+                activity: Mutex::new(ActivityState::default()),
+                activity_notifier: ChangeNotifier::new(),
             }),
         }
     }
@@ -556,6 +575,74 @@ impl ScrollPosition {
     /// `set_pixels` path, which never schedules one.
     pub fn notify(&self) {
         self.inner.notify();
+    }
+
+    // ========== Scroll activity (Flutter: isScrollingNotifier) ==========
+
+    /// Whether a user drag or ballistic fling is currently underway.
+    #[must_use]
+    pub fn is_scrolling(&self) -> bool {
+        self.inner.activity.lock().is_scrolling
+    }
+
+    /// Records that scrolling started or stopped. Activity listeners fire on
+    /// the TRANSITION only — a same-value write is silent, so a caller may
+    /// set unconditionally at each gesture edge without spamming subscribers.
+    ///
+    /// Stopping also resets [`Self::user_scroll_direction`] to `Idle`,
+    /// mirroring Flutter's `ScrollPosition.didEndScroll`.
+    pub fn set_is_scrolling(&self, is_scrolling: bool) {
+        let changed = {
+            let mut activity = self.inner.activity.lock();
+            let changed = activity.is_scrolling != is_scrolling;
+            activity.is_scrolling = is_scrolling;
+            if changed && !is_scrolling {
+                activity.user_scroll_direction = super::ScrollDirection::Idle;
+            }
+            changed
+        };
+        // Lock released before listeners run — a subscriber reading the
+        // activity back must not deadlock.
+        if changed {
+            self.inner.activity_notifier.notify_listeners();
+        }
+    }
+
+    /// The direction of the user's current scroll, `Idle` when none is
+    /// underway.
+    #[must_use]
+    pub fn user_scroll_direction(&self) -> super::ScrollDirection {
+        self.inner.activity.lock().user_scroll_direction
+    }
+
+    /// Records the user's scroll direction. Listeners fire on change only.
+    pub fn set_user_scroll_direction(&self, direction: super::ScrollDirection) {
+        let changed = {
+            let mut activity = self.inner.activity.lock();
+            let changed = activity.user_scroll_direction != direction;
+            activity.user_scroll_direction = direction;
+            changed
+        };
+        if changed {
+            self.inner.activity_notifier.notify_listeners();
+        }
+    }
+
+    /// Subscribe to activity transitions (scrolling started/stopped, user
+    /// direction changed). The pixel [`Listenable`] is deliberately a
+    /// different sink — see the `activity` field's own doc.
+    pub fn add_activity_listener(
+        &self,
+        listener: flui_foundation::ListenerCallback,
+    ) -> flui_foundation::ListenerId {
+        use flui_foundation::Listenable as _;
+        self.inner.activity_notifier.add_listener(listener)
+    }
+
+    /// Remove an activity subscription.
+    pub fn remove_activity_listener(&self, id: flui_foundation::ListenerId) {
+        use flui_foundation::Listenable as _;
+        self.inner.activity_notifier.remove_listener(id);
     }
 
     /// Notifies exactly once, synchronously — consuming any coalesced-flush
@@ -826,6 +913,53 @@ impl ViewportOffset for ScrollPosition {
 
 #[cfg(test)]
 mod tests {
+
+    /// Activity listeners fire on TRANSITIONS only: a same-value write is
+    /// silent, so gesture code may set unconditionally at each edge without
+    /// spamming a snap trigger with no-op wakeups.
+    #[test]
+    fn activity_listeners_fire_on_transitions_only() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let position = ScrollPosition::zero();
+        let fired = std::sync::Arc::new(AtomicUsize::new(0));
+        let sink = std::sync::Arc::clone(&fired);
+        position.add_activity_listener(std::sync::Arc::new(move || {
+            sink.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        position.set_is_scrolling(true);
+        position.set_is_scrolling(true); // same value: silent
+        assert_eq!(fired.load(Ordering::SeqCst), 1);
+
+        position.set_user_scroll_direction(super::super::ScrollDirection::Reverse);
+        position.set_user_scroll_direction(super::super::ScrollDirection::Reverse);
+        assert_eq!(fired.load(Ordering::SeqCst), 2);
+
+        position.set_is_scrolling(false);
+        assert_eq!(fired.load(Ordering::SeqCst), 3);
+    }
+
+    /// Ending a scroll resets the user direction to Idle — Flutter's
+    /// `didEndScroll` contract. A stale Forward left behind would make the
+    /// NEXT snap decision from a direction the user is no longer moving in.
+    #[test]
+    fn stopping_resets_the_user_direction_to_idle() {
+        let position = ScrollPosition::zero();
+        position.set_is_scrolling(true);
+        position.set_user_scroll_direction(super::super::ScrollDirection::Forward);
+        assert_eq!(
+            position.user_scroll_direction(),
+            super::super::ScrollDirection::Forward
+        );
+
+        position.set_is_scrolling(false);
+        assert!(!position.is_scrolling());
+        assert_eq!(
+            position.user_scroll_direction(),
+            super::super::ScrollDirection::Idle,
+            "ending the scroll must not leave a stale direction behind"
+        );
+    }
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use flui_scheduler::UpdateScheduler;

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -373,9 +373,6 @@ impl ScrollableState {
         if let Some(id) = self.fling_listener_id.take() {
             self.fling_controller.remove_listener(id);
         }
-        if let Some(id) = self.fling_status_listener_id.take() {
-            self.fling_controller.remove_status_listener(id);
-        }
         let fling_ref = self.fling_controller.clone();
         let scroll_ref = self.scroll_controller.clone();
         let listener_id = self.fling_controller.add_listener(Arc::new(move || {
@@ -604,6 +601,17 @@ impl ViewState<Scrollable> for ScrollableState {
         // stay in sync if a parent rebuild hands us a new configuration —
         // both re-installs below always read `self.scroll_controller` as
         // just updated here.
+        // A swapped-out position is no longer scrolled by this scrollable:
+        // end its activity NOW, or a swap mid-drag/mid-fling leaves the old
+        // position's `is_scrolling` stuck true forever (its status listener
+        // is about to be moved onto the new controller's position).
+        if !self
+            .scroll_controller
+            .position()
+            .ptr_eq(&new_view.controller.position())
+        {
+            self.scroll_controller.position().set_is_scrolling(false);
+        }
         self.scroll_controller = new_view.controller.clone();
 
         // Re-install the fling value listener on the (possibly new)
@@ -629,6 +637,12 @@ impl ViewState<Scrollable> for ScrollableState {
     }
 
     fn dispose(&mut self) {
+        // An unmount mid-drag or mid-ballistic-run must not leave the shared
+        // position claiming a scroll is underway — end the activity FIRST,
+        // while this state still knows which position it was driving (the
+        // status listener below is about to be detached and could never
+        // deliver the settle).
+        self.scroll_controller.position().set_is_scrolling(false);
         // Remove the value listener before disposing the controller so the
         // listener closure cannot fire after the state is gone.
         if let Some(id) = self.fling_listener_id.take() {

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -52,10 +52,10 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use flui_animation::{Animation, AnimationController, Vsync, VsyncRegistration};
+use flui_animation::{Animation, AnimationController, AnimationStatus, Vsync, VsyncRegistration};
 use flui_foundation::{Listenable, ListenerId};
 use flui_rendering::hit_testing::HitTestBehavior;
-use flui_rendering::view::ScrollPosition;
+use flui_rendering::view::{ScrollDirection, ScrollPosition};
 use flui_types::layout::{Axis, AxisDirection};
 use flui_view::prelude::StatefulView;
 use flui_view::{BoxedView, BuildContext, BuildContextExt, Child, IntoView, ViewExt, ViewState};
@@ -276,6 +276,10 @@ pub struct ScrollableState {
     /// controller swap moves it onto the new controller), removed in
     /// `dispose`.
     fling_listener_id: Option<ListenerId>,
+    /// Status-listener ID on `fling_controller` that marks the shared
+    /// `ScrollPosition` idle when the ballistic run settles or is stopped.
+    /// Same install/remove lifecycle as `fling_listener_id`.
+    fling_status_listener_id: Option<ListenerId>,
     /// Vsync handle kept for `unregister` in `dispose`.
     vsync: Option<Vsync>,
     /// Registration handle returned by `vsync.register(fling_controller)`.
@@ -312,6 +316,7 @@ impl StatefulView for Scrollable {
             scroll_controller: self.controller.clone(),
             fling_controller,
             fling_listener_id: None,
+            fling_status_listener_id: None,
             vsync: None,
             vsync_registration: None,
         }
@@ -368,12 +373,38 @@ impl ScrollableState {
         if let Some(id) = self.fling_listener_id.take() {
             self.fling_controller.remove_listener(id);
         }
+        if let Some(id) = self.fling_status_listener_id.take() {
+            self.fling_controller.remove_status_listener(id);
+        }
         let fling_ref = self.fling_controller.clone();
         let scroll_ref = self.scroll_controller.clone();
         let listener_id = self.fling_controller.add_listener(Arc::new(move || {
             scroll_ref.set_pixels(fling_ref.value());
         }));
         self.fling_listener_id = Some(listener_id);
+    }
+
+    /// Installs the status listener that ends the position's scroll
+    /// activity when the ballistic run settles (`Completed`) or is stopped
+    /// by a grab or teardown (`Dismissed`). The activity signal is what a
+    /// floating header's snap trigger listens to — without this half, a
+    /// fling would leave `is_scrolling` stuck true forever.
+    fn install_fling_status_listener(&mut self) {
+        if let Some(id) = self.fling_status_listener_id.take() {
+            self.fling_controller.remove_status_listener(id);
+        }
+        let position = self.scroll_controller.position();
+        let listener_id = self
+            .fling_controller
+            .add_status_listener(Arc::new(move |status| {
+                if matches!(
+                    status,
+                    AnimationStatus::Completed | AnimationStatus::Dismissed
+                ) {
+                    position.set_is_scrolling(false);
+                }
+            }));
+        self.fling_status_listener_id = Some(listener_id);
     }
 }
 
@@ -382,6 +413,7 @@ impl ViewState<Scrollable> for ScrollableState {
         self.install_flush_handle(ctx);
         self.install_stop_hook();
         self.install_fling_listener();
+        self.install_fling_status_listener();
 
         // Register with the ambient VsyncScope so the binding ticks the fling
         // controller on each virtual frame — the same pattern used by
@@ -458,6 +490,9 @@ impl ViewState<Scrollable> for ScrollableState {
             // Flutter parity: Scrollable uses HitTestBehavior::Opaque so the
             // gesture area fires regardless of whether the child content is
             // itself hittable (e.g. an empty SizedBox).
+            let position_start = ctrl_update.position();
+            let position_update = ctrl_update.position();
+            let position_end = ctrl_update.position();
             GestureDetector::new()
                 .behavior(HitTestBehavior::Opaque)
                 .on_pan_start(move |_details| {
@@ -465,6 +500,11 @@ impl ViewState<Scrollable> for ScrollableState {
                     // finger's contact position (Flutter parity — ScrollPosition
                     // calls `activity.cancel()` on `handleDragStart`).
                     let _ = fling_stop.stop();
+                    // AFTER the stop: stopping fires the status listener,
+                    // which marks the position idle — the grab that begins a
+                    // new drag must win that ordering, or a fling-into-drag
+                    // hand-off would flicker the activity signal off.
+                    position_start.set_is_scrolling(true);
                 })
                 .on_pan_update(move |details| {
                     // Flutter convention: a downward/rightward finger drag
@@ -488,6 +528,14 @@ impl ViewState<Scrollable> for ScrollableState {
                     } else {
                         raw_delta
                     };
+                    // The user's direction, for activity subscribers (a
+                    // floating header's snap decision): a positive signed
+                    // delta moves the offset toward the start — Forward.
+                    if signed_delta > 0.0 {
+                        position_update.set_user_scroll_direction(ScrollDirection::Forward);
+                    } else if signed_delta < 0.0 {
+                        position_update.set_user_scroll_direction(ScrollDirection::Reverse);
+                    }
                     let proposed = ctrl_update.pixels() - signed_delta;
                     let metrics = ScrollMetrics::from(&ctrl_update.position());
                     let clamped = phys_update.apply_boundary_conditions(&metrics, proposed);
@@ -537,7 +585,14 @@ impl ViewState<Scrollable> for ScrollableState {
                         // `Box<dyn Simulation>` implements `Simulation` via the
                         // blanket impl in `flui-animation`, so it can be passed
                         // directly as `S: Simulation + 'static`.
+                        // Scrolling continues through the ballistic run; the
+                        // fling controller's status listener marks the
+                        // position idle when it settles.
                         let _ = fling_start.animate_with(sim);
+                    } else {
+                        // No ballistic run: the release IS the end of
+                        // scrolling.
+                        position_end.set_is_scrolling(false);
                     }
                 })
                 .child(scroll_view)
@@ -561,6 +616,7 @@ impl ViewState<Scrollable> for ScrollableState {
         // would ever copy it into the new controller's own `ScrollPosition`
         // — its pixels would never move.
         self.install_fling_listener();
+        self.install_fling_status_listener();
 
         // Re-install the stop hook on the (possibly new) controller —
         // `install_stop_hook` is idempotent (see its doc), so this is cheap
@@ -577,6 +633,9 @@ impl ViewState<Scrollable> for ScrollableState {
         // listener closure cannot fire after the state is gone.
         if let Some(id) = self.fling_listener_id.take() {
             self.fling_controller.remove_listener(id);
+        }
+        if let Some(id) = self.fling_status_listener_id.take() {
+            self.fling_controller.remove_status_listener(id);
         }
         // Release the vsync registration so the binding does not hold a
         // reference to the disposed controller.

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -17,6 +17,7 @@ use crate::common::{LaidOut, lay_out, offset, size, tight};
 use flui_animation::{Curves, Vsync};
 use flui_interaction::events::{PointerEvent, PointerEventExt as _};
 use flui_rendering::constraints::BoxConstraints;
+use flui_rendering::view::ScrollDirection;
 use flui_types::Color;
 use flui_types::geometry::px;
 use flui_view::prelude::StatelessView;
@@ -2400,5 +2401,100 @@ fn hit_through_a_visible_sliver_offstage_reaches_its_child_at_the_correct_positi
             .expect("on_pointer_down must have fired through the visible SliverOffstage"),
         local_point,
         "sliver->sliver override arm (RenderSliverOffstage): tap must localize to the child's own box",
+    );
+}
+
+// ============================================================================
+// Scrollable — scroll-activity signal (Flutter: isScrollingNotifier)
+// ============================================================================
+
+/// The scroll-activity signal across a full gesture: idle before, live
+/// from the grab with the user's direction recorded, live through the
+/// ballistic run past the release, and idle again — direction reset — once
+/// the run settles. The signal a floating header's snap trigger keys on.
+#[test]
+fn scroll_activity_tracks_the_whole_gesture_lifecycle() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+    let position = controller.position();
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    assert!(!position.is_scrolling(), "idle before any gesture");
+    assert_eq!(position.user_scroll_direction(), ScrollDirection::Idle);
+
+    scoped.dispatch_pointer_down(150.0, 250.0);
+    scoped.dispatch_pointer_move(150.0, 180.0); // slop-crossing: on_pan_start
+    assert!(
+        position.is_scrolling(),
+        "the grab begins the scroll activity"
+    );
+    scoped.dispatch_pointer_move(150.0, 150.0); // on_pan_update
+    assert_eq!(
+        position.user_scroll_direction(),
+        ScrollDirection::Reverse,
+        "an upward finger drag increases the offset — Reverse"
+    );
+    scoped.dispatch_pointer_up(150.0, 150.0);
+
+    // Whether the release produced a ballistic run (fast release) or not,
+    // the signal must return to idle once everything settles; the bounded
+    // pump keeps a stuck-true regression a loud failure, not a hang.
+    let mut frames = 0;
+    while position.is_scrolling() && frames < 2_000 {
+        scoped.pump_for(Duration::from_millis(16));
+        frames += 1;
+    }
+    assert!(
+        !position.is_scrolling(),
+        "the activity must end after the release settles (still scrolling \
+         after {frames} frames)"
+    );
+    assert_eq!(
+        position.user_scroll_direction(),
+        ScrollDirection::Idle,
+        "ending the scroll resets the direction"
+    );
+}
+
+/// A fling keeps the activity alive through the ballistic run and ends it
+/// when the simulation settles — the status-listener half of the signal.
+/// Without it, `is_scrolling` would stick true forever after any fling.
+#[test]
+fn a_fling_keeps_scrolling_until_the_ballistic_run_settles() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+    let position = controller.position();
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    scoped.dispatch_pointer_down(150.0, 250.0);
+    scoped.dispatch_pointer_move(150.0, 180.0);
+    scoped.dispatch_pointer_move(150.0, 150.0);
+    scoped.dispatch_pointer_up(150.0, 150.0);
+
+    assert!(
+        position.is_scrolling(),
+        "the ballistic run keeps the activity alive past the release"
+    );
+
+    // Drive frames until the friction simulation settles (bounded so a
+    // never-settling regression fails loudly instead of hanging).
+    let mut frames = 0;
+    while position.is_scrolling() && frames < 2_000 {
+        scoped.pump_for(Duration::from_millis(16));
+        frames += 1;
+    }
+    assert!(
+        !position.is_scrolling(),
+        "the fling's completion must end the activity (still scrolling after {frames} frames)"
     );
 }


### PR DESCRIPTION
The first half of #699's snap seam — the signal a floating header's snap trigger listens to.

## Shape

Flutter's `isScrollingNotifier` + `userScrollDirection`, fused onto FLUI's shared `ScrollPosition` as `is_scrolling` / `user_scroll_direction` with a **dedicated activity notifier**: a snap trigger must not be woken by every scroll pixel, and pixel subscribers must not be woken by drag edges. Transitions notify; same-value writes are silent, so gesture code sets unconditionally at each edge without spamming subscribers. Ending a scroll resets the direction to `Idle` (Flutter's `didEndScroll`).

## Scrollable drives all four edges

- **grab** (`on_pan_start`) marks scrolling — deliberately *after* the fling stop, whose status listener marks idle, so a fling-into-drag hand-off cannot flicker the signal off;
- **drag** (`on_pan_update`) records the user direction from the signed delta;
- **release with no ballistic run** ends the activity at the release;
- **fling** keeps it alive until the run settles, via a status listener on the fling controller with the same install / re-install-on-controller-swap / dispose lifecycle as the existing value listener.

## Tests

| test | red evidence |
|---|---|
| `activity_listeners_fire_on_transitions_only` (unit) | count-exact |
| `stopping_resets_the_user_direction_to_idle` (unit) | value-exact |
| `scroll_activity_tracks_the_whole_gesture_lifecycle` (gesture-driven) | grab mark removed → fails at "the grab begins the scroll activity" |
| `a_fling_keeps_scrolling_until_the_ballistic_run_settles` (gesture-driven) | status listener removed → `is_scrolling` stuck true, bounded settle loop fails loudly |

The lifecycle test is deliberately release-path-agnostic (either the no-fling branch or the settle path may end it, both are asserted to *end* it) — the velocity tracker's window makes a guaranteed zero-velocity release harness-dependent, and a wall-clock-sleep construction would violate the repo's own no-flakiness rule.

## What follows (remaining #699 snap work)

The material-side listener (feed `update_scroll_start_direction` + `maybe_start_snap_animation` from these transitions) and controller injection into the floating render objects.

`just ci` green (log-verified exit 0), typos clean.

Refs #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM