### PR TITLE
fix(rendering): content-contract sliver geometry warns and commits — no more silent viewport freeze

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -550,6 +550,11 @@ required-features = ["cupertino"]
 # Renders any demo tree offscreen to a PNG; it `#[path]`-includes both catalog
 # demos, so it needs both.
 [[example]]
+name = "sliver_demo"
+path = "examples/sliver_demo.rs"
+required-features = ["material"]
+
+[[example]]
 name = "screenshot"
 path = "examples/screenshot.rs"
 required-features = ["material", "cupertino"]

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -383,8 +383,8 @@ impl SliverGeometry {
     /// (`sliver.dart:881-894`, `debugAssertIsValid`) — a release build
     /// commits and consumes the geometry as-is, placing the successor at
     /// `layout_extent` past the shorter paint. Rejecting them from the
-    /// commit (the pre-#708 behavior) left the node's previous geometry
-    /// committed forever: every retry re-violated, and the viewport froze
+    /// commit instead leaves the node's previous geometry committed
+    /// forever — every retry re-violates, and the viewport freezes
     /// silently. The commit path warns on these instead.
     pub fn content_contract_violation(&self) -> Option<&'static str> {
         if self.layout_extent > self.paint_extent {

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -361,13 +361,6 @@ impl SliverGeometry {
             }
         }
 
-        if self.layout_extent > self.paint_extent {
-            return Some("layout_extent exceeds paint_extent");
-        }
-        if self.paint_extent - self.max_paint_extent > PRECISION_ERROR_TOLERANCE {
-            return Some("paint_extent exceeds max_paint_extent");
-        }
-
         if let Some(correction) = self.scroll_offset_correction {
             if !correction.is_finite() {
                 return Some("scroll_offset_correction is not finite");
@@ -377,6 +370,29 @@ impl SliverGeometry {
             }
         }
 
+        None
+    }
+
+    /// The geometry's CONTENT contract, checked separately from
+    /// [`validation_error`](Self::validation_error): a violation here means
+    /// a widget broke its sizing contract (e.g. a persistent header's child
+    /// sized below the header's extent), not that the pipeline cannot
+    /// consume the numbers.
+    ///
+    /// Flutter draws the same line: these two rules are DEBUG-ONLY asserts
+    /// (`sliver.dart:881-894`, `debugAssertIsValid`) — a release build
+    /// commits and consumes the geometry as-is, placing the successor at
+    /// `layout_extent` past the shorter paint. Rejecting them from the
+    /// commit (the pre-#708 behavior) left the node's previous geometry
+    /// committed forever: every retry re-violated, and the viewport froze
+    /// silently. The commit path warns on these instead.
+    pub fn content_contract_violation(&self) -> Option<&'static str> {
+        if self.layout_extent > self.paint_extent {
+            return Some("layout_extent exceeds paint_extent");
+        }
+        if self.paint_extent - self.max_paint_extent > PRECISION_ERROR_TOLERANCE {
+            return Some("paint_extent exceeds max_paint_extent");
+        }
         None
     }
 
@@ -567,8 +583,9 @@ mod tests {
             max_paint_extent: 1.0 - flui_foundation::EPSILON_F32 * 2.0,
             ..SliverGeometry::ZERO
         };
+        assert_eq!(geometry.validation_error(), None);
         assert_eq!(
-            geometry.validation_error(),
+            geometry.content_contract_violation(),
             Some("paint_extent exceeds max_paint_extent")
         );
     }

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -136,9 +136,9 @@ impl Protocol for SliverProtocol {
             // A content bug, not a pipeline hazard: commit and consume the
             // geometry the way a Flutter RELEASE build does (the matching
             // Flutter checks are debug-only asserts, `sliver.dart:881-894`).
-            // Rejecting it instead left the previous committed geometry in
-            // place on every retry — a silent, permanent viewport freeze
-            // (issue #708).
+            // Rejecting it instead leaves the previous committed geometry
+            // in place on every retry — a silent, permanent viewport
+            // freeze.
             tracing::warn!(
                 render_object,
                 reason,

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -132,6 +132,19 @@ impl Protocol for SliverProtocol {
                 reason,
             ));
         }
+        if let Some(reason) = geometry.content_contract_violation() {
+            // A content bug, not a pipeline hazard: commit and consume the
+            // geometry the way a Flutter RELEASE build does (the matching
+            // Flutter checks are debug-only asserts, `sliver.dart:881-894`).
+            // Rejecting it instead left the previous committed geometry in
+            // place on every retry — a silent, permanent viewport freeze
+            // (issue #708).
+            tracing::warn!(
+                render_object,
+                reason,
+                "sliver geometry violates its content contract; committed as-is"
+            );
+        }
         Ok(())
     }
 

--- a/crates/flui-rendering/tests/sliver_geometry_validation.rs
+++ b/crates/flui-rendering/tests/sliver_geometry_validation.rs
@@ -41,7 +41,29 @@ fn sliver_constraints() -> SliverConstraints {
     }
 }
 
-fn invalid_layout_exceeds_paint_geometry() -> SliverGeometry {
+/// Violates a PIPELINE-SAFETY rule (negative paint extent) — the class
+/// `validate_layout_output` still rejects. The softer content-contract
+/// rules (layout > paint, paint > max_paint) commit with a warning instead
+/// — see `sliver_content_contract_violation_commits_and_stays_clean`.
+fn invalid_negative_paint_geometry() -> SliverGeometry {
+    SliverGeometry {
+        scroll_extent: 100.0,
+        paint_extent: -10.0,
+        layout_extent: 0.0,
+        max_paint_extent: 100.0,
+        hit_test_extent: 0.0,
+        cache_extent: 0.0,
+        visible: true,
+        ..SliverGeometry::ZERO
+    }
+}
+
+/// The content contract (Flutter's DEBUG-ONLY asserts, `sliver.dart:881-894`):
+/// a violating geometry still COMMITS — a release Flutter build consumes it
+/// as-is, and rejecting it instead froze the viewport permanently (issue
+/// #708: every retry re-violated, so the stale committed geometry never
+/// refreshed).
+fn layout_exceeds_paint_geometry() -> SliverGeometry {
     SliverGeometry {
         scroll_extent: 100.0,
         paint_extent: 10.0,
@@ -133,9 +155,10 @@ fn sliver_leaf_layout_rejects_invalid_geometry_before_state_commit() {
     let mut owner = PipelineOwner::new();
     let sliver_id = owner
         .render_tree_mut()
-        .insert_sliver(Box::new(BadGeometrySliver::new(
-            invalid_layout_exceeds_paint_geometry(),
-        )) as BoxedSliverObject);
+        .insert_sliver(
+            Box::new(BadGeometrySliver::new(invalid_negative_paint_geometry()))
+                as BoxedSliverObject,
+        );
 
     let entry = owner
         .render_tree_mut()
@@ -146,7 +169,7 @@ fn sliver_leaf_layout_rejects_invalid_geometry_before_state_commit() {
         .layout_leaf_only(sliver_constraints())
         .expect_err("invalid sliver geometry must fail layout");
 
-    assert_invalid_geometry(err, "layout_extent exceeds paint_extent");
+    assert_invalid_geometry(err, "paint_extent is negative");
     assert!(
         entry.state().geometry().is_none(),
         "invalid geometry must not be committed to RenderState"
@@ -158,15 +181,48 @@ fn sliver_leaf_layout_rejects_invalid_geometry_before_state_commit() {
 }
 
 #[test]
+fn sliver_content_contract_violation_commits_and_stays_clean() {
+    let mut owner = PipelineOwner::new();
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver(
+            Box::new(BadGeometrySliver::new(layout_exceeds_paint_geometry())) as BoxedSliverObject,
+        );
+
+    let entry = owner
+        .render_tree_mut()
+        .get_mut(sliver_id)
+        .and_then(|node| node.as_sliver_mut())
+        .expect("sliver entry");
+    let committed = entry
+        .layout_leaf_only(sliver_constraints())
+        .expect("a content-contract violation must not fail layout");
+
+    assert_eq!(
+        committed,
+        layout_exceeds_paint_geometry(),
+        "the violating geometry is consumed as-is (Flutter release behavior)"
+    );
+    assert_eq!(
+        entry.state().geometry(),
+        Some(layout_exceeds_paint_geometry()),
+        "the violating geometry must be COMMITTED — leaving the previous          commit in place freezes the node forever (issue #708)"
+    );
+    assert!(
+        !entry.needs_layout(),
+        "a committed layout is a completed layout"
+    );
+}
+
+#[test]
 fn sliver_descendant_invalid_geometry_returns_zero_and_poisons() {
     let captured: Arc<Mutex<Option<SliverGeometry>>> = Arc::new(Mutex::new(None));
     let parent_obj: BoxedRenderObject = Box::new(BoxWithSliverChild::new(
         sliver_constraints(),
         Arc::clone(&captured),
     ));
-    let sliver_obj: BoxedSliverObject = Box::new(BadGeometrySliver::new(
-        invalid_layout_exceeds_paint_geometry(),
-    ));
+    let sliver_obj: BoxedSliverObject =
+        Box::new(BadGeometrySliver::new(invalid_negative_paint_geometry()));
 
     let mut pipeline = PipelineOwner::new().into_layout();
     let parent_id = pipeline.render_tree_mut().insert_box(parent_obj);

--- a/crates/flui-rendering/tests/sliver_geometry_validation.rs
+++ b/crates/flui-rendering/tests/sliver_geometry_validation.rs
@@ -60,9 +60,8 @@ fn invalid_negative_paint_geometry() -> SliverGeometry {
 
 /// The content contract (Flutter's DEBUG-ONLY asserts, `sliver.dart:881-894`):
 /// a violating geometry still COMMITS — a release Flutter build consumes it
-/// as-is, and rejecting it instead froze the viewport permanently (issue
-/// #708: every retry re-violated, so the stale committed geometry never
-/// refreshed).
+/// as-is, and rejecting it instead freezes the viewport permanently (every
+/// retry re-violates, so the stale committed geometry never refreshes).
 fn layout_exceeds_paint_geometry() -> SliverGeometry {
     SliverGeometry {
         scroll_extent: 100.0,
@@ -206,7 +205,7 @@ fn sliver_content_contract_violation_commits_and_stays_clean() {
     assert_eq!(
         entry.state().geometry(),
         Some(layout_exceeds_paint_geometry()),
-        "the violating geometry must be COMMITTED — leaving the previous          commit in place freezes the node forever (issue #708)"
+        "the violating geometry must be committed; leaving the previous commit in place freezes the node forever"
     );
     assert!(
         !entry.needs_layout(),

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -373,6 +373,136 @@ fn a_delegate_swap_rebuilds_only_when_should_rebuild_says_so() {
 }
 
 // ============================================================================
+// #708 regression: the child-driven paint boundary must not freeze layout
+// ============================================================================
+
+/// A delegate whose child can size BELOW the header's layout extent: a
+/// bare `ConstrainedBox` (min 100 / max 200) with no child. On the frames
+/// where the child measures under the header's `layout_extent`, the pinned
+/// header emits `layout_extent > paint_extent` — a geometry that violates
+/// its CONTENT contract (Flutter's debug-only assert,
+/// `sliver.dart:881-885`) while remaining perfectly consumable.
+struct MinSizingDelegate;
+
+impl SliverPersistentHeaderDelegate for MinSizingDelegate {
+    fn build(
+        &self,
+        _ctx: &dyn flui_view::BuildContext,
+        _shrink_offset: f32,
+        _overlaps_content: bool,
+    ) -> BoxedView {
+        flui_widgets::ConstrainedBox::new(flui_rendering::constraints::BoxConstraints {
+            min_width: flui_types::geometry::px(0.0),
+            max_width: flui_types::geometry::px(f32::INFINITY),
+            min_height: flui_types::geometry::px(100.0),
+            max_height: flui_types::geometry::px(200.0),
+        })
+        .into_view()
+        .boxed()
+    }
+
+    fn min_extent(&self) -> f32 {
+        100.0
+    }
+
+    fn max_extent(&self) -> f32 {
+        200.0
+    }
+}
+
+/// Issue #708: before the fix, `validate_layout_output` REJECTED that
+/// content-contract-violating geometry — the commit was skipped, the
+/// parent saw a `SliverGeometry::ZERO` stand-in, and since every retry
+/// re-violated, the header's committed geometry stayed frozen at its last
+/// pre-boundary value for the rest of the app's life. The scene must be
+/// driven by real animation frames (a root-dirtying `pump` masks the
+/// freeze) and must cross the boundary where the child's measure first
+/// falls below the header's layout extent.
+#[test]
+fn a_min_sizing_child_survives_the_child_driven_paint_boundary() {
+    use flui_widgets::{ScrollController, Scrollable, Viewport};
+
+    let controller = ScrollController::new();
+    let position_for_viewport = controller.position();
+    let big = |height: f32| -> BoxedView {
+        SliverToBoxAdapter::new()
+            .child(SizedBox::new(800.0, height))
+            .into_view()
+            .boxed()
+    };
+    let slivers: Vec<BoxedView> = vec![
+        big(550.0),
+        SliverPersistentHeader::new(MinSizingDelegate)
+            .pinned(true)
+            .into_view()
+            .boxed(),
+        SliverPersistentHeader::new(MinSizingDelegate)
+            .pinned(true)
+            .into_view()
+            .boxed(),
+        big(550.0),
+        big(550.0),
+    ];
+    let scrollable = Scrollable::new()
+        .controller(controller.clone())
+        .viewport_builder(Rc::new(move |_| {
+            Viewport::new(slivers.clone())
+                .position(position_for_viewport.clone())
+                .boxed()
+        }));
+    let vsync = flui_animation::Vsync::new();
+    let mut laid = lay_out(
+        flui_widgets::VsyncScope::new(vsync.clone(), scrollable),
+        tight(800.0, 600.0),
+    );
+    laid.adopt_vsync(vsync);
+
+    // The FIRST header in scroll order — `find_all_by_render_type` returns
+    // render-tree order, not paint order, so pick by committed offset.
+    let header = *laid
+        .find_all_by_render_type("RenderSliverPinnedPersistentHeader")
+        .iter()
+        .min_by(|a, b| {
+            laid.offset(**a)
+                .dy
+                .get()
+                .total_cmp(&laid.offset(**b).dy.get())
+        })
+        .expect("two pinned headers are mounted");
+    // Premise: below the boundary the header's paint is capped by the
+    // remaining room (600 − 550 = 50), not the child.
+    assert_eq!(laid.sliver_geometry(header).paint_extent, 50.0);
+
+    // March across the boundary (remaining exceeds the child's 100 once
+    // pixels pass 50) the way a scroll animation does: the fling
+    // controller's vsync tick writes pixels DURING the frame.
+    controller.animate_to(
+        550.0,
+        std::time::Duration::from_mins(1),
+        std::sync::Arc::new(flui_animation::Curves::Linear),
+    );
+    for _ in 0..64 {
+        laid.pump_for(std::time::Duration::from_secs(1));
+        if !controller.position().is_scrolling() {
+            break;
+        }
+    }
+    laid.tick();
+
+    // pixels = 120 ⇒ remaining = 170 ⇒ the committed paint extent is the
+    // CHILD's 100 — and, critically, layout must still be tracking at all.
+    assert_eq!(
+        laid.sliver_geometry(header).paint_extent,
+        100.0,
+        "the committed geometry must track across the child-driven boundary          (a stale pre-boundary value means the viewport froze — issue #708)"
+    );
+    assert!(
+        laid.sliver_geometry(header).visible,
+        "a 100px-painted pinned header is visible"
+    );
+}
+
+// ============================================================================
 // Snap: the full seam — gesture end → activity signal → epoch command →
 // render snap animation
 // ============================================================================

--- a/crates/flui-widgets/tests/sliver_persistent_header.rs
+++ b/crates/flui-widgets/tests/sliver_persistent_header.rs
@@ -373,7 +373,7 @@ fn a_delegate_swap_rebuilds_only_when_should_rebuild_says_so() {
 }
 
 // ============================================================================
-// #708 regression: the child-driven paint boundary must not freeze layout
+// The child-driven paint boundary must not freeze layout (issue #708)
 // ============================================================================
 
 /// A delegate whose child can size BELOW the header's layout extent: a
@@ -494,7 +494,7 @@ fn a_min_sizing_child_survives_the_child_driven_paint_boundary() {
     assert_eq!(
         laid.sliver_geometry(header).paint_extent,
         100.0,
-        "the committed geometry must track across the child-driven boundary          (a stale pre-boundary value means the viewport froze — issue #708)"
+        "the committed geometry must track across the child-driven boundary; a stale pre-boundary value means the viewport froze"
     );
     assert!(
         laid.sliver_geometry(header).visible,

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -72,10 +72,18 @@ fn main() {
         "colored-box" => render_view_to_layers(colored_box_app::App, width, height),
         "text" => render_view_to_layers(text_app::App, width, height),
         "telemetry-overlay" => telemetry_overlay_layers(),
+        // The collapsing-sliver scene at three scroll depths — a visual
+        // check on the SliverAppBar / FlexibleSpaceBar / pinned-header
+        // pipeline (expanded, mid-collapse with the background fading and
+        // parallaxing, and fully collapsed to the pinned toolbar).
+        "sliver" => render_view_to_layers(sliver_demo(0.0), width, height),
+        "sliver-mid" => render_view_to_layers(sliver_demo(90.0), width, height),
+        "sliver-collapsed" => render_view_to_layers(sliver_demo(500.0), width, height),
         other => {
             eprintln!(
                 "unknown demo {other:?}; expected: material | cupertino | vertical-slice | \
-                 gallery | animated-box | colored-box | text | telemetry-overlay"
+                 gallery | animated-box | colored-box | text | telemetry-overlay | \
+                 sliver | sliver-mid | sliver-collapsed"
             );
             std::process::exit(2);
         }
@@ -96,6 +104,54 @@ fn main() {
     .expect("encode the captured pixels as PNG");
 
     println!("wrote {out_path} ({demo}, {width}x{height})");
+}
+
+/// A Material collapsing-header scene: pinned `SliverAppBar` with a
+/// `FlexibleSpaceBar` (title + gradient-ish colored background) over a list
+/// of labeled rows, mounted pre-scrolled to `offset`.
+fn sliver_demo(offset: f32) -> impl IntoView {
+    use flui::material::{FlexibleSpaceBar, SliverAppBar, Theme, ThemeData};
+    use flui::widgets::{
+        ColoredBox, CustomScrollView, MediaQuery, MediaQueryData, Padding, SizedBox,
+        SliverToBoxAdapter, Text,
+    };
+    use flui_types::{Color, EdgeInsets};
+    use flui_view::view::ViewExt;
+
+    // The title lives in the flexible space only (the usual collapsing-bar
+    // shape): it rides the collapse, scaling from 1.5x at the bottom edge
+    // to toolbar size.
+    let bar = SliverAppBar::new()
+        .expanded_height(220.0)
+        .pinned(true)
+        .flexible_space(
+            FlexibleSpaceBar::new()
+                .title(Text::new("FLUI Slivers"))
+                .background(ColoredBox::new(Color::rgb(21, 101, 192))),
+        );
+
+    let mut slivers: Vec<flui_view::BoxedView> = vec![bar.into_view().boxed()];
+    for i in 0..14 {
+        let shade = if i % 2 == 0 { 245 } else { 232 };
+        slivers.push(
+            SliverToBoxAdapter::new()
+                .child(ColoredBox::new(Color::rgb(shade, shade, shade)).child(
+                    SizedBox::new(0.0, 56.0).child(Padding::new(EdgeInsets::all(px(16.0))).child(
+                        Text::new(format!("Row {i} — scrolled under a pinned SliverAppBar")),
+                    )),
+                ))
+                .into_view()
+                .boxed(),
+        );
+    }
+
+    Theme::new(
+        ThemeData::light(),
+        MediaQuery::new(
+            MediaQueryData::default(),
+            CustomScrollView::new(slivers).offset(offset),
+        ),
+    )
 }
 
 fn telemetry_overlay_layers() -> LayerTree {
@@ -157,18 +213,15 @@ fn render_view_to_layers<V: IntoView + 'static>(
         ))));
     });
 
-    // `PipelineOwner::run_frame` runs layout → compositing → paint and returns
-    // the composited `LayerTree` (same extraction as `RendererBinding::
-    // draw_frame`): take the owner out of the lock by value, run the frame,
-    // restore it. Driving the render frame directly on the freshly-built tree
-    // keeps its paint dirty — a prior widgets-layer frame would have consumed it.
+    // The layout↔build fixpoint frame — the SAME helper `HeadlessBinding`'s
+    // pump and the live `draw_frame` use. A bare `PipelineOwner::run_frame`
+    // never services build-during-layout content (a `SliverAppBar`'s
+    // delegate child, any persistent-header body), so a hand-rolled frame
+    // here captured collapsing app bars as empty space.
     let layer_tree = binding.enter_owner_scope(|| {
-        pipeline_owner.with_mut(|guard| {
-            let owner = std::mem::take(guard);
-            let (owner, result) = owner.run_frame();
-            *guard = owner;
-            result.expect("the render frame must succeed")
-        })
+        build_owner
+            .run_frame_with_layout_builders(&mut element_tree, &pipeline_owner)
+            .expect("the render frame must succeed")
     });
 
     layer_tree.expect("the render frame must produce a LayerTree")

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -36,6 +36,9 @@ mod animated_box_app;
 #[path = "colored_box_app.rs"]
 mod colored_box_app;
 #[allow(dead_code, unused_imports)]
+#[path = "sliver_demo.rs"]
+mod sliver_demo_app;
+#[allow(dead_code, unused_imports)]
 #[path = "text_app.rs"]
 mod text_app;
 #[allow(dead_code, unused_imports)]
@@ -76,9 +79,9 @@ fn main() {
         // check on the SliverAppBar / FlexibleSpaceBar / pinned-header
         // pipeline (expanded, mid-collapse with the background fading and
         // parallaxing, and fully collapsed to the pinned toolbar).
-        "sliver" => render_view_to_layers(sliver_demo(0.0), width, height),
-        "sliver-mid" => render_view_to_layers(sliver_demo(90.0), width, height),
-        "sliver-collapsed" => render_view_to_layers(sliver_demo(500.0), width, height),
+        "sliver" => render_view_to_layers(sliver_demo_app::tree(0.0), width, height),
+        "sliver-mid" => render_view_to_layers(sliver_demo_app::tree(90.0), width, height),
+        "sliver-collapsed" => render_view_to_layers(sliver_demo_app::tree(500.0), width, height),
         other => {
             eprintln!(
                 "unknown demo {other:?}; expected: material | cupertino | vertical-slice | \
@@ -104,54 +107,6 @@ fn main() {
     .expect("encode the captured pixels as PNG");
 
     println!("wrote {out_path} ({demo}, {width}x{height})");
-}
-
-/// A Material collapsing-header scene: pinned `SliverAppBar` with a
-/// `FlexibleSpaceBar` (title + gradient-ish colored background) over a list
-/// of labeled rows, mounted pre-scrolled to `offset`.
-fn sliver_demo(offset: f32) -> impl IntoView {
-    use flui::material::{FlexibleSpaceBar, SliverAppBar, Theme, ThemeData};
-    use flui::widgets::{
-        ColoredBox, CustomScrollView, MediaQuery, MediaQueryData, Padding, SizedBox,
-        SliverToBoxAdapter, Text,
-    };
-    use flui_types::{Color, EdgeInsets};
-    use flui_view::view::ViewExt;
-
-    // The title lives in the flexible space only (the usual collapsing-bar
-    // shape): it rides the collapse, scaling from 1.5x at the bottom edge
-    // to toolbar size.
-    let bar = SliverAppBar::new()
-        .expanded_height(220.0)
-        .pinned(true)
-        .flexible_space(
-            FlexibleSpaceBar::new()
-                .title(Text::new("FLUI Slivers"))
-                .background(ColoredBox::new(Color::rgb(21, 101, 192))),
-        );
-
-    let mut slivers: Vec<flui_view::BoxedView> = vec![bar.into_view().boxed()];
-    for i in 0..14 {
-        let shade = if i % 2 == 0 { 245 } else { 232 };
-        slivers.push(
-            SliverToBoxAdapter::new()
-                .child(ColoredBox::new(Color::rgb(shade, shade, shade)).child(
-                    SizedBox::new(0.0, 56.0).child(Padding::new(EdgeInsets::all(px(16.0))).child(
-                        Text::new(format!("Row {i} — scrolled under a pinned SliverAppBar")),
-                    )),
-                ))
-                .into_view()
-                .boxed(),
-        );
-    }
-
-    Theme::new(
-        ThemeData::light(),
-        MediaQuery::new(
-            MediaQueryData::default(),
-            CustomScrollView::new(slivers).offset(offset),
-        ),
-    )
 }
 
 fn telemetry_overlay_layers() -> LayerTree {

--- a/examples/sliver_demo.rs
+++ b/examples/sliver_demo.rs
@@ -1,0 +1,104 @@
+//! Collapsing-sliver demo — a pinned [`SliverAppBar`] with a
+//! [`FlexibleSpaceBar`] (title + colored background) over a list of labeled
+//! rows, scrolled live by drag/fling.
+//!
+//! Run with: cargo run -p flui --features material --example sliver_demo
+//!
+//! The same tree, pre-scrolled to fixed offsets, is captured headlessly by
+//! `examples/screenshot.rs`'s `sliver` | `sliver-mid` | `sliver-collapsed`
+//! arms (which `#[path]`-include this file), so the screenshots and this
+//! window always show the same widget tree.
+//!
+//! No local `tracing_subscriber` init, matching every other `run_app`-based
+//! example: `run_app` installs the process-global subscriber itself.
+
+use std::rc::Rc;
+
+use flui::material::{FlexibleSpaceBar, SliverAppBar, Theme, ThemeData};
+use flui::widgets::{
+    ColoredBox, CustomScrollView, MediaQuery, MediaQueryData, Padding, ScrollController,
+    Scrollable, SizedBox, SliverToBoxAdapter, Text, Viewport,
+};
+use flui_types::geometry::px;
+use flui_types::{Color, EdgeInsets};
+use flui_view::view::ViewExt;
+use flui_view::{BoxedView, BuildContext, IntoView, StatelessView, View};
+
+/// The demo slivers: the collapsing bar plus 30 labeled rows.
+fn demo_slivers() -> Vec<BoxedView> {
+    let bar = SliverAppBar::new()
+        .expanded_height(220.0)
+        .pinned(true)
+        .flexible_space(
+            FlexibleSpaceBar::new()
+                .title(Text::new("FLUI Slivers"))
+                .background(ColoredBox::new(Color::rgb(21, 101, 192))),
+        );
+
+    let mut slivers: Vec<BoxedView> = vec![bar.into_view().boxed()];
+    for i in 0..30 {
+        let shade = if i % 2 == 0 { 245 } else { 232 };
+        slivers.push(
+            SliverToBoxAdapter::new()
+                .child(ColoredBox::new(Color::rgb(shade, shade, shade)).child(
+                    SizedBox::height(56.0).child(Padding::new(EdgeInsets::all(px(16.0))).child(
+                        Text::new(format!("Row {i} — scrolled under a pinned SliverAppBar")),
+                    )),
+                ))
+                .into_view()
+                .boxed(),
+        );
+    }
+    slivers
+}
+
+/// The screenshot tree: the demo slivers at a FIXED programmatic offset —
+/// `CustomScrollView`'s offset mode carries no gestures by design (see its
+/// module doc), which is exactly right for a deterministic capture.
+pub fn tree(offset: f32) -> impl IntoView {
+    Theme::new(
+        ThemeData::light(),
+        MediaQuery::new(
+            MediaQueryData::default(),
+            CustomScrollView::new(demo_slivers()).offset(offset),
+        ),
+    )
+}
+
+/// The LIVE tree: the same slivers behind a gesture-driven [`Scrollable`]
+/// (drag and fling; the collapsing bar reacts to the shared position).
+fn live_tree() -> impl IntoView {
+    let controller = ScrollController::new();
+    let slivers = demo_slivers();
+    Theme::new(
+        ThemeData::light(),
+        MediaQuery::new(
+            MediaQueryData::default(),
+            Scrollable::new()
+                .controller(controller)
+                .viewport_builder(Rc::new(move |position| {
+                    Viewport::new(slivers.clone()).position(position).boxed()
+                })),
+        ),
+    )
+}
+
+/// Stateless root: the demo tree, fully expanded, scrolled live.
+#[derive(Clone, Debug)]
+pub struct SliverDemoApp;
+
+impl StatelessView for SliverDemoApp {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        live_tree()
+    }
+}
+
+impl View for SliverDemoApp {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateless(self)
+    }
+}
+
+fn main() {
+    flui::run_app(SliverDemoApp);
+}


### PR DESCRIPTION
## What

Fixes #708 — the permanent viewport freeze at the child-driven paint boundary — and repairs the headless screenshot harness that was hiding every build-during-layout subtree from visual verification. A `sliver` demo triple rides along as the visual proof (and promptly caught #710).

## The #708 fix: content-contract violations warn and commit, matching release Flutter

Root cause (diagnosed with per-child layout instrumentation, then pinned): when a pinned header's seam-built child measures below the header's `layout_extent` (a min-sizing child — a delegate content bug), the header emits `layout_extent > paint_extent`. FLUI's `SliverGeometry::validation_error` treated that as a **fatal** commit-blocker: `validate_layout_output` rejected it, the commit and `clear_needs_layout` were skipped, the parent saw a `SliverGeometry::ZERO` stand-in — and since every retry re-violated, the node's committed geometry stayed frozen at its last pre-boundary value for the rest of the app's life. Silently.

Flutter draws this exact line differently (`sliver.dart:881-894`): `layoutExtent <= paintExtent` and `paintExtent <= maxPaintExtent` are **debug-only asserts**; a release build commits and consumes the geometry as-is (the successor sits at `layout_extent` past the shorter paint). Per FLUI's established policy for content bugs (the viewport's own non-convergence precedent: warn in release, never crash on third-party widget bugs), the two rules move out of `validation_error()` into a new `SliverGeometry::content_contract_violation()`, and `SliverProtocol::validate_layout_output` now **warns and commits** on them. Pipeline-safety rules (NaN/∞/negative) still reject; the layout-poison mechanism for those is untouched (its test fixtures switched to a genuinely-hard violation).

Tests: `a_min_sizing_child_survives_the_child_driven_paint_boundary` (born red at 95.83-stale vs 100; needs the two-pinned-header scene driven by real animation frames at 1s cadence — a root-dirtying `pump` masks the freeze) and `sliver_content_contract_violation_commits_and_stays_clean` (leaf-level pin of commit + clean bit). Both red-verified by restoring the rejection in `validate_layout_output`.

## The screenshot-harness fix: use the shared fixpoint frame

`examples/screenshot.rs` hand-rolled `PipelineOwner::run_frame` — which never services build-during-layout content, so a `SliverAppBar`'s entire delegate subtree captured as empty space. The helper's own doc says neither path may hand-roll this loop; the example now calls the same `BuildOwner::run_frame_with_layout_builders` that `HeadlessBinding::pump_frame` and the live `draw_frame` use.

## The demo triple

`cargo run -p flui --features "material cupertino" --example screenshot -- sliver | sliver-mid | sliver-collapsed` — a pinned `SliverAppBar` + `FlexibleSpaceBar` (title + colored background) over a labeled list, pre-scrolled to 0 / 90 / 500. Verified by eye: expanded 220px bar with the 1.5×-scaled bottom-start title, mid-collapse tracking, pinned 56px toolbar with the background faded exactly at the fade window. The collapsed capture exposed **#710** (SliverAppBar paints no toolbar surface of its own once the flexible background fades) — filed, not fixed here.

## Evidence

- Both #708 pins red→green; the freeze reproduction requires the animation-driven 1s-cadence scene (documented in the test).
- 863 flui-rendering + 3489 flui-objects/widgets/material/cupertino tests green; `just ci` green (log-verified `JUST_CI_EXIT: 0`).
- The three captures inspected visually — the collapse geometry, title scaling, and fade all behave; #710 tracks the one cosmetic gap found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
