### PR TITLE
feat(widgets): a driven animate_to is a scroll activity — and parity :301

### DIFF
--- a/crates/flui-animation/src/controller.rs
+++ b/crates/flui-animation/src/controller.rs
@@ -1159,11 +1159,18 @@ impl AnimationController {
             return;
         }
 
-        // Non-repeating completion.
+        // Non-repeating completion. Flutter parity: `_tick` reports the
+        // settled status BY DIRECTION — completed after a forward run,
+        // dismissed after a reverse one — with no at-a-bound requirement
+        // (`animation_controller.dart:940-944`). Keeping the running status
+        // for a mid-range stop (the previous behavior) starved every status
+        // listener of the run's end: on an unbounded controller (a
+        // scrollable's pixel-space fling controller) a driven `animate_to`
+        // NEVER lands on a bound, so its completion was silent.
         if let Some(ticker) = &mut inner.ticker {
             ticker.stop();
         }
-        let status = inner.settled_status_keep_direction();
+        let status = inner.settled_status_directed();
         inner.status = status;
         let callbacks = inner.take_status_change();
         drop(inner);

--- a/crates/flui-widgets/src/scroll/scroll_controller.rs
+++ b/crates/flui-widgets/src/scroll/scroll_controller.rs
@@ -491,6 +491,14 @@ impl ScrollController {
                 // would visibly jump instead of starting from where the
                 // position actually sits.
                 fling.set_value(self.pixels());
+                // Flutter parity: `animateTo` runs inside a driven scroll
+                // activity, so `isScrollingNotifier` holds true for the run
+                // (`scroll_position.dart`, `beginActivity`) — while the USER
+                // direction stays idle, because nobody's finger is down. The
+                // fling controller's status listener (installed by
+                // `ScrollableState`) ends the activity when the run settles,
+                // exactly as it does for a ballistic fling.
+                self.position().set_is_scrolling(true);
                 let _ = fling.animate_to_curved(target_pixels, Some(duration), curve);
             }
             PendingScrollCommand::Cancel => {

--- a/crates/flui-widgets/tests/parity/sliver_persistent_header_test.rs
+++ b/crates/flui-widgets/tests/parity/sliver_persistent_header_test.rs
@@ -23,7 +23,7 @@
 //! | :105 | pinned updates showOnScreenConfiguration | DEFERRED: `show_on_screen` is omitted at the render layer by documented design (`sliver_persistent_header.rs` module doc) — there is no configuration to update |
 //! | :140 | floating — scroll offset doesn't change | PORTED |
 //! | :173 | floating — normal behavior | PORTED |
-//! | :301 | floating — no floating during a position animation | DEFERRED: keys on `ScrollPosition.isScrollingNotifier` suppressing the float during `animateTo`; FLUI's `animate_to` is a documented synchronous-jump fallback (`ScrollPosition::animate_to`), so the mid-animation state the oracle asserts does not exist yet |
+//! | :301 | floating — no floating during a position animation | PORTED (`ScrollController::animate_to` drives a real curve run through the fling controller; the run raises the scroll-activity signal but records no USER direction, which is exactly what keeps the float suppressed) |
 //! | :346 | floating — behavior when dragging | DEFERRED: same technique as :173 but driven by drag gestures over a position-mode viewport; portable once the parity harness grows the `Scrollable` + `viewport_builder` gesture fixture (tests/sliver_persistent_header.rs has the widget-level equivalent) |
 //! | :400 | floating — overscroll gap below header | PORTED |
 //! | :437 | pinned | PORTED |
@@ -80,6 +80,10 @@ use flui_widgets::{
 };
 
 use crate::common::{LaidOut, lay_out, tight};
+use flui_animation::{Curves, Vsync};
+use flui_widgets::VsyncScope;
+use std::sync::Arc;
+use std::time::Duration;
 
 /// `TestDelegate`: min = max = 200, fixed 200-high child.
 struct FixedDelegate {
@@ -340,6 +344,99 @@ fn floating_header_normal_behavior() {
     // Fully past: the floating header scrolls away entirely.
     controller.jump_to(1400.0);
     laid.pump();
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key2, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key3, (0.0, 0.0), Some(true));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// :301 — floating: no floating behavior when animating
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// [`mount`] plus a [`VsyncScope`], so `ScrollController::animate_to`'s
+/// curve run (driven by the scrollable's fling controller) ticks
+/// deterministically under `pump_for`.
+fn mount_animated(controller: &ScrollController, slivers: Vec<BoxedView>) -> LaidOut {
+    let position = controller.position();
+    let vsync = Vsync::new();
+    let mut laid = lay_out(
+        VsyncScope::new(
+            vsync.clone(),
+            Scrollable::new()
+                .controller(controller.clone())
+                .viewport_builder(Rc::new(move |_| {
+                    Viewport::new(slivers.clone())
+                        .position(position.clone())
+                        .boxed()
+                })),
+        ),
+        tight(800.0, 600.0),
+    );
+    laid.adopt_vsync(vsync);
+    laid
+}
+
+/// Drive frames until the position's scroll activity ends — the oracle's
+/// `pumpAndSettle(Duration(milliseconds: 1000))`: second-long virtual
+/// steps, bounded so a never-settling run fails loudly instead of hanging.
+fn settle_animation(laid: &mut LaidOut, controller: &ScrollController) {
+    // Always pump at least once (the oracle's `pumpAndSettle` does too):
+    // the queued command is serviced by the FIRST rebuild after
+    // `animate_to`'s notify, so the activity signal only rises after it.
+    let mut pumps = 0;
+    loop {
+        laid.pump_for(Duration::from_secs(1));
+        pumps += 1;
+        if !controller.position().is_scrolling() || pumps >= 120 {
+            break;
+        }
+    }
+    assert!(
+        !controller.position().is_scrolling(),
+        "the driven run must settle (still animating after {pumps} 1s pumps)"
+    );
+}
+
+/// Oracle: a floating header must NOT float back into view when the
+/// position is moved START-WARD by `animateTo` — a driven run is not a
+/// user scroll, and floating keys on the USER direction only. Both
+/// animations use the oracle's own 1-minute linear runs, settled to
+/// completion before asserting.
+#[test]
+fn floating_header_does_not_float_during_a_position_animation() {
+    let controller = ScrollController::new();
+    let mut laid = mount_animated(
+        &controller,
+        vec![
+            big_sliver(1000.0),
+            SliverPersistentHeader::new(fixed_delegate())
+                .floating(true)
+                .into_view()
+                .boxed(),
+            big_sliver(1000.0),
+        ],
+    );
+    let (key1, key2, key3) = (
+        viewport_child(&laid, 0),
+        viewport_child(&laid, 1),
+        viewport_child(&laid, 2),
+    );
+
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(true));
+    verify_paint_position(&laid, key2, (0.0, 1000.0), Some(false));
+    verify_paint_position(&laid, key3, (0.0, 1200.0), Some(false));
+
+    // bigHeight + maxExtent * 2 = 1400: fully past the header.
+    controller.animate_to(1400.0, Duration::from_mins(1), Arc::new(Curves::Linear));
+    settle_animation(&mut laid, &controller);
+    verify_paint_position(&laid, key1, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key2, (0.0, 0.0), Some(false));
+    verify_paint_position(&laid, key3, (0.0, 0.0), Some(true));
+
+    // bigHeight + maxExtent * 1.9 = 1380: 20px START-WARD — a drag in this
+    // direction would float the header; a driven run must not.
+    controller.animate_to(1380.0, Duration::from_mins(1), Arc::new(Curves::Linear));
+    settle_animation(&mut laid, &controller);
     verify_paint_position(&laid, key1, (0.0, 0.0), Some(false));
     verify_paint_position(&laid, key2, (0.0, 0.0), Some(false));
     verify_paint_position(&laid, key3, (0.0, 0.0), Some(true));

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -2461,6 +2461,68 @@ fn scroll_activity_tracks_the_whole_gesture_lifecycle() {
     );
 }
 
+/// A driven `animate_to` IS a scroll activity — Flutter parity:
+/// `animateTo` begins a `DrivenScrollActivity`, so `isScrollingNotifier`
+/// holds true for the run's whole duration (`scroll_position.dart`,
+/// `beginActivity`) — while `userScrollDirection` stays `Idle` throughout,
+/// because a driven run is not a USER scroll. Both halves matter to a
+/// floating header: the activity keeps its snap trigger honest, and the
+/// idle direction is what keeps the header from float-revealing during a
+/// programmatic backward animation.
+#[test]
+fn a_driven_animate_to_is_a_scroll_activity_but_not_a_user_scroll() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+    let position = controller.position();
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    assert!(!position.is_scrolling(), "idle before the call");
+    controller.animate_to(1000.0, Duration::from_millis(100), Arc::new(Curves::Linear));
+
+    // Pump 1 services the queued command and starts the run — the activity
+    // must be live from that point.
+    scoped.pump_for(Duration::from_millis(16));
+    assert!(
+        position.is_scrolling(),
+        "a driven animation is a scroll activity from the frame that starts it"
+    );
+    assert_eq!(
+        position.user_scroll_direction(),
+        ScrollDirection::Idle,
+        "a driven run is not a USER scroll — the direction stays idle"
+    );
+
+    // Mid-run the signal holds.
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    assert!(
+        position.is_scrolling(),
+        "the activity holds through the run"
+    );
+
+    // Bounded settle: completion must end the activity through the same
+    // status-listener half a ballistic fling uses.
+    let mut frames = 0;
+    while position.is_scrolling() && frames < 2_000 {
+        scoped.pump_for(Duration::from_millis(16));
+        frames += 1;
+    }
+    assert!(
+        !position.is_scrolling(),
+        "the run's completion must end the activity (still scrolling after {frames} frames)"
+    );
+    assert_eq!(
+        controller.pixels(),
+        1000.0,
+        "and the run itself still lands on the target"
+    );
+}
+
 /// A fling keeps the activity alive through the ballistic run and ends it
 /// when the simulation settles — the status-listener half of the signal.
 /// Without it, `is_scrolling` would stick true forever after any fling.

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -488,6 +488,76 @@ fn a_floating_snap_header_snaps_fully_open_when_a_startward_scroll_ends() {
         controller.pixels()
     );
 }
+/// A driven `animate_to` ending must NOT trigger a snap — Flutter parity:
+/// snapping keys on USER scrolls only, and a driven run never records a
+/// user direction, so the listener's idle edge finds nothing captured.
+/// Now that a driven run raises the scroll-activity signal (it IS a
+/// scroll activity), this is the case that keeps the signal's new
+/// coverage from leaking into the snap trigger: the run's start-and-end
+/// edges fire with no direction, and the header must stay collapsed.
+#[test]
+fn a_driven_animate_to_ending_does_not_snap() {
+    use std::time::Duration;
+
+    use flui_animation::{Curves, Vsync};
+    use flui_widgets::{ScrollController, Scrollable, Viewport, VsyncScope};
+
+    let builds = Rc::new(RefCell::new(Vec::new()));
+    let builds_for_delegate = Rc::clone(&builds);
+    let controller = ScrollController::new();
+    let vsync = Vsync::new();
+
+    let scrollable = Scrollable::new()
+        .controller(controller.clone())
+        .viewport_builder(Rc::new(move |position| {
+            Viewport::new((
+                SliverPersistentHeader::new(SnappingDelegate {
+                    builds: Rc::clone(&builds_for_delegate),
+                })
+                .floating(true),
+                trailing_content(),
+            ))
+            .position(position)
+            .boxed()
+        }));
+
+    let mut laid = lay_out(
+        VsyncScope::new(vsync.clone(), scrollable),
+        tight(300.0, 300.0),
+    );
+    laid.adopt_vsync(vsync);
+
+    // Scroll deep: the floating header scrolls away entirely.
+    controller.jump_to(200.0);
+    laid.pump();
+    assert_eq!(
+        builds.borrow().last().map(|(shrink, _)| *shrink),
+        Some(120.0),
+        "premise: the header is fully collapsed after the deep scroll"
+    );
+
+    // A programmatic START-WARD animation — the same direction of travel
+    // that, coming from a finger, would seed the snap trigger.
+    controller.animate_to(
+        180.0,
+        Duration::from_millis(64),
+        std::sync::Arc::new(Curves::Linear),
+    );
+    // Drive well past the run's end AND past any snap animation that a
+    // regression would have started (the snap config in this fixture is
+    // 64ms too).
+    for _ in 0..12 {
+        laid.pump_for(Duration::from_millis(16));
+    }
+    assert_eq!(controller.pixels(), 180.0, "premise: the run completed");
+    assert_eq!(
+        builds.borrow().last().map(|(shrink, _)| *shrink),
+        Some(120.0),
+        "a driven run's end is not a user gesture — no snap may start;          builds: {:?}",
+        builds.borrow()
+    );
+}
+
 /// A new drag beginning mid-snap must STOP the snap immediately — the
 /// finger owns the header now. Without the stop, the settle animation
 /// keeps driving the reveal underneath the user's drag and the header


### PR DESCRIPTION
## What

A driven `animate_to` is now a scroll activity — Flutter's `isScrollingNotifier` contract — which un-defers parity case :301 (a floating header must not float during a position animation). One production bug in `flui-animation` fell out of verifying the end of the run.

## The two production changes

1. **`ScrollController::service_pending_command` raises `is_scrolling(true)` when it starts an `AnimateTo` run.** Flutter parity: `animateTo` begins a `DrivenScrollActivity`, so `isScrollingNotifier` holds true for the run's duration (`scroll_position.dart`, `beginActivity`) — while `userScrollDirection` stays idle, because nobody's finger is down. Previously the signal only covered drags and ballistic flings; a programmatic animation was invisible to everything listening (a floating header's snap trigger, scrollbar fades). The fling controller's existing status listener ends the activity when the run settles, same as a fling.

2. **`AnimationController`'s duration-tick completion reported no status on unbounded controllers.** The non-repeating tick end used `settled_status_keep_direction()` — which keeps the *running* status for any stop that isn't at a bound. A scrollable's fling controller is pixel-space unbounded (±∞), so a driven `animate_to`'s completion NEVER emitted `Completed`: the status listener stayed silent and `is_scrolling` would have stuck true forever. Flutter's `_tick` reports the settled status **by direction** with no at-a-bound requirement (`animation_controller.dart:940-944`) — and FLUI's own simulation branch (`tick_simulation`) already did exactly that via `settled_status_directed()`. The duration branch now matches both. (`set_value`'s keep-direction behavior is untouched — that one matches Flutter's `_internalSetValue`.)

## Tests

- `a_driven_animate_to_is_a_scroll_activity_but_not_a_user_scroll` (tests/scroll.rs) — born red on the missing raise; after fix #1 it exposed bug #2 empirically (activity held true through 2000 frames past completion). Green only with both. Asserts the full contract: live from the starting frame, direction stays `Idle`, ends on settle, run still lands on target.
- `a_driven_animate_to_ending_does_not_snap` (tests/sliver_persistent_header.rs) — pins the interaction with the snap seam: a driven run's idle edge finds no captured user direction, so no snap fires. Red-verified by sabotaging the listener's `last_direction.take()` to a `Forward` fallback.
- **Parity :301 ported** (`floating_header_does_not_float_during_a_position_animation`) — the oracle's exact shape: two 1-minute linear `animateTo` runs (the second 20px start-ward), settled, all paint positions and visibility literal. Red-verified by forcing `allow_floating_expansion = true` in the floating header's layout: the backward driven run then floats the header and the test fails. Ledger row :301 flipped DEFERRED → PORTED (21 remaining rows unchanged; 8→9 ported of 22).

## Evidence

- 2802 tests green across flui-animation, flui-widgets, flui-material, flui-cupertino after the tick-end change; full parity module 10/10.
- `just ci` green (log-verified `JUST_CI_EXIT: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
