### PR TITLE
feat(widgets): floating-header snap, end to end — and SliverAppBar.snap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "criterion",
  "downcast-rs 2.0.2",
  "dyn-clone",
+ "flui-animation",
  "flui-foundation",
  "flui-interaction",
  "flui-macros",

--- a/crates/flui-material/src/sliver_app_bar.rs
+++ b/crates/flui-material/src/sliver_app_bar.rs
@@ -307,12 +307,11 @@ impl SliverPersistentHeaderDelegate for SliverAppBarDelegate {
 
     fn snap_configuration(&self) -> Option<flui_widgets::FloatingHeaderSnapConfiguration> {
         // The oracle's own defaults (`FloatingHeaderSnapConfiguration`,
-        // `rendering/sliver_persistent_header.dart:488-491`): Curves.ease —
-        // cubic(0.25, 0.1, 0.25, 1.0) — over 300ms. FLUI's `Curves` table
-        // has no plain `Ease` constant, so the cubic is spelled out.
+        // `rendering/sliver_persistent_header.dart:488-491`): Curves.ease
+        // over 300ms.
         self.snap.then(|| {
             flui_widgets::FloatingHeaderSnapConfiguration::new(
-                flui_animation::ArcCurve::new(flui_animation::Cubic::new(0.25, 0.1, 0.25, 1.0)),
+                flui_animation::ArcCurve::new(flui_animation::Curves::Ease),
                 std::time::Duration::from_millis(300),
             )
         })

--- a/crates/flui-material/src/sliver_app_bar.rs
+++ b/crates/flui-material/src/sliver_app_bar.rs
@@ -18,10 +18,6 @@
 //!
 //! # Deferred, deliberately
 //!
-//! - **Snap** — starting a snap animation needs a scroll-end trigger from
-//!   the enclosing scrollable, which does not exist yet; see the
-//!   persistent-header widget's own note. A `snap` flag here today would do
-//!   nothing.
 //! - **Stretch and `FlexibleSpaceBar`** — over-scroll stretch is reachable
 //!   through a custom [`SliverPersistentHeaderDelegate`]'s
 //!   `stretch_configuration`; surfacing it here without a
@@ -63,6 +59,7 @@ use crate::AppBar;
 #[derive(Clone, StatelessView)]
 pub struct SliverAppBar {
     app_bar: AppBar,
+    snap: bool,
     /// Mirrors of the inner app bar's height inputs, kept here because the
     /// extent arithmetic needs them and [`AppBar`] does not expose getters.
     toolbar_height: f32,
@@ -81,6 +78,7 @@ impl SliverAppBar {
     pub fn new() -> Self {
         Self {
             app_bar: AppBar::new(),
+            snap: false,
             toolbar_height: crate::app_bar::DEFAULT_TOOLBAR_HEIGHT,
             bottom_height: 0.0,
             has_bottom: false,
@@ -205,6 +203,17 @@ impl SliverAppBar {
         self.floating = floating;
         self
     }
+
+    /// Snap a [`floating`](Self::floating) bar fully open when a scroll
+    /// gesture toward the start ends, instead of leaving it partially
+    /// revealed. Ignored unless `floating` is also set, matching Flutter's
+    /// contract. The animation uses the oracle's defaults (`Curves.ease`,
+    /// 300ms — `rendering/sliver_persistent_header.dart:488-491`).
+    #[must_use]
+    pub fn snap(mut self, snap: bool) -> Self {
+        self.snap = snap;
+        self
+    }
 }
 
 impl Default for SliverAppBar {
@@ -267,6 +276,7 @@ struct SliverAppBarDelegate {
     app_bar: AppBar,
     min_extent: f32,
     max_extent: f32,
+    snap: bool,
 }
 
 impl SliverPersistentHeaderDelegate for SliverAppBarDelegate {
@@ -294,6 +304,19 @@ impl SliverPersistentHeaderDelegate for SliverAppBarDelegate {
     fn max_extent(&self) -> f32 {
         self.max_extent
     }
+
+    fn snap_configuration(&self) -> Option<flui_widgets::FloatingHeaderSnapConfiguration> {
+        // The oracle's own defaults (`FloatingHeaderSnapConfiguration`,
+        // `rendering/sliver_persistent_header.dart:488-491`): Curves.ease —
+        // cubic(0.25, 0.1, 0.25, 1.0) — over 300ms. FLUI's `Curves` table
+        // has no plain `Ease` constant, so the cubic is spelled out.
+        self.snap.then(|| {
+            flui_widgets::FloatingHeaderSnapConfiguration::new(
+                flui_animation::ArcCurve::new(flui_animation::Cubic::new(0.25, 0.1, 0.25, 1.0)),
+                std::time::Duration::from_millis(300),
+            )
+        })
+    }
 }
 
 impl StatelessView for SliverAppBar {
@@ -316,6 +339,7 @@ impl StatelessView for SliverAppBar {
             app_bar: self.app_bar.clone(),
             min_extent,
             max_extent,
+            snap: self.snap,
         })
         .pinned(self.pinned)
         .floating(self.floating)

--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -93,6 +93,6 @@ pub use sliver::{
     RenderSliverFloatingPinnedPersistentHeader, RenderSliverGrid, RenderSliverGridLazy,
     RenderSliverIgnorePointer, RenderSliverList, RenderSliverListLazy, RenderSliverOffstage,
     RenderSliverOpacity, RenderSliverPadding, RenderSliverPinnedPersistentHeader,
-    RenderSliverScrollingPersistentHeader, RenderSliverToBoxAdapter, RenderViewport, SnapCommand,
-    StretchTriggerSignal,
+    RenderSliverScrollingPersistentHeader, RenderSliverToBoxAdapter, RenderViewport, SnapAction,
+    SnapCommand, StretchTriggerSignal,
 };

--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -93,6 +93,6 @@ pub use sliver::{
     RenderSliverFloatingPinnedPersistentHeader, RenderSliverGrid, RenderSliverGridLazy,
     RenderSliverIgnorePointer, RenderSliverList, RenderSliverListLazy, RenderSliverOffstage,
     RenderSliverOpacity, RenderSliverPadding, RenderSliverPinnedPersistentHeader,
-    RenderSliverScrollingPersistentHeader, RenderSliverToBoxAdapter, RenderViewport,
+    RenderSliverScrollingPersistentHeader, RenderSliverToBoxAdapter, RenderViewport, SnapCommand,
     StretchTriggerSignal,
 };

--- a/crates/flui-objects/src/sliver/mod.rs
+++ b/crates/flui-objects/src/sliver/mod.rs
@@ -30,7 +30,7 @@ pub use sliver_padding::*;
 pub use sliver_persistent_header::{
     FloatingHeaderSnapConfiguration, OverScrollHeaderStretchConfiguration,
     RenderSliverFloatingPersistentHeader, RenderSliverFloatingPinnedPersistentHeader,
-    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader,
+    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader, SnapCommand,
     StretchTriggerSignal,
 };
 pub use sliver_to_box_adapter::*;

--- a/crates/flui-objects/src/sliver/mod.rs
+++ b/crates/flui-objects/src/sliver/mod.rs
@@ -30,8 +30,8 @@ pub use sliver_padding::*;
 pub use sliver_persistent_header::{
     FloatingHeaderSnapConfiguration, OverScrollHeaderStretchConfiguration,
     RenderSliverFloatingPersistentHeader, RenderSliverFloatingPinnedPersistentHeader,
-    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader, SnapCommand,
-    StretchTriggerSignal,
+    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader, SnapAction,
+    SnapCommand, StretchTriggerSignal,
 };
 pub use sliver_to_box_adapter::*;
 pub use viewport::*;

--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -181,7 +181,7 @@ impl fmt::Debug for StretchTriggerSignal {
 /// A widget-layer instruction for a floating header to consider snapping,
 /// stamped with a monotone epoch so redelivery through view updates is
 /// idempotent — see
-/// [`RenderSliverFloatingHeaderBase::apply_snap_command`].
+/// `apply_snap_command` on the floating header render objects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SnapCommand {
     /// Strictly increasing per issuing widget; an epoch not newer than the

--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -178,7 +178,7 @@ impl fmt::Debug for StretchTriggerSignal {
     }
 }
 
-/// A widget-layer instruction for a floating header to consider snapping,
+/// A widget-layer instruction for a floating header's snap machinery,
 /// stamped with a monotone epoch so redelivery through view updates is
 /// idempotent — see
 /// `apply_snap_command` on the floating header render objects.
@@ -187,9 +187,21 @@ pub struct SnapCommand {
     /// Strictly increasing per issuing widget; an epoch not newer than the
     /// last applied one is refused.
     pub epoch: u64,
-    /// The direction of the user scroll that just ended — decides whether
-    /// the header settles open (`Forward`) or closed (`Reverse`).
-    pub direction: ScrollDirection,
+    /// What the snap machinery should do.
+    pub action: SnapAction,
+}
+
+/// The two things a scroll edge asks of a floating header's snap machinery —
+/// mirroring the two calls Flutter's `_isScrollingListener` makes
+/// (`widgets/sliver_persistent_header.dart:202-244`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapAction {
+    /// A user scroll ended moving in `ScrollDirection`: settle the reveal
+    /// to the nearest edge (fully open for `Forward`).
+    Settle(ScrollDirection),
+    /// A new user scroll began: an in-flight snap must yield to the finger
+    /// immediately.
+    Stop,
 }
 
 /// Specifies how a stretched header reports overscroll trigger crossings.
@@ -1122,8 +1134,18 @@ impl<M: FloatingHeaderMode> RenderSliverFloatingHeaderBase<M> {
             return;
         }
         self.last_snap_epoch = command.epoch;
-        self.update_scroll_start_direction(command.direction);
-        self.maybe_start_snap_animation(command.direction);
+        match command.action {
+            SnapAction::Settle(direction) => {
+                self.update_scroll_start_direction(direction);
+                self.maybe_start_snap_animation(direction);
+            }
+            SnapAction::Stop => {
+                // The direction parameter mirrors the oracle's signature but
+                // is unused by the stop path — Idle is the honest value for
+                // "a new gesture, direction not yet known".
+                self.maybe_stop_snap_animation(ScrollDirection::Idle);
+            }
+        }
     }
 
     /// Injects (or withdraws) the controller that drives snap and

--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -178,6 +178,20 @@ impl fmt::Debug for StretchTriggerSignal {
     }
 }
 
+/// A widget-layer instruction for a floating header to consider snapping,
+/// stamped with a monotone epoch so redelivery through view updates is
+/// idempotent — see
+/// [`RenderSliverFloatingHeaderBase::apply_snap_command`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapCommand {
+    /// Strictly increasing per issuing widget; an epoch not newer than the
+    /// last applied one is refused.
+    pub epoch: u64,
+    /// The direction of the user scroll that just ended — decides whether
+    /// the header settles open (`Forward`) or closed (`Reverse`).
+    pub direction: ScrollDirection,
+}
+
 /// Specifies how a stretched header reports overscroll trigger crossings.
 ///
 /// Flutter parity: `OverScrollHeaderStretchConfiguration` (`:33-46`). The
@@ -1001,6 +1015,9 @@ pub struct RenderSliverFloatingHeaderBase<M: FloatingHeaderMode> {
     /// [`Self::update_scroll_start_direction`], never internally driven in
     /// this pass (see module docs).
     last_started_scroll_direction: Option<ScrollDirection>,
+    /// The last [`SnapCommand::epoch`] applied — see
+    /// [`Self::apply_snap_command`]'s idempotency contract.
+    last_snap_epoch: u64,
     /// Cached return value of `update_geometry`, mirroring `_childPosition`.
     child_position: Option<f32>,
     /// Value-change subscription on `controller`, torn down in `detach`.
@@ -1023,6 +1040,7 @@ impl<M: FloatingHeaderMode> RenderSliverFloatingHeaderBase<M> {
             last_actual_scroll_offset: None,
             effective_scroll_offset: None,
             last_started_scroll_direction: None,
+            last_snap_epoch: 0,
             child_position: None,
             listener_id: None,
             _mode: PhantomData,
@@ -1087,6 +1105,25 @@ impl<M: FloatingHeaderMode> RenderSliverFloatingHeaderBase<M> {
     /// plain-assignment `snapConfiguration` field) — no dirty-marking.
     pub fn set_snap_configuration(&mut self, snap: Option<FloatingHeaderSnapConfiguration>) {
         self.snap_configuration = snap;
+    }
+
+    /// Applies a widget-layer snap command exactly once per epoch.
+    ///
+    /// The command rides the VIEW through the canonical
+    /// `update_render_object` path (so no caller ever mutates this render
+    /// object outside the frame's own update step), and updates re-deliver
+    /// whatever command the view currently carries — the epoch is what
+    /// makes redelivery idempotent. A command with an epoch not NEWER than
+    /// the last applied one is refused, never re-run: an update pass
+    /// rebuilding the view for an unrelated reason must not restart a snap
+    /// the user has since interrupted.
+    pub fn apply_snap_command(&mut self, command: SnapCommand) {
+        if command.epoch <= self.last_snap_epoch {
+            return;
+        }
+        self.last_snap_epoch = command.epoch;
+        self.update_scroll_start_direction(command.direction);
+        self.maybe_start_snap_animation(command.direction);
     }
 
     /// Injects (or withdraws) the controller that drives snap and

--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -1089,6 +1089,20 @@ impl<M: FloatingHeaderMode> RenderSliverFloatingHeaderBase<M> {
         self.snap_configuration = snap;
     }
 
+    /// Injects (or withdraws) the controller that drives snap and
+    /// programmatic-expand animations.
+    ///
+    /// Constructor-time injection covers a header built where a vsync is in
+    /// hand; this setter covers the element-driven path, where the render
+    /// object is created first and the element registers a controller with
+    /// its ambient vsync afterwards. `None` returns
+    /// [`Self::maybe_start_snap_animation`] to its documented inert state;
+    /// any in-flight animation keeps its own already-cloned controller and
+    /// settles normally.
+    pub fn set_snap_controller(&mut self, controller: Option<AnimationController>) {
+        self.controller = controller;
+    }
+
     /// The scroll offset currently driving the header's shrink/reveal state
     /// (post-clamp, as tracked by the re-reveal state machine). `None` before
     /// the first layout.

--- a/crates/flui-view/Cargo.toml
+++ b/crates/flui-view/Cargo.toml
@@ -23,6 +23,10 @@ flui-rendering = { path = "../flui-rendering", version = "0.2.0" }
 # Owner-routed interaction targets/dispatch handles (ADR-0027).
 flui-interaction = { path = "../flui-interaction", version = "0.2.0" }
 # Concrete render-object catalog (moved out of flui-rendering per ADR-0008).
+# Snap/expand controller plumb-through for the floating persistent headers:
+# the WIDGET layer owns the controller lifecycle (vsync lives there); this
+# crate only carries the already-built controller into the render object.
+flui-animation = { path = "../flui-animation", version = "0.2.0" }
 flui-objects = { path = "../flui-objects", version = "0.2.0" }
 # The frame-driven async task driver. A `ViewState` reaches its
 # binding's driver through `BuildContext::async_driver()`; the type lives here.

--- a/crates/flui-view/src/element/sliver_persistent_header.rs
+++ b/crates/flui-view/src/element/sliver_persistent_header.rs
@@ -209,12 +209,9 @@ pub trait PersistentHeaderRenderObject:
     );
 
     /// Deliver the widget layer's current snap command, if any. Floating
-    /// variants apply it epoch-idempotently
-    /// ([`RenderSliverFloatingHeaderBase::apply_snap_command`]); the others
-    /// ignore it, same rationale as [`Self::install_snap`].
-    ///
-    /// [`RenderSliverFloatingHeaderBase::apply_snap_command`]:
-    /// flui_objects::RenderSliverFloatingPersistentHeader::apply_snap_command
+    /// variants apply it epoch-idempotently (`apply_snap_command` on the
+    /// floating render objects); the others ignore it, same rationale as
+    /// [`Self::install_snap`].
     fn deliver_snap(&mut self, command: Option<SnapCommand>);
 }
 

--- a/crates/flui-view/src/element/sliver_persistent_header.rs
+++ b/crates/flui-view/src/element/sliver_persistent_header.rs
@@ -59,7 +59,7 @@ use flui_animation::AnimationController;
 use flui_objects::{
     FloatingHeaderSnapConfiguration, HeaderShrinkCell, OverScrollHeaderStretchConfiguration,
     RenderSliverFloatingPersistentHeader, RenderSliverFloatingPinnedPersistentHeader,
-    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader,
+    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader, SnapCommand,
 };
 use flui_rendering::protocol::SliverProtocol;
 
@@ -207,6 +207,15 @@ pub trait PersistentHeaderRenderObject:
         controller: Option<AnimationController>,
         configuration: Option<FloatingHeaderSnapConfiguration>,
     );
+
+    /// Deliver the widget layer's current snap command, if any. Floating
+    /// variants apply it epoch-idempotently
+    /// ([`RenderSliverFloatingHeaderBase::apply_snap_command`]); the others
+    /// ignore it, same rationale as [`Self::install_snap`].
+    ///
+    /// [`RenderSliverFloatingHeaderBase::apply_snap_command`]:
+    /// flui_objects::RenderSliverFloatingPersistentHeader::apply_snap_command
+    fn deliver_snap(&mut self, command: Option<SnapCommand>);
 }
 
 impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
@@ -241,6 +250,10 @@ impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
         // Not floating: nothing to settle. Flutter's non-floating headers
         // likewise ignore snapConfiguration.
     }
+
+    fn deliver_snap(&mut self, _command: Option<SnapCommand>) {
+        // Not floating: see install_snap.
+    }
 }
 
 impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
@@ -274,6 +287,10 @@ impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
     ) {
         // Not floating: nothing to settle. Flutter's non-floating headers
         // likewise ignore snapConfiguration.
+    }
+
+    fn deliver_snap(&mut self, _command: Option<SnapCommand>) {
+        // Not floating: see install_snap.
     }
 }
 
@@ -311,6 +328,12 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPersistentHeader {
         self.set_snap_controller(controller);
         self.set_snap_configuration(configuration);
     }
+
+    fn deliver_snap(&mut self, command: Option<SnapCommand>) {
+        if let Some(command) = command {
+            self.apply_snap_command(command);
+        }
+    }
 }
 
 impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader {
@@ -345,6 +368,12 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader
         self.set_snap_controller(controller);
         self.set_snap_configuration(configuration);
     }
+
+    fn deliver_snap(&mut self, command: Option<SnapCommand>) {
+        if let Some(command) = command {
+            self.apply_snap_command(command);
+        }
+    }
 }
 
 // ============================================================================
@@ -366,6 +395,9 @@ pub struct PersistentHeaderView<R> {
     /// `None` for non-floating variants and for floating headers whose
     /// delegate declares no snap.
     snap_controller: Option<AnimationController>,
+    /// The widget layer's current snap command, redelivered on every update
+    /// and applied epoch-idempotently by the floating render objects.
+    snap_command: Option<SnapCommand>,
     _variant: PhantomData<fn() -> R>,
 }
 
@@ -387,6 +419,7 @@ impl<R> PersistentHeaderView<R> {
         Self {
             delegate,
             snap_controller: None,
+            snap_command: None,
             _variant: PhantomData,
         }
     }
@@ -397,6 +430,13 @@ impl<R> PersistentHeaderView<R> {
         self.snap_controller = controller;
         self
     }
+
+    /// Attach the widget layer's current snap command. See the field doc.
+    #[must_use]
+    pub fn with_snap_command(mut self, command: Option<SnapCommand>) -> Self {
+        self.snap_command = command;
+        self
+    }
 }
 
 impl<R> Clone for PersistentHeaderView<R> {
@@ -404,6 +444,7 @@ impl<R> Clone for PersistentHeaderView<R> {
         Self {
             delegate: Rc::clone(&self.delegate),
             snap_controller: self.snap_controller.clone(),
+            snap_command: self.snap_command,
             _variant: PhantomData,
         }
     }
@@ -446,6 +487,7 @@ impl<R: PersistentHeaderRenderObject> RenderView for PersistentHeaderView<R> {
             self.snap_controller.clone(),
             self.delegate.snap_configuration(),
         );
+        render_object.deliver_snap(self.snap_command);
         render_object.update_extents(self.delegate.min_extent(), self.delegate.max_extent())
             | render_object.update_stretch(self.delegate.stretch_configuration())
     }
@@ -475,6 +517,11 @@ impl<R: PersistentHeaderRenderObject> View for PersistentHeaderView<R> {
     /// obliges it to answer `true` if content *or extents* could differ, so
     /// skipping on `false` also safely skips the extent refresh.
     fn should_skip_rebuild(&self, previous: &Self) -> bool {
+        // A fresh snap command must reach `update_render_object` even when
+        // the delegate is unchanged — skipping here would drop it.
+        if self.snap_command != previous.snap_command {
+            return false;
+        }
         Rc::ptr_eq(&self.delegate, &previous.delegate)
             || !self.delegate.should_rebuild(previous.delegate.as_ref())
     }

--- a/crates/flui-view/src/element/sliver_persistent_header.rs
+++ b/crates/flui-view/src/element/sliver_persistent_header.rs
@@ -55,10 +55,11 @@
 
 use std::{marker::PhantomData, rc::Rc, sync::Arc};
 
+use flui_animation::AnimationController;
 use flui_objects::{
-    HeaderShrinkCell, OverScrollHeaderStretchConfiguration, RenderSliverFloatingPersistentHeader,
-    RenderSliverFloatingPinnedPersistentHeader, RenderSliverPinnedPersistentHeader,
-    RenderSliverScrollingPersistentHeader,
+    FloatingHeaderSnapConfiguration, HeaderShrinkCell, OverScrollHeaderStretchConfiguration,
+    RenderSliverFloatingPersistentHeader, RenderSliverFloatingPinnedPersistentHeader,
+    RenderSliverPinnedPersistentHeader, RenderSliverScrollingPersistentHeader,
 };
 use flui_rendering::protocol::SliverProtocol;
 
@@ -131,6 +132,18 @@ pub trait SliverPersistentHeaderDelegate {
         None
     }
 
+    /// The snap behavior for a FLOATING header, if any.
+    ///
+    /// `Some` gives the floating variants a snap animation (expand or
+    /// collapse to the nearest edge when a scroll gesture ends) once a
+    /// controller is injected by the widget layer. Ignored by the
+    /// non-floating variants, exactly as Flutter ignores
+    /// `snapConfiguration` outside floating headers. Read on every widget
+    /// update, same as [`Self::stretch_configuration`].
+    fn snap_configuration(&self) -> Option<FloatingHeaderSnapConfiguration> {
+        None
+    }
+
     /// Whether replacing `old` with `self` is observable. See the trait doc
     /// for the obligation this carries.
     fn should_rebuild(
@@ -182,6 +195,18 @@ pub trait PersistentHeaderRenderObject:
         &mut self,
         stretch: Option<OverScrollHeaderStretchConfiguration>,
     ) -> flui_rendering::RenderUpdateImpact;
+
+    /// Install the snap controller and configuration.
+    ///
+    /// Meaningful only for the floating variants; the others ignore it,
+    /// exactly as Flutter ignores `snapConfiguration` outside floating
+    /// headers — snapping is the floating reveal's settling behavior, and a
+    /// pinned or scrolling header has nothing to settle.
+    fn install_snap(
+        &mut self,
+        controller: Option<AnimationController>,
+        configuration: Option<FloatingHeaderSnapConfiguration>,
+    );
 }
 
 impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
@@ -207,6 +232,15 @@ impl PersistentHeaderRenderObject for RenderSliverScrollingPersistentHeader {
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_stretch_configuration(stretch)
     }
+
+    fn install_snap(
+        &mut self,
+        _controller: Option<AnimationController>,
+        _configuration: Option<FloatingHeaderSnapConfiguration>,
+    ) {
+        // Not floating: nothing to settle. Flutter's non-floating headers
+        // likewise ignore snapConfiguration.
+    }
 }
 
 impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
@@ -231,6 +265,15 @@ impl PersistentHeaderRenderObject for RenderSliverPinnedPersistentHeader {
         stretch: Option<OverScrollHeaderStretchConfiguration>,
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_stretch_configuration(stretch)
+    }
+
+    fn install_snap(
+        &mut self,
+        _controller: Option<AnimationController>,
+        _configuration: Option<FloatingHeaderSnapConfiguration>,
+    ) {
+        // Not floating: nothing to settle. Flutter's non-floating headers
+        // likewise ignore snapConfiguration.
     }
 }
 
@@ -259,6 +302,15 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPersistentHeader {
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_stretch_configuration(stretch)
     }
+
+    fn install_snap(
+        &mut self,
+        controller: Option<AnimationController>,
+        configuration: Option<FloatingHeaderSnapConfiguration>,
+    ) {
+        self.set_snap_controller(controller);
+        self.set_snap_configuration(configuration);
+    }
 }
 
 impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader {
@@ -284,6 +336,15 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader
     ) -> flui_rendering::RenderUpdateImpact {
         self.set_stretch_configuration(stretch)
     }
+
+    fn install_snap(
+        &mut self,
+        controller: Option<AnimationController>,
+        configuration: Option<FloatingHeaderSnapConfiguration>,
+    ) {
+        self.set_snap_controller(controller);
+        self.set_snap_configuration(configuration);
+    }
 }
 
 // ============================================================================
@@ -300,6 +361,11 @@ impl PersistentHeaderRenderObject for RenderSliverFloatingPinnedPersistentHeader
 /// render object into a floating one.
 pub struct PersistentHeaderView<R> {
     delegate: SharedHeaderDelegate,
+    /// The widget layer's already-built, vsync-registered snap controller
+    /// (the controller lifecycle lives where the ambient vsync does).
+    /// `None` for non-floating variants and for floating headers whose
+    /// delegate declares no snap.
+    snap_controller: Option<AnimationController>,
     _variant: PhantomData<fn() -> R>,
 }
 
@@ -320,8 +386,16 @@ impl<R> PersistentHeaderView<R> {
     pub fn new(delegate: SharedHeaderDelegate) -> Self {
         Self {
             delegate,
+            snap_controller: None,
             _variant: PhantomData,
         }
+    }
+
+    /// Attach the widget layer's snap controller. See the field doc.
+    #[must_use]
+    pub fn with_snap_controller(mut self, controller: Option<AnimationController>) -> Self {
+        self.snap_controller = controller;
+        self
     }
 }
 
@@ -329,6 +403,7 @@ impl<R> Clone for PersistentHeaderView<R> {
     fn clone(&self) -> Self {
         Self {
             delegate: Rc::clone(&self.delegate),
+            snap_controller: self.snap_controller.clone(),
             _variant: PhantomData,
         }
     }
@@ -352,6 +427,10 @@ impl<R: PersistentHeaderRenderObject> RenderView for PersistentHeaderView<R> {
         // Impact is irrelevant on a freshly created object — it has never
         // been laid out, so there is nothing to invalidate yet.
         let _ = render_object.update_stretch(self.delegate.stretch_configuration());
+        render_object.install_snap(
+            self.snap_controller.clone(),
+            self.delegate.snap_configuration(),
+        );
         render_object
     }
 
@@ -363,6 +442,10 @@ impl<R: PersistentHeaderRenderObject> RenderView for PersistentHeaderView<R> {
         _ctx: &crate::RenderObjectContext<'_>,
         render_object: &mut Self::RenderObject,
     ) -> flui_rendering::RenderUpdateImpact {
+        render_object.install_snap(
+            self.snap_controller.clone(),
+            self.delegate.snap_configuration(),
+        );
         render_object.update_extents(self.delegate.min_extent(), self.delegate.max_extent())
             | render_object.update_stretch(self.delegate.stretch_configuration())
     }

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -211,6 +211,7 @@ pub use scroll::{
     SliverOpacity, SliverPadding, SliverPersistentHeader, SliverPersistentHeaderDelegate,
     SliverToBoxAdapter, StretchTriggerSignal, Viewport,
 };
+pub use scroll::{FloatingHeaderSnapConfiguration, ScrollPositionScope};
 pub use semantics::{ExcludeSemantics, MergeSemantics, Semantics};
 pub use stack::{IndexedStack, Positioned, Stack};
 pub use text::{

--- a/crates/flui-widgets/src/scroll/mod.rs
+++ b/crates/flui-widgets/src/scroll/mod.rs
@@ -17,6 +17,7 @@ mod page_view;
 mod refresh_indicator;
 mod scroll_controller;
 mod scroll_physics;
+mod scroll_position_scope;
 mod scrollable;
 mod scrollbar;
 mod single_child_scroll_view;
@@ -42,6 +43,7 @@ pub use scroll_controller::ScrollController;
 pub use scroll_physics::{
     BouncingScrollPhysics, ClampingScrollPhysics, ScrollMetrics, ScrollPhysics, SharedScrollPhysics,
 };
+pub use scroll_position_scope::ScrollPositionScope;
 pub use scrollable::Scrollable;
 pub use scrollbar::Scrollbar;
 pub use single_child_scroll_view::SingleChildScrollView;

--- a/crates/flui-widgets/src/scroll/mod.rs
+++ b/crates/flui-widgets/src/scroll/mod.rs
@@ -64,6 +64,8 @@ pub use sliver_persistent_header::SliverPersistentHeader;
 pub use flui_view::element::SliverPersistentHeaderDelegate;
 // What a delegate's `stretch_configuration` returns — surfaced with the
 // trait for the same reason.
-pub use flui_objects::{OverScrollHeaderStretchConfiguration, StretchTriggerSignal};
+pub use flui_objects::{
+    FloatingHeaderSnapConfiguration, OverScrollHeaderStretchConfiguration, StretchTriggerSignal,
+};
 pub use sliver_to_box_adapter::SliverToBoxAdapter;
 pub use viewport::{ShrinkWrappingViewport, Viewport};

--- a/crates/flui-widgets/src/scroll/scroll_position_scope.rs
+++ b/crates/flui-widgets/src/scroll/scroll_position_scope.rs
@@ -1,0 +1,74 @@
+//! [`ScrollPositionScope`] — provides the enclosing scrollable's shared
+//! [`ScrollPosition`] to its subtree.
+
+use flui_rendering::view::ScrollPosition;
+use flui_view::prelude::*;
+use flui_view::{BoxedView, InheritedView, impl_inherited_view};
+
+/// Provides the enclosing [`Scrollable`](super::Scrollable)'s shared
+/// [`ScrollPosition`] to descendant widgets.
+///
+/// `Scrollable` installs this around the product of its
+/// [`viewport_builder`](super::Scrollable::viewport_builder), so anything
+/// living inside the scrolled content — a floating header's snap trigger, a
+/// scrollbar, an "is the user scrolling" fade — can reach the SAME position
+/// the gestures drive, without threading it through every intermediate
+/// widget by hand.
+///
+/// Flutter parity: the discovery role of `Scrollable.of(context).position`,
+/// carried as inherited data because FLUI's `Scrollable` state is not
+/// otherwise reachable from a descendant.
+///
+/// The handle itself is `Arc`-backed and stable for a given controller;
+/// [`update_should_notify`](InheritedView::update_should_notify) fires only
+/// when a rebuild swaps in a genuinely different position (a controller
+/// swap), which is exactly when a dependent must re-subscribe its listeners.
+#[derive(Clone)]
+pub struct ScrollPositionScope {
+    position: ScrollPosition,
+    child: BoxedView,
+}
+
+impl ScrollPositionScope {
+    /// Wrap `child` in a scope providing `position` to its descendants.
+    #[must_use]
+    pub fn new(position: ScrollPosition, child: impl IntoView) -> Self {
+        Self {
+            position,
+            child: BoxedView(Box::new(child.into_view())),
+        }
+    }
+
+    /// The shared position this scope provides.
+    #[must_use]
+    pub fn position(&self) -> &ScrollPosition {
+        &self.position
+    }
+}
+
+impl std::fmt::Debug for ScrollPositionScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScrollPositionScope")
+            .field("position", &self.position)
+            .finish_non_exhaustive()
+    }
+}
+
+impl InheritedView for ScrollPositionScope {
+    type Data = ScrollPosition;
+
+    fn data(&self) -> &Self::Data {
+        &self.position
+    }
+
+    fn child(&self) -> &dyn View {
+        &self.child
+    }
+
+    fn update_should_notify(&self, old: &Self) -> bool {
+        // Same underlying position ⇒ dependents' subscriptions stay valid.
+        !self.position.ptr_eq(&old.position)
+    }
+}
+
+impl_inherited_view!(ScrollPositionScope);

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -65,6 +65,8 @@ use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{ClampingScrollPhysics, ScrollController, ScrollMetrics, SharedScrollPhysics};
 use crate::{AnimatedBuilder, GestureDetector, SingleChildScrollView};
 
+use super::scroll_position_scope::ScrollPositionScope;
+
 /// A caller-supplied composition of the scrollable content, receiving the
 /// [`Scrollable`]'s shared [`ScrollPosition`] and returning the view to
 /// scroll. See [`Scrollable::viewport_builder`].
@@ -472,8 +474,16 @@ impl ViewState<Scrollable> for ScrollableState {
             // `ScrollPosition`'s docs and `Viewport::position`.
             let scroll_view: BoxedView = if let Some(build_viewport) = &viewport_builder {
                 // Custom composition: the closure owns injecting the shared
-                // position into whatever it builds.
-                build_viewport(scroll_controller.position())
+                // position into whatever it builds. The scope re-publishes
+                // that same position to the built subtree, so content INSIDE
+                // the scrolled slivers (a floating header's snap trigger, a
+                // scrollbar) can subscribe to the position the gestures
+                // actually drive.
+                ScrollPositionScope::new(
+                    scroll_controller.position(),
+                    build_viewport(scroll_controller.position()),
+                )
+                .boxed()
             } else {
                 let mut scsv = SingleChildScrollView::new()
                     .scroll_direction(scroll_direction)

--- a/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
+++ b/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
@@ -2,13 +2,22 @@
 //! collapses, pinnable and floatable.
 
 use std::rc::Rc;
+use std::sync::Arc;
 
+use flui_animation::{AnimationController, Vsync, VsyncRegistration};
+use flui_foundation::ListenerId;
+use flui_objects::SnapCommand;
+use flui_rendering::view::{ScrollDirection, ScrollPosition};
+use flui_view::BuildContextExt as _;
 use flui_view::element::{
     FloatingPersistentHeaderView, FloatingPinnedPersistentHeaderView, PinnedPersistentHeaderView,
-    ScrollingPersistentHeaderView, SliverPersistentHeaderDelegate,
+    ScrollingPersistentHeaderView, SharedHeaderDelegate, SliverPersistentHeaderDelegate,
 };
-use flui_view::prelude::StatelessView;
-use flui_view::{BuildContext, IntoView, ViewExt};
+use flui_view::prelude::{StatefulView, StatelessView, ViewState};
+use flui_view::{BuildContext, IntoView, RebuildHandle, ViewExt};
+
+use crate::VsyncScope;
+use crate::scroll::scroll_position_scope::ScrollPositionScope;
 
 /// A sliver that keeps a header of delegate-controlled extent at the leading
 /// edge, rebuilding its content as the header collapses from
@@ -93,8 +102,211 @@ impl StatelessView for SliverPersistentHeader {
         match (self.pinned, self.floating) {
             (false, false) => ScrollingPersistentHeaderView::new(delegate).boxed(),
             (true, false) => PinnedPersistentHeaderView::new(delegate).boxed(),
-            (false, true) => FloatingPersistentHeaderView::new(delegate).boxed(),
-            (true, true) => FloatingPinnedPersistentHeaderView::new(delegate).boxed(),
+            // Floating variants route through the host, which owns the
+            // snap machinery (controller + scroll-activity trigger). With a
+            // snap-less delegate the host is a transparent pass-through.
+            (false, true) => FloatingHeaderHost {
+                delegate,
+                pinned: false,
+            }
+            .boxed(),
+            (true, true) => FloatingHeaderHost {
+                delegate,
+                pinned: true,
+            }
+            .boxed(),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Floating host: the snap trigger
+// ---------------------------------------------------------------------------
+
+/// Hosts a floating header's snap machinery: the animation controller (built
+/// here, where the ambient [`VsyncScope`] lives) and the scroll-activity
+/// trigger.
+///
+/// # How a snap fires
+///
+/// The enclosing [`Scrollable`](super::Scrollable) publishes its shared
+/// [`ScrollPosition`] via [`ScrollPositionScope`], and marks scroll activity
+/// on it at every gesture edge. This host subscribes an activity listener in
+/// `init_state`; the listener remembers the last non-idle user direction
+/// and, when scrolling ENDS, stamps a fresh epoch onto a
+/// [`SnapCommand`] and schedules a rebuild through the ADR-0018
+/// [`RebuildHandle`]. The rebuilt view carries the command to
+/// `update_render_object`, which the floating render object applies
+/// epoch-idempotently — the mutation rides the canonical update path, never
+/// a listener reaching into the render tree.
+///
+/// The listener only ever runs on the UI owner thread (every activity
+/// transition originates from gesture callbacks or the fling controller's
+/// vsync-driven status listener), but it deliberately touches nothing except
+/// the shared pending-command slot and the rebuild handle.
+#[derive(Clone, StatefulView)]
+struct FloatingHeaderHost {
+    delegate: SharedHeaderDelegate,
+    pinned: bool,
+}
+
+impl std::fmt::Debug for FloatingHeaderHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FloatingHeaderHost")
+            .field("pinned", &self.pinned)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The listener↔build shared slot. Every touch is owner-thread today (see
+/// the host's own doc), but the activity-listener type is structurally
+/// `Send + Sync`, so the slot carries a real lock rather than a promise.
+#[derive(Default)]
+struct SnapTriggerSlot {
+    /// The last non-idle direction observed while scrolling — what the
+    /// scroll that just ended was doing. Captured here because ending the
+    /// scroll resets the position's own direction to `Idle` before
+    /// listeners run.
+    last_direction: Option<ScrollDirection>,
+    /// Monotone stamp for [`SnapCommand`]s issued by this host.
+    epoch: u64,
+    /// The command the next build will carry, `None` until the first
+    /// scroll ends.
+    pending: Option<SnapCommand>,
+}
+
+struct FloatingHeaderHostState {
+    snap_controller: Option<AnimationController>,
+    vsync: Option<Vsync>,
+    vsync_registration: Option<VsyncRegistration>,
+    position: Option<ScrollPosition>,
+    activity_listener: Option<ListenerId>,
+    slot: Arc<parking_lot::Mutex<SnapTriggerSlot>>,
+}
+
+impl std::fmt::Debug for FloatingHeaderHostState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FloatingHeaderHostState")
+            .field("has_controller", &self.snap_controller.is_some())
+            .field("subscribed", &self.activity_listener.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for FloatingHeaderHost {
+    type State = FloatingHeaderHostState;
+
+    fn create_state(&self) -> Self::State {
+        FloatingHeaderHostState {
+            snap_controller: None,
+            vsync: None,
+            vsync_registration: None,
+            position: None,
+            activity_listener: None,
+            slot: Arc::new(parking_lot::Mutex::new(SnapTriggerSlot::default())),
+        }
+    }
+}
+
+impl ViewState<FloatingHeaderHost> for FloatingHeaderHostState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        // Everything below is lifecycle-only capability acquisition
+        // (ADR-0018 / ADR-0021 discipline): the handles are taken HERE and
+        // used later, from the listener.
+        // The controller: built where the vsync lives. Duration is a
+        // placeholder — `maybe_start_snap_animation` re-applies the snap
+        // configuration's own duration on every start.
+        let controller = AnimationController::without_ticker(std::time::Duration::from_millis(200));
+        if let Some(vsync) = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone()) {
+            let registration = vsync.register(controller.clone());
+            self.vsync = Some(vsync);
+            self.vsync_registration = Some(registration);
+        }
+        self.snap_controller = Some(controller);
+
+        // The trigger: subscribe to the enclosing scrollable's activity.
+        // No scope (a header outside any Scrollable, or in a purely
+        // programmatic scroll view) simply means no snap trigger — the
+        // header still floats; it just never settles by animation.
+        if let Some(position) = ctx.get::<ScrollPositionScope, _>(|scope| scope.position().clone())
+        {
+            let rebuild: RebuildHandle = ctx.rebuild_handle();
+            let slot = Arc::clone(&self.slot);
+            let listener_position = position.clone();
+            let listener = OwnerThreadSnapListener {
+                slot,
+                position: listener_position,
+                rebuild,
+            };
+            let id = position.add_activity_listener(std::sync::Arc::new(move || {
+                listener.on_activity();
+            }));
+            self.position = Some(position);
+            self.activity_listener = Some(id);
+        }
+    }
+
+    fn build(&self, view: &FloatingHeaderHost, _ctx: &dyn BuildContext) -> impl IntoView {
+        let command = self.slot.lock().pending;
+        let controller = self.snap_controller.clone();
+        if view.pinned {
+            FloatingPinnedPersistentHeaderView::new(Rc::clone(&view.delegate))
+                .with_snap_controller(controller)
+                .with_snap_command(command)
+                .boxed()
+        } else {
+            FloatingPersistentHeaderView::new(Rc::clone(&view.delegate))
+                .with_snap_controller(controller)
+                .with_snap_command(command)
+                .boxed()
+        }
+    }
+
+    fn dispose(&mut self) {
+        if let (Some(position), Some(id)) = (self.position.take(), self.activity_listener.take()) {
+            position.remove_activity_listener(id);
+        }
+        if let (Some(vsync), Some(registration)) =
+            (self.vsync.take(), self.vsync_registration.take())
+        {
+            vsync.unregister(registration);
+        }
+    }
+}
+
+/// The activity listener's owner-thread half, named so the safety argument
+/// above has an anchor.
+struct OwnerThreadSnapListener {
+    slot: Arc<parking_lot::Mutex<SnapTriggerSlot>>,
+    position: ScrollPosition,
+    rebuild: RebuildHandle,
+}
+
+impl OwnerThreadSnapListener {
+    fn on_activity(&self) {
+        let is_scrolling = self.position.is_scrolling();
+        let direction = self.position.user_scroll_direction();
+        let mut slot = self.slot.lock();
+        if is_scrolling {
+            if direction != ScrollDirection::Idle {
+                slot.last_direction = Some(direction);
+            }
+            return;
+        }
+        // Scrolling just ended: the position's own direction is already
+        // reset, so the captured one is the scroll that ended. No captured
+        // direction (a programmatic jump) ⇒ no snap, matching Flutter,
+        // where snapping keys on user gestures only.
+        let Some(direction) = slot.last_direction.take() else {
+            return;
+        };
+        slot.epoch += 1;
+        slot.pending = Some(SnapCommand {
+            epoch: slot.epoch,
+            direction,
+        });
+        drop(slot);
+        self.rebuild
+            .schedule(flui_view::RebuildReason::AnimationTick);
     }
 }

--- a/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
+++ b/crates/flui-widgets/src/scroll/sliver_persistent_header.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use flui_animation::{AnimationController, Vsync, VsyncRegistration};
 use flui_foundation::ListenerId;
-use flui_objects::SnapCommand;
+use flui_objects::{SnapAction, SnapCommand};
 use flui_rendering::view::{ScrollDirection, ScrollPosition};
 use flui_view::BuildContextExt as _;
 use flui_view::element::{
@@ -168,10 +168,13 @@ struct SnapTriggerSlot {
     /// scroll resets the position's own direction to `Idle` before
     /// listeners run.
     last_direction: Option<ScrollDirection>,
+    /// Whether the previous notification observed an active scroll — what
+    /// turns a level (`is_scrolling`) into the two edges (started/ended).
+    was_scrolling: bool,
     /// Monotone stamp for [`SnapCommand`]s issued by this host.
     epoch: u64,
     /// The command the next build will carry, `None` until the first
-    /// scroll ends.
+    /// scroll edge.
     pending: Option<SnapCommand>,
 }
 
@@ -208,6 +211,32 @@ impl StatefulView for FloatingHeaderHost {
     }
 }
 
+impl FloatingHeaderHostState {
+    /// (Re)subscribe the activity listener to `position`, detaching from any
+    /// previous one first — the swap path a controller replacement takes.
+    fn subscribe_to(&mut self, position: Option<ScrollPosition>, ctx: &dyn BuildContext) {
+        if let (Some(old_position), Some(id)) =
+            (self.position.take(), self.activity_listener.take())
+        {
+            old_position.remove_activity_listener(id);
+        }
+        let Some(position) = position else {
+            return;
+        };
+        let rebuild: RebuildHandle = ctx.rebuild_handle();
+        let listener = OwnerThreadSnapListener {
+            slot: Arc::clone(&self.slot),
+            position: position.clone(),
+            rebuild,
+        };
+        let id = position.add_activity_listener(std::sync::Arc::new(move || {
+            listener.on_activity();
+        }));
+        self.position = Some(position);
+        self.activity_listener = Some(id);
+    }
+}
+
 impl ViewState<FloatingHeaderHost> for FloatingHeaderHostState {
     fn init_state(&mut self, ctx: &dyn BuildContext) {
         // Everything below is lifecycle-only capability acquisition
@@ -225,24 +254,26 @@ impl ViewState<FloatingHeaderHost> for FloatingHeaderHostState {
         self.snap_controller = Some(controller);
 
         // The trigger: subscribe to the enclosing scrollable's activity.
-        // No scope (a header outside any Scrollable, or in a purely
-        // programmatic scroll view) simply means no snap trigger — the
-        // header still floats; it just never settles by animation.
-        if let Some(position) = ctx.get::<ScrollPositionScope, _>(|scope| scope.position().clone())
-        {
-            let rebuild: RebuildHandle = ctx.rebuild_handle();
-            let slot = Arc::clone(&self.slot);
-            let listener_position = position.clone();
-            let listener = OwnerThreadSnapListener {
-                slot,
-                position: listener_position,
-                rebuild,
-            };
-            let id = position.add_activity_listener(std::sync::Arc::new(move || {
-                listener.on_activity();
-            }));
-            self.position = Some(position);
-            self.activity_listener = Some(id);
+        // `depend_on` (not `get`): a controller swap on the enclosing
+        // Scrollable republishes the scope, and this dependency is what
+        // routes that into `did_change_dependencies` so the listener can
+        // follow the position. No scope (a header outside any Scrollable,
+        // or in a purely programmatic scroll view) simply means no snap
+        // trigger — the header still floats; it just never settles by
+        // animation.
+        let position = ctx.depend_on::<ScrollPositionScope, _>(|scope| scope.position().clone());
+        self.subscribe_to(position, ctx);
+    }
+
+    fn did_change_dependencies(&mut self, ctx: &dyn BuildContext) {
+        let position = ctx.depend_on::<ScrollPositionScope, _>(|scope| scope.position().clone());
+        let unchanged = match (&self.position, &position) {
+            (Some(current), Some(new)) => current.ptr_eq(new),
+            (None, None) => true,
+            _ => false,
+        };
+        if !unchanged {
+            self.subscribe_to(position, ctx);
         }
     }
 
@@ -287,10 +318,26 @@ impl OwnerThreadSnapListener {
         let is_scrolling = self.position.is_scrolling();
         let direction = self.position.user_scroll_direction();
         let mut slot = self.slot.lock();
+        let was_scrolling = std::mem::replace(&mut slot.was_scrolling, is_scrolling);
         if is_scrolling {
             if direction != ScrollDirection::Idle {
                 slot.last_direction = Some(direction);
             }
+            if was_scrolling {
+                // Mid-scroll direction change: nothing edge-shaped to do.
+                return;
+            }
+            // A NEW scroll began: an in-flight snap must yield to the
+            // finger immediately (Flutter's maybeStopSnapAnimation on the
+            // isScrollingNotifier's true edge).
+            slot.epoch += 1;
+            slot.pending = Some(SnapCommand {
+                epoch: slot.epoch,
+                action: SnapAction::Stop,
+            });
+            drop(slot);
+            self.rebuild
+                .schedule(flui_view::RebuildReason::AnimationTick);
             return;
         }
         // Scrolling just ended: the position's own direction is already
@@ -303,7 +350,7 @@ impl OwnerThreadSnapListener {
         slot.epoch += 1;
         slot.pending = Some(SnapCommand {
             epoch: slot.epoch,
-            direction,
+            action: SnapAction::Settle(direction),
         });
         drop(slot);
         self.rebuild

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -488,3 +488,71 @@ fn a_floating_snap_header_snaps_fully_open_when_a_startward_scroll_ends() {
         controller.pixels()
     );
 }
+/// A new drag beginning mid-snap must STOP the snap immediately — the
+/// finger owns the header now. Without the stop, the settle animation
+/// keeps driving the reveal underneath the user's drag and the header
+/// fights the gesture all the way to fully open.
+#[test]
+fn a_new_drag_stops_an_in_flight_snap() {
+    use std::time::Duration;
+
+    use flui_animation::Vsync;
+    use flui_widgets::{ScrollController, Scrollable, Viewport, VsyncScope};
+
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let builds_for_delegate = Rc::clone(&builds);
+    let controller = ScrollController::new();
+    let vsync = Vsync::new();
+
+    let scrollable = Scrollable::new()
+        .controller(controller.clone())
+        .viewport_builder(Rc::new(move |position| {
+            Viewport::new((
+                SliverPersistentHeader::new(SnappingDelegate {
+                    builds: Rc::clone(&builds_for_delegate),
+                })
+                .floating(true),
+                trailing_content(),
+            ))
+            .position(position)
+            .boxed()
+        }));
+
+    let mut laid = lay_out(
+        VsyncScope::new(vsync.clone(), scrollable),
+        tight(300.0, 300.0),
+    );
+    laid.adopt_vsync(vsync);
+
+    controller.jump_to(200.0);
+    laid.pump();
+
+    // End a start-ward drag: the snap toward fully-open begins.
+    laid.dispatch_pointer_down(150.0, 100.0);
+    laid.dispatch_pointer_move(150.0, 170.0);
+    laid.dispatch_pointer_move(150.0, 175.0);
+    laid.dispatch_pointer_up(150.0, 175.0);
+    // One frame: the snap is in flight but far from settled (64ms config).
+    laid.pump_for(Duration::from_millis(16));
+    let mid_snap = builds.borrow().last().map(|(shrink, _)| *shrink);
+    assert!(
+        mid_snap.is_some_and(|shrink| shrink > 0.0),
+        "premise: the snap is mid-flight, not settled; saw {mid_snap:?}"
+    );
+
+    // A NEW drag begins and HOLDS — the snap must yield to the finger.
+    laid.dispatch_pointer_down(150.0, 100.0);
+    laid.dispatch_pointer_move(150.0, 130.0); // crosses slop: pan_start
+    for _ in 0..12 {
+        laid.pump_for(Duration::from_millis(16));
+    }
+    assert!(
+        builds
+            .borrow()
+            .last()
+            .is_some_and(|(shrink, _)| *shrink > 0.0),
+        "the stopped snap must not keep animating the header open under \
+         the user's finger; builds: {:?}",
+        builds.borrow()
+    );
+}

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -371,3 +371,120 @@ fn a_delegate_swap_rebuilds_only_when_should_rebuild_says_so() {
         "should_rebuild == true must rebuild the child"
     );
 }
+
+// ============================================================================
+// Snap: the full seam — gesture end → activity signal → epoch command →
+// render snap animation
+// ============================================================================
+
+/// A snapping delegate: records builds and declares a fast snap so the test
+/// pumps few frames.
+struct SnappingDelegate {
+    builds: Rc<RefCell<Vec<(f32, bool)>>>,
+}
+
+impl SliverPersistentHeaderDelegate for SnappingDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        shrink_offset: f32,
+        overlaps_content: bool,
+    ) -> BoxedView {
+        self.builds
+            .borrow_mut()
+            .push((shrink_offset, overlaps_content));
+        SizedBox::new(300.0, 10.0).into_view().boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        40.0
+    }
+
+    fn max_extent(&self) -> f32 {
+        120.0
+    }
+
+    fn snap_configuration(&self) -> Option<flui_widgets::FloatingHeaderSnapConfiguration> {
+        Some(flui_widgets::FloatingHeaderSnapConfiguration::new(
+            flui_animation::ArcCurve::new(flui_animation::Curves::Linear),
+            std::time::Duration::from_millis(64),
+        ))
+    }
+}
+
+/// The whole snap seam, end to end: scroll the header away, then end a
+/// start-ward drag — the activity signal's end transition must stamp a snap
+/// command, and the floating header must animate to FULLY revealed
+/// (`shrink_offset == 0`) even though the scroll offset itself stays deep.
+/// Snapping is reveal animation, not scroll-to-top.
+#[test]
+fn a_floating_snap_header_snaps_fully_open_when_a_startward_scroll_ends() {
+    use std::time::Duration;
+
+    use flui_animation::Vsync;
+    use flui_widgets::{ScrollController, Scrollable, Viewport, VsyncScope};
+
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let builds_for_delegate = Rc::clone(&builds);
+    let controller = ScrollController::new();
+    let vsync = Vsync::new();
+
+    let scrollable = Scrollable::new()
+        .controller(controller.clone())
+        .viewport_builder(Rc::new(move |position| {
+            Viewport::new((
+                SliverPersistentHeader::new(SnappingDelegate {
+                    builds: Rc::clone(&builds_for_delegate),
+                })
+                .floating(true),
+                trailing_content(),
+            ))
+            .position(position)
+            .boxed()
+        }));
+
+    let mut laid = lay_out(
+        VsyncScope::new(vsync.clone(), scrollable),
+        tight(300.0, 300.0),
+    );
+    laid.adopt_vsync(vsync);
+
+    // Scroll deep: the floating header scrolls away entirely.
+    controller.jump_to(200.0);
+    laid.pump();
+    assert_eq!(
+        builds.borrow().last().map(|(shrink, _)| *shrink),
+        Some(120.0),
+        "premise: the header is fully collapsed after the deep scroll"
+    );
+
+    // A small START-WARD drag (finger moving down = revealing earlier
+    // content = Forward), released without fling velocity: the release is
+    // what must trigger the snap.
+    laid.dispatch_pointer_down(150.0, 100.0);
+    laid.dispatch_pointer_move(150.0, 170.0); // 70px down: slop + pan_start
+    laid.dispatch_pointer_move(150.0, 175.0); // small further drag
+    laid.dispatch_pointer_up(150.0, 175.0);
+
+    // Drive frames: whatever the release produced (immediate end or a brief
+    // ballistic run), the snap animation must then expand the header to
+    // fully revealed. Bounded so a never-snapping regression fails loudly.
+    let mut frames = 0;
+    while builds.borrow().last().map(|(shrink, _)| *shrink) != Some(0.0) && frames < 2_000 {
+        laid.pump_for(Duration::from_millis(16));
+        frames += 1;
+    }
+    assert_eq!(
+        builds.borrow().last().map(|(shrink, _)| *shrink),
+        Some(0.0),
+        "the snap must animate the header to fully revealed (still not after \
+         {frames} frames); builds: {:?}",
+        builds.borrow()
+    );
+    assert!(
+        controller.pixels() > 100.0,
+        "snap is reveal animation, not scroll-to-top — the offset must stay \
+         deep; got {}",
+        controller.pixels()
+    );
+}


### PR DESCRIPTION
Completes #699 item 1: floating headers (and `SliverAppBar.snap(true)`) now settle fully open when a start-ward scroll gesture ends.

## The chain, layer by layer

1. **Render** — `set_snap_controller` (the element-driven injection path the ctor-only parameter couldn't serve) and `apply_snap_command`, which applies a widget-layer command **epoch-idempotently**: a command with a non-newer epoch is refused, so view-update redelivery can't restart a snap the user has since interrupted.
2. **View** — the delegate gains `snap_configuration()` (Flutter's placement, beside stretch); `PersistentHeaderView` carries the widget-built controller and the current command through `create`/`update_render_object` — the render mutation travels the **canonical update path**, never a listener reaching into the render tree. `should_skip_rebuild` learned that a fresh command must defeat the delegate-identity skip or it would be silently dropped.
3. **Widgets** — `ScrollPositionScope` (new): `Scrollable` publishes its shared position around the `viewport_builder` product — the discovery role of Flutter's `Scrollable.of(context).position`. `FloatingHeaderHost` (new, stateful; floating variants route through it transparently): builds the controller where the ambient `VsyncScope` lives, subscribes an activity listener (#703's signal), captures the last non-idle user direction (the position's own resets to `Idle` before listeners run), and on scroll-end stamps a fresh epoch and schedules a rebuild through the ADR-0018 `RebuildHandle`. A programmatic jump captures no direction and never snaps — Flutter's gesture-only rule.
4. **Material** — `SliverAppBar.snap(bool)`, ignored without `floating` per Flutter's contract, using the oracle's exact defaults (`Curves.ease` cubic over 300ms, `rendering/sliver_persistent_header.dart:488-491`).

## The test drives the whole seam through real gestures

Scroll the header away; end a small start-ward drag. The header must animate to **exactly** `shrink_offset == 0.0` while the scroll offset stays deep — snapping is reveal animation, not scroll-to-top, and both halves are asserted. Red-verified by unplugging the trigger: the drag alone leaves a partial reveal and the bounded settle loop fails loudly.

`just ci` green (log-verified exit 0), typos/taplo clean.

Closes the snap half of #699 (the 22-case parity port remains, now unblocked — its snap cases finally have something to exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM