### PR TITLE
test(widgets): the 22-case persistent-header parity port — and the 3 bugs it caught

### DIFF
--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -597,10 +597,19 @@ impl RenderSliverScrollingPersistentHeader {
         let max_extent = self.core.max_extent;
         let raw_paint_extent = max_extent - constraints.scroll_offset;
         let cache_extent = self.calculate_cache_offset(constraints, 0.0, max_extent);
+        let paint_extent = raw_paint_extent.clamp(0.0, constraints.remaining_paint_extent);
         let geometry = SliverGeometry {
             scroll_extent: max_extent,
             paint_origin: constraints.overlap.min(0.0),
-            paint_extent: raw_paint_extent.clamp(0.0, constraints.remaining_paint_extent),
+            paint_extent,
+            // The oracle passes neither `layoutExtent` nor `visible`
+            // (`:374-381`), so `SliverGeometry`'s constructor defaults
+            // apply: layout = paint, visible = paint > 0
+            // (`sliver.dart:662-665`). A Rust struct literal has no such
+            // defaults — spell them out or the next sliver lays out at 0
+            // and the header reports itself invisible.
+            layout_extent: paint_extent,
+            visible: paint_extent > 0.0,
             max_paint_extent: max_extent + stretch_offset,
             cache_extent,
             has_visual_overflow: true,
@@ -619,6 +628,9 @@ impl Diagnosticable for RenderSliverScrollingPersistentHeader {
     fn debug_fill_properties(&self, builder: &mut DiagnosticsBuilder) {
         builder.add("min_extent", self.core.min_extent);
         builder.add("max_extent", self.core.max_extent);
+        if let Some(stretch) = &self.core.stretch_configuration {
+            builder.add("stretch_trigger_offset", stretch.stretch_trigger_offset);
+        }
     }
 }
 
@@ -744,6 +756,9 @@ impl Diagnosticable for RenderSliverPinnedPersistentHeader {
     fn debug_fill_properties(&self, builder: &mut DiagnosticsBuilder) {
         builder.add("min_extent", self.core.min_extent);
         builder.add("max_extent", self.core.max_extent);
+        if let Some(stretch) = &self.core.stretch_configuration {
+            builder.add("stretch_trigger_offset", stretch.stretch_trigger_offset);
+        }
     }
 }
 
@@ -774,10 +789,15 @@ impl RenderSliver for RenderSliverPinnedPersistentHeader {
             (max_extent - constraints.scroll_offset).clamp(0.0, effective_remaining_paint_extent);
         let stretch_offset = self.core.stretch_offset_for_geometry(&constraints);
 
+        let paint_extent = child_extent.min(effective_remaining_paint_extent);
         let geometry = SliverGeometry {
             scroll_extent: max_extent,
             paint_origin: constraints.overlap,
-            paint_extent: child_extent.min(effective_remaining_paint_extent),
+            paint_extent,
+            // `visible` is not given by the oracle (`:435-444`) → the
+            // constructor default `paintExtent > 0` (`sliver.dart:665`):
+            // a pinned header stays visible while it holds at the edge.
+            visible: paint_extent > 0.0,
             layout_extent,
             max_paint_extent: max_extent + stretch_offset,
             max_scroll_obstruction_extent: min_extent,
@@ -906,6 +926,9 @@ impl FloatingHeaderMode for FloatingMode {
             scroll_extent: max_extent,
             paint_origin: constraints.overlap.min(0.0),
             paint_extent,
+            // `visible` is not given by the oracle (`:588-595`) → the
+            // constructor default `paintExtent > 0` (`sliver.dart:665`).
+            visible: paint_extent > 0.0,
             layout_extent,
             max_paint_extent: max_extent + stretch_offset,
             // `cacheExtent` was not given explicitly by the oracle here, so it
@@ -954,6 +977,9 @@ impl FloatingHeaderMode for FloatingPinnedMode {
             scroll_extent: max_extent,
             paint_origin: constraints.overlap.min(0.0),
             paint_extent: clamped_paint_extent,
+            // `visible` is not given by the oracle (`:825-833`) → the
+            // constructor default `paintExtent > 0` (`sliver.dart:665`).
+            visible: clamped_paint_extent > 0.0,
             layout_extent,
             max_paint_extent: max_extent + stretch_offset,
             max_scroll_obstruction_extent: min_extent,
@@ -1271,6 +1297,9 @@ impl<M: FloatingHeaderMode> Diagnosticable for RenderSliverFloatingHeaderBase<M>
     fn debug_fill_properties(&self, builder: &mut DiagnosticsBuilder) {
         builder.add("min_extent", self.core.min_extent);
         builder.add("max_extent", self.core.max_extent);
+        if let Some(stretch) = &self.core.stretch_configuration {
+            builder.add("stretch_trigger_offset", stretch.stretch_trigger_offset);
+        }
         if let Some(offset) = self.effective_scroll_offset {
             builder.add("effective_scroll_offset", offset);
         }

--- a/crates/flui-objects/src/sliver/viewport.rs
+++ b/crates/flui-objects/src/sliver/viewport.rs
@@ -508,8 +508,9 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
         }
 
         if has_reverse_group {
-            // W3.2 limitation: reverse pass reuses the forward-pass cache window.
-            // Flutter recomputes cache parameters from forward results (Wave 3.3).
+            // Known gap: the reverse pass reuses the forward pass's cache
+            // window; Flutter derives the reverse pass's own cache parameters
+            // from the forward results (`rendering/viewport.dart:1812-1825`).
             let reverse_params = LayoutChildSequenceParams {
                 growth_direction: GrowthDirection::Reverse,
                 // Oracle: the reverse sequence always lays out with `overlap: 0.0`
@@ -517,11 +518,13 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
                 // `forward_overlap` above — stated explicitly so this invariant
                 // survives future changes to the `has_reverse_group` branch.
                 overlap: 0.0,
-                // W3.2 limitation (see the cache note above): the reverse pass
+                // Same known gap as the cache note above: the reverse pass
                 // keeps the leading-edge origin and full paint budget it has
                 // always used, rather than inheriting the forward pass's
                 // center-line values — Flutter derives the reverse pass's own
-                // window (`viewport.dart:1812-1825`), which lands in Wave 3.3.
+                // window (`rendering/viewport.dart:1812-1825`). Pinned here so
+                // the forward-sequence fix cannot change reverse behavior as a
+                // side effect.
                 layout_offset: 0.0,
                 remaining_paint_extent: main_axis_extent,
                 child_start: center,

--- a/crates/flui-objects/src/sliver/viewport.rs
+++ b/crates/flui-objects/src/sliver/viewport.rs
@@ -469,11 +469,27 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
             corrected_offset.min(0.0)
         };
 
+        // Oracle (`rendering/viewport.dart:1831-1846`): the forward sequence
+        // starts at the ZERO-SCROLL LINE, not the viewport's leading edge —
+        // `centerOffset` clamped into the viewport (and unclamped once fully
+        // past it), with the paint budget shrunk by the same amount. The two
+        // differ from the previous constants (`0.0` / `main_axis_extent`)
+        // exactly when `center_offset > 0`: an overscrolled-at-the-start
+        // viewport, where every sliver shifts down by the overscroll and the
+        // gap opens below a persistent header's negative `paint_origin`.
+        let forward_layout_offset = if center_offset >= main_axis_extent {
+            center_offset
+        } else {
+            center_offset.clamp(0.0, main_axis_extent)
+        };
+        let forward_remaining_paint_extent =
+            (main_axis_extent - center_offset).clamp(0.0, main_axis_extent);
+
         let sequence_base = LayoutChildSequenceParams {
             scroll_offset: corrected_offset.max(0.0),
             overlap: forward_overlap,
-            layout_offset: 0.0,
-            remaining_paint_extent: main_axis_extent,
+            layout_offset: forward_layout_offset,
+            remaining_paint_extent: forward_remaining_paint_extent,
             main_axis_extent,
             cross_axis_extent,
             size,
@@ -501,6 +517,13 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
                 // `forward_overlap` above — stated explicitly so this invariant
                 // survives future changes to the `has_reverse_group` branch.
                 overlap: 0.0,
+                // W3.2 limitation (see the cache note above): the reverse pass
+                // keeps the leading-edge origin and full paint budget it has
+                // always used, rather than inheriting the forward pass's
+                // center-line values — Flutter derives the reverse pass's own
+                // window (`viewport.dart:1812-1825`), which lands in Wave 3.3.
+                layout_offset: 0.0,
+                remaining_paint_extent: main_axis_extent,
                 child_start: center,
                 child_end: child_count,
                 ..sequence_base

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -339,7 +339,6 @@ impl LaidOut {
             .expect("render node should have box geometry after layout")
     }
 
-    /// The committed sliver geometry of a render node.
     /// The string value of a mounted render node's named diagnostics
     /// property — mirrors the flui-material harness helper of the same
     /// name, so parity ports can assert configuration reached the render
@@ -353,6 +352,7 @@ impl LaidOut {
         })
     }
 
+    /// The committed sliver geometry of a render node.
     pub fn sliver_geometry(&self, id: RenderId) -> SliverGeometry {
         self.pipeline_owner
             .with(|owner| inspect::sliver_geometry(owner, id))

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -340,6 +340,19 @@ impl LaidOut {
     }
 
     /// The committed sliver geometry of a render node.
+    /// The string value of a mounted render node's named diagnostics
+    /// property — mirrors the flui-material harness helper of the same
+    /// name, so parity ports can assert configuration reached the render
+    /// object without downcasting.
+    pub fn render_property(&self, id: RenderId, property_name: &str) -> Option<String> {
+        self.pipeline_owner.with(|owner| {
+            let diagnostics = owner.debug_node_diagnostics(id)?;
+            diagnostics
+                .find_property(property_name)
+                .map(|property| property.value().to_string())
+        })
+    }
+
     pub fn sliver_geometry(&self, id: RenderId) -> SliverGeometry {
         self.pipeline_owner
             .with(|owner| inspect::sliver_geometry(owner, id))

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -31,6 +31,7 @@ mod grid_view_test;
 mod icon_test;
 mod safe_area_test;
 mod sliver_grid_test;
+mod sliver_persistent_header_test;
 mod spacer_test;
 mod visibility_test;
 

--- a/crates/flui-widgets/tests/parity/sliver_persistent_header_test.rs
+++ b/crates/flui-widgets/tests/parity/sliver_persistent_header_test.rs
@@ -1,0 +1,500 @@
+//! ## Test parity notes
+//!
+//! Flutter source:
+//! - Widget: `packages/flutter/lib/src/widgets/sliver_persistent_header.dart`
+//!   `SliverPersistentHeader`.
+//! - Render objects: `packages/flutter/lib/src/rendering/sliver_persistent_header.dart`
+//!   (the pinned × floating matrix).
+//! - Tests: `packages/flutter/test/widgets/sliver_persistent_header_test.dart`
+//!   (22 `testWidgets` cases).
+//!
+//! Widget → render-object mapping: FLUI `SliverPersistentHeader` (facade in
+//! `flui-widgets`, element in `flui-view`, four render variants in
+//! `flui-objects`); the delegate child is built through the
+//! build-during-layout seam, so it appears one fixpoint pass after layout
+//! publishes — same frame, matching the oracle's synchronous `build`.
+//!
+//! # Case ledger (all 22 accounted; `sliver_test_utils.dart` fixtures below)
+//!
+//! | oracle line | case | status |
+//! |---|---|---|
+//! | :36 | scrolling updates stretchConfiguration | PORTED |
+//! | :70 | pinned updates stretchConfiguration | PORTED |
+//! | :105 | pinned updates showOnScreenConfiguration | DEFERRED: `show_on_screen` is omitted at the render layer by documented design (`sliver_persistent_header.rs` module doc) — there is no configuration to update |
+//! | :140 | floating — scroll offset doesn't change | PORTED |
+//! | :173 | floating — normal behavior | PORTED |
+//! | :301 | floating — no floating during a position animation | DEFERRED: keys on `ScrollPosition.isScrollingNotifier` suppressing the float during `animateTo`; FLUI's `animate_to` is a documented synchronous-jump fallback (`ScrollPosition::animate_to`), so the mid-animation state the oracle asserts does not exist yet |
+//! | :346 | floating — behavior when dragging | DEFERRED: same technique as :173 but driven by drag gestures over a position-mode viewport; portable once the parity harness grows the `Scrollable` + `viewport_builder` gesture fixture (tests/sliver_persistent_header.rs has the widget-level equivalent) |
+//! | :400 | floating — overscroll gap below header | PORTED |
+//! | :437 | pinned | PORTED |
+//! | :484 | toStringDeep of throwing maxExtent | NOT PORTABLE: FLUI delegate extents are infallible `f32` getters — the throwing-getter diagnostic path has no analogue |
+//! | :552 | pinned with slow scroll | DEFERRED: a 12-step offset sweep of the same paint-position technique as :437; adds step count, not coverage class — tracked with :346's fixture growth |
+//! | :673 | pinned with less overlap | DEFERRED: same technique/fixture family as :552 |
+//! | :720 | overscroll gap is below header | PORTED (the :883 scrolling variant is the same assertion set; both ported as one) |
+//! | :759 | pointer scrolled floating | DEFERRED: needs mouse-wheel pointer-scroll dispatch, which the harness does not synthesize yet |
+//! | :812 | scrolling | PORTED |
+//! | :851 | scrolling off screen | PORTED |
+//! | :883 | scrolling — overscroll gap below header | PORTED (see :720) |
+//! | :910 | (unnamed) pinned+floating with bottom — opacity fade | DEFERRED: asserts the material `SliverAppBar` toolbar-opacity fade, covered value-exact by `flui-material`'s `toolbar_opacity_follows_the_oracle_branches` unit tests |
+//! | :945 | semantics — within viewport | DEFERRED: `find.semantics`-family case; FLUI's semantics query harness lives in `flui-testing` (`a11y_tree`), not this crate's parity harness — porting rides a harness bridge, not header work |
+//! | :974 | semantics — partially scrolling off screen | DEFERRED: same |
+//! | :1015 | semantics — completely off screen within cache extent | DEFERRED: same |
+//! | :1052 | semantics — completely off screen, not within cache extent | DEFERRED: same |
+//!
+//! # Content sweep (standing rule)
+//!
+//! `grep -l "SliverPersistentHeader" .flutter/packages/flutter/test/` also
+//! hits `material/sliver_app_bar_test.dart` (subject: `SliverAppBar`),
+//! `widgets/slivers_evil_test.dart` (subject: sliver-removal robustness),
+//! and `widgets/nested_scroll_view_test.dart` (subject: `NestedScrollView`)
+//! — all use the header as scene scaffolding for a different subject;
+//! incidental, 0 subject cases beyond the 22 above.
+//!
+//! # Fixture equivalences
+//!
+//! - `TestDelegate` (min = max = 200, child labelled 200-high box) →
+//!   [`fixed_delegate`].
+//! - `TestDelegate2` (min 100, max 200) → [`shrinking_delegate`].
+//! - `BigSliver(height)` (a plain fixed-extent sliver) →
+//!   `SliverToBoxAdapter` over a `SizedBox` of that height.
+//! - `verifyPaintPosition(key, offset, visible)` → the harness's sliver
+//!   `offset(render_id)` (the committed `SliverPhysicalParentData` paint
+//!   offset) plus `sliver_geometry(render_id).visible`.
+//! - `position.animateTo(x) + pumpAndSettle` → `controller.jump_to(x)` +
+//!   `pump()`: the oracle's linear minute-long animation exists only to
+//!   arrive at `x` settled, and FLUI's controller commits the same
+//!   destination synchronously.
+//! - The oracle viewport is 800×600; every literal below keeps those
+//!   dimensions so the expected offsets read identically.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use flui_foundation::RenderId;
+use flui_view::BoxedView;
+use flui_view::IntoView;
+use flui_view::view::ViewExt;
+use flui_widgets::{
+    OverScrollHeaderStretchConfiguration, ScrollController, Scrollable, SizedBox,
+    SliverPersistentHeader, SliverPersistentHeaderDelegate, SliverToBoxAdapter, Viewport,
+};
+
+use crate::common::{LaidOut, lay_out, tight};
+
+/// `TestDelegate`: min = max = 200, fixed 200-high child.
+struct FixedDelegate {
+    stretch: Option<OverScrollHeaderStretchConfiguration>,
+    builds: Rc<RefCell<Vec<(f32, bool)>>>,
+}
+
+fn fixed_delegate() -> FixedDelegate {
+    FixedDelegate {
+        stretch: None,
+        builds: Rc::new(RefCell::new(Vec::new())),
+    }
+}
+
+impl SliverPersistentHeaderDelegate for FixedDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        shrink_offset: f32,
+        overlaps_content: bool,
+    ) -> BoxedView {
+        self.builds
+            .borrow_mut()
+            .push((shrink_offset, overlaps_content));
+        SizedBox::new(800.0, 200.0).into_view().boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        200.0
+    }
+
+    fn max_extent(&self) -> f32 {
+        200.0
+    }
+
+    fn stretch_configuration(&self) -> Option<OverScrollHeaderStretchConfiguration> {
+        self.stretch.clone()
+    }
+}
+
+/// `TestDelegate2`: min 100, max 200.
+struct ShrinkingDelegate;
+
+impl SliverPersistentHeaderDelegate for ShrinkingDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        _shrink_offset: f32,
+        _overlaps_content: bool,
+    ) -> BoxedView {
+        SizedBox::new(800.0, 200.0).into_view().boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        100.0
+    }
+
+    fn max_extent(&self) -> f32 {
+        200.0
+    }
+}
+
+/// `BigSliver(height)` — a plain box sliver of the given height.
+fn big_sliver(height: f32) -> BoxedView {
+    SliverToBoxAdapter::new()
+        .child(SizedBox::new(800.0, height))
+        .into_view()
+        .boxed()
+}
+
+/// Mount `slivers` in an 800×600 position-mode viewport driven by
+/// `controller` — the oracle's `CustomScrollView` + `ScrollableState`
+/// position, minus gestures (every ported case scrolls programmatically).
+fn mount(controller: &ScrollController, slivers: Vec<BoxedView>) -> LaidOut {
+    let position = controller.position();
+    lay_out(
+        Scrollable::new()
+            .controller(controller.clone())
+            .viewport_builder(Rc::new(move |_| {
+                Viewport::new(slivers.clone())
+                    .position(position.clone())
+                    .boxed()
+            })),
+        tight(800.0, 600.0),
+    )
+}
+
+/// `verifyPaintPosition` — the committed sliver paint offset and, when
+/// given, the sliver geometry's visibility.
+fn verify_paint_position(laid: &LaidOut, id: RenderId, ideal: (f32, f32), visible: Option<bool>) {
+    let offset = laid.offset(id);
+    assert_eq!(
+        (offset.dx.get(), offset.dy.get()),
+        ideal,
+        "sliver paint offset diverges from the oracle"
+    );
+    if let Some(visible) = visible {
+        assert_eq!(
+            laid.sliver_geometry(id).visible,
+            visible,
+            "sliver visibility diverges from the oracle"
+        );
+    }
+}
+
+/// The N-th sliver child of the viewport, in paint order.
+fn viewport_child(laid: &LaidOut, index: usize) -> RenderId {
+    let viewport = laid.find_by_render_type("RenderViewport");
+    laid.child(viewport, index)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :36 / :70 — stretchConfiguration updates reach the live render object
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle: pump twice with trigger offsets 10 then 20; the LIVE render
+/// object must carry the second value. Pins that a delegate swap re-pushes
+/// the stretch configuration through `update_render_object` instead of
+/// freezing the mount-time value. One test per variant, as in the oracle.
+fn stretch_configuration_updates(pinned: bool, render_type: &str) {
+    let controller = ScrollController::new();
+    let build = move |trigger: f32| -> Vec<BoxedView> {
+        vec![
+            SliverPersistentHeader::new(FixedDelegate {
+                stretch: Some(OverScrollHeaderStretchConfiguration::new(trigger, None)),
+                builds: Rc::new(RefCell::new(Vec::new())),
+            })
+            .pinned(pinned)
+            .into_view()
+            .boxed(),
+            big_sliver(300.0),
+        ]
+    };
+
+    let mut laid = mount(&controller, build(10.0));
+    let position = controller.position();
+    laid.pump_widget(
+        Scrollable::new()
+            .controller(controller.clone())
+            .viewport_builder(Rc::new(move |_| {
+                Viewport::new(build(20.0))
+                    .position(position.clone())
+                    .boxed()
+            })),
+    );
+
+    let header = laid.find_by_render_type(render_type);
+    assert_eq!(
+        laid.render_property(header, "stretch_trigger_offset")
+            .as_deref(),
+        Some("20"),
+        "the SECOND pump's stretch trigger must reach the live render object"
+    );
+}
+
+#[test]
+fn scrolling_header_updates_stretch_configuration() {
+    stretch_configuration_updates(false, "RenderSliverScrollingPersistentHeader");
+}
+
+#[test]
+fn pinned_header_updates_stretch_configuration() {
+    stretch_configuration_updates(true, "RenderSliverPinnedPersistentHeader");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :140 — floating: the header does not change the scroll extents
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle: two 1000-high slivers around a floating 200-header in a 600
+/// viewport ⇒ max scroll extent 1600, unchanged after scrolling to the end.
+#[test]
+fn floating_header_does_not_change_the_scroll_offset_range() {
+    let controller = ScrollController::new();
+    let mut laid = mount(
+        &controller,
+        vec![
+            big_sliver(1000.0),
+            SliverPersistentHeader::new(fixed_delegate())
+                .floating(true)
+                .into_view()
+                .boxed(),
+            big_sliver(1000.0),
+        ],
+    );
+
+    let position = controller.position();
+    assert_eq!(controller.pixels(), 0.0);
+    assert_eq!(position.min_scroll_extent(), 0.0);
+    assert_eq!(position.max_scroll_extent(), 1600.0);
+
+    controller.jump_to(10_000.0);
+    laid.pump();
+    assert_eq!(controller.pixels(), 1600.0, "clamped to the max extent");
+    assert_eq!(position.min_scroll_extent(), 0.0);
+    assert_eq!(position.max_scroll_extent(), 1600.0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :173 — floating: the reveal state machine, offset by offset
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle: a floating min-100/max-200 header after a 1000-high sliver in a
+/// 600 viewport, stepped through six settled offsets. The paint offsets and
+/// visibility below are the oracle's own literals.
+#[test]
+fn floating_header_normal_behavior() {
+    let controller = ScrollController::new();
+    let mut laid = mount(
+        &controller,
+        vec![
+            big_sliver(1000.0),
+            SliverPersistentHeader::new(ShrinkingDelegate)
+                .floating(true)
+                .into_view()
+                .boxed(),
+            big_sliver(1000.0),
+        ],
+    );
+    let (key1, key2, key3) = (
+        viewport_child(&laid, 0),
+        viewport_child(&laid, 1),
+        viewport_child(&laid, 2),
+    );
+
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, key2, (0.0, 1000.0), Some(false));
+    verify_paint_position(&laid, key3, (0.0, 1200.0), Some(false));
+
+    // 1000 − 600 + 200: the header's bottom reaches the viewport bottom.
+    controller.jump_to(600.0);
+    laid.pump();
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, key2, (0.0, 400.0), Some(true));
+    verify_paint_position(&laid, key3, (0.0, 600.0), Some(false));
+
+    // 1000 − 600 + 400.
+    controller.jump_to(800.0);
+    laid.pump();
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, key2, (0.0, 200.0), Some(true));
+    verify_paint_position(&laid, key3, (0.0, 400.0), Some(true));
+
+    // Scrolled exactly to the header's start.
+    controller.jump_to(1000.0);
+    laid.pump();
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key2, (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, key3, (0.0, 200.0), Some(true));
+
+    // 10% into the header: it shrinks from 200 toward its min.
+    controller.jump_to(1020.0);
+    laid.pump();
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key2, (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, key3, (0.0, 180.0), Some(true));
+
+    // Fully past: the floating header scrolls away entirely.
+    controller.jump_to(1400.0);
+    laid.pump();
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key2, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key3, (0.0, 0.0), Some(true));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :400 / :720 / :883 — the overscroll gap opens BELOW the header
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle (all three variants share the assertion set): over-scrolled at
+/// the start, the header stays put at the top and the gap opens between it
+/// and the content — never above the header.
+fn overscroll_gap_is_below_header(header: SliverPersistentHeader) {
+    let controller = ScrollController::new();
+    let mut laid = mount(
+        &controller,
+        vec![header.into_view().boxed(), big_sliver(300.0)],
+    );
+    let (key_header, key_content) = (viewport_child(&laid, 0), viewport_child(&laid, 1));
+
+    verify_paint_position(&laid, key_header, (0.0, 0.0), None);
+    verify_paint_position(&laid, key_content, (0.0, 200.0), None);
+
+    // The oracle's `position.jumpTo(-50.0)` is unclamped; the FLUI
+    // controller clamps to the extents, so force the overscroll through
+    // the position's own unclamped setter.
+    controller.position().set_pixels(-50.0);
+    laid.pump();
+
+    verify_paint_position(&laid, key_header, (0.0, 0.0), None);
+    verify_paint_position(&laid, key_content, (0.0, 250.0), None);
+}
+
+#[test]
+fn scrolling_overscroll_gap_is_below_header() {
+    overscroll_gap_is_below_header(SliverPersistentHeader::new(fixed_delegate()));
+}
+
+#[test]
+fn floating_overscroll_gap_is_below_header() {
+    overscroll_gap_is_below_header(SliverPersistentHeader::new(fixed_delegate()).floating(true));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :437 — pinned: both headers hold, stacked, at full scroll
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle literals: max scroll extent 1450; at the end the first pinned
+/// header holds at the top edge (visible), the second right below it at its
+/// collapsed 100, and the last big sliver peeks at y = 50.
+#[test]
+fn pinned_headers_hold_at_full_scroll() {
+    let controller = ScrollController::new();
+    let mut laid = mount(
+        &controller,
+        vec![
+            big_sliver(550.0),
+            SliverPersistentHeader::new(ShrinkingDelegate)
+                .pinned(true)
+                .into_view()
+                .boxed(),
+            SliverPersistentHeader::new(ShrinkingDelegate)
+                .pinned(true)
+                .into_view()
+                .boxed(),
+            big_sliver(550.0),
+            big_sliver(550.0),
+        ],
+    );
+    let position = controller.position();
+    assert_eq!(position.max_scroll_extent(), 1450.0);
+
+    controller.jump_to(10_000.0);
+    laid.pump();
+    assert_eq!(controller.pixels(), 1450.0);
+
+    let ids: Vec<_> = (0..5).map(|i| viewport_child(&laid, i)).collect();
+    verify_paint_position(&laid, ids[0], (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, ids[1], (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, ids[2], (0.0, 100.0), Some(true));
+    verify_paint_position(&laid, ids[3], (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, ids[4], (0.0, 50.0), Some(true));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :812 — scrolling: everything scrolls away; the tail peeks
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle literals: max 1450; at full scroll every earlier sliver paints at
+/// the origin (scrolled past) and the last one peeks at y = 50.
+#[test]
+fn scrolling_headers_scroll_away_entirely() {
+    let controller = ScrollController::new();
+    let mut laid = mount(
+        &controller,
+        vec![
+            big_sliver(550.0),
+            SliverPersistentHeader::new(fixed_delegate())
+                .into_view()
+                .boxed(),
+            SliverPersistentHeader::new(fixed_delegate())
+                .into_view()
+                .boxed(),
+            big_sliver(550.0),
+            big_sliver(550.0),
+        ],
+    );
+    let position = controller.position();
+    assert_eq!(position.max_scroll_extent(), 1450.0);
+
+    controller.jump_to(10_000.0);
+    laid.pump();
+    assert_eq!(controller.pixels(), 1450.0);
+
+    let ids: Vec<_> = (0..5).map(|i| viewport_child(&laid, i)).collect();
+    for id in &ids[..4] {
+        verify_paint_position(&laid, *id, (0.0, 0.0), None);
+    }
+    verify_paint_position(&laid, ids[4], (0.0, 50.0), None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :851 — scrolling off screen: the child's box juts above the viewport
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Oracle: scrolled to `550 + 200 − 5`, the header's CHILD box sits at
+/// y = −195 with its full 200 height — the header scrolls off without
+/// collapsing (min == max), so 5px of it still shows.
+#[test]
+fn scrolling_header_scrolls_off_screen_uncollapsed() {
+    let controller = ScrollController::new();
+    let delegate = fixed_delegate();
+    let mut laid = mount(
+        &controller,
+        vec![
+            big_sliver(550.0),
+            SliverPersistentHeader::new(delegate).into_view().boxed(),
+            big_sliver(550.0),
+            big_sliver(550.0),
+        ],
+    );
+
+    controller.jump_to(550.0 + 200.0 - 5.0);
+    laid.pump();
+
+    let header = viewport_child(&laid, 1);
+    let child = laid.only_child(header);
+    assert_eq!(
+        laid.absolute_offset(child).dy.get(),
+        -195.0,
+        "the child box juts 195px above the viewport"
+    );
+    assert_eq!(
+        laid.size(child).height.get(),
+        200.0,
+        "an uncollapsible header keeps its full extent while scrolling off"
+    );
+}


### PR DESCRIPTION
## What

The 22-case parity port of Flutter's `sliver_persistent_header_test.dart` (#699 item 2) — and the three real production bugs it caught.

**New parity binary module** (`crates/flui-widgets/tests/parity/sliver_persistent_header_test.rs`): all 22 oracle cases accounted for in the module-doc ledger — 8 PORTED, 14 DEFERRED / NOT PORTABLE, each with the specific reason (no silent drops). Fixtures map `TestDelegate`/`TestDelegate2`/`BigSliver`/`verifyPaintPosition` onto the shared harness; every literal keeps the oracle's 800×600 viewport so expected offsets read identically.

## Production bugs the port caught

1. **All four persistent-header variants reported `visible: false` at positive paint extents, and the scrolling variant returned `layout_extent: 0` with `paint_extent: 200`** — the next sliver laid out *at* the header, overlapping it. Root cause: Flutter's `SliverGeometry` constructor applies defaults (`layoutExtent ??= paintExtent`, `visible ??= paintExtent > 0`, `sliver.dart:662-665`); the Rust struct-update `..SliverGeometry::ZERO` silently encodes "omitted = zero/false" instead. Fixed at the four literals in `sliver_persistent_header.rs`, each citing the oracle lines. Swept `crates/flui-objects/src/sliver/` (`grep -A12 'SliverGeometry {'`): the persistent-header file was the only offender — the other slivers set both fields explicitly or pass through the child's geometry.

2. **The viewport hardcoded the forward sequence's `layout_offset: 0.0` and `remaining_paint_extent: main_axis_extent`** — Flutter derives both from `centerOffset` (`viewport.dart:1831-1846`), which differs exactly when overscrolled at the start: every sliver shifts down by the overscroll and the gap opens *below* a persistent header's negative `paint_origin`. Before the fix, the header sat at −50 instead of 0. The reverse pass keeps its previous values explicitly (the acknowledged W3.2 limitation), so this fix does not ripple into it unreviewed.

3. **No header variant published its stretch configuration in diagnostics** — the oracle's stretch-config-update cases assert the *live* render object carries the second pump's trigger; `debug_fill_properties` now publishes `stretch_trigger_offset` on all variants (the oracle reads `stretchConfiguration.stretchTriggerOffset` by downcast; FLUI asserts via diagnostics).

Harness: `tests/common/mod.rs` gains `render_property` (mirrors the flui-material helper).

## Deferred cases (ledger excerpts — full table in the module doc)

- `:105` show_on_screen — omitted at the render layer by documented design; nothing to update.
- `:301` no-float-during-animation — FLUI's `animate_to` is a documented synchronous-jump fallback; the mid-animation state doesn't exist yet.
- `:346`/`:552`/`:673` — same techniques as ported cases, gated on the parity harness growing a gesture fixture.
- `:759` — needs mouse-wheel pointer-scroll dispatch the harness doesn't synthesize.
- `:910` — the material toolbar-opacity fade, covered value-exact by flui-material's `toolbar_opacity_follows_the_oracle_branches`.
- `:945`–`:1052` semantics — ride the `flui-testing` a11y harness bridge, not header work.
- `:484` — NOT PORTABLE: FLUI delegate extents are infallible `f32` getters; the throwing-getter diagnostic path has no analogue.

## Evidence

- 9/9 parity tests green; 6 were born red against unmodified production (the geometry and viewport fixes turned them); 1 of the 3 initially-green ports red-verified by unplugging the scrolling header's child positioning (fails unplugged, passes restored).
- Full regression sweep: 4253 tests green across flui-objects, flui-widgets, flui-material, flui-rendering — no existing test pinned the old wrong behavior.
- `just ci` green (log-verified `JUST_CI_EXIT: 0`), typos + taplo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
