### PR TITLE
fix(platform): winit cursor moves carry the held mouse buttons — live drag-scrolling works

### DIFF
--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1480,6 +1480,15 @@ impl UiRealm {
     fn request_redraw_for(&self, presentation: &PresentationState) {
         self.needs_redraw.store(true, Ordering::Relaxed);
         presentation.mark_redraw_pending();
+        // The flags alone are inert while the event loop is parked: nothing
+        // converts them into a frame until SOMETHING pokes the platform.
+        // An input-driven redraw request (a drag's scroll write) was
+        // exactly that case — the loop went straight back to waiting after
+        // the pointer event, the flags sat unread, and a live drag froze
+        // the screen while the position advanced invisibly. The wake sets
+        // `needs_redraw` (idempotent with the store above) AND requests a
+        // platform redraw, which winit coalesces per frame.
+        (self.wake)();
     }
 
     /// [`Self::request_redraw_for`]'s pipeline-dirtying counterpart,
@@ -4042,6 +4051,36 @@ mod tests {
     /// `RealmServices` (a fresh `UpdateScheduler` strong root) instead of reaching
     /// a process-global one, so two realms on one thread no longer alias
     /// anything to guard against.
+    /// An input-driven redraw request must WAKE the platform loop, not just
+    /// set flags: the loop parks between events, and flags nobody pokes it
+    /// about are inert — a live drag froze the screen for exactly this
+    /// reason (125 pointer moves produced 2 frames; the pointer-routing
+    /// path requested a redraw every time, flag-only). The wake is what
+    /// converts the request into a `RedrawRequested` and therefore a frame.
+    #[test]
+    fn a_redraw_request_fires_the_platform_wake() {
+        let wake_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let wake_count_in_closure = Arc::clone(&wake_count);
+        let wake: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            wake_count_in_closure.fetch_add(1, Ordering::Relaxed);
+        });
+        let realm = UiRealm::new(
+            wake,
+            crate::app::presentation::test_platform_window(None),
+            1.0,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("test realm construction");
+
+        realm.request_redraw();
+
+        assert!(
+            wake_count.load(Ordering::Relaxed) >= 1,
+            "request_redraw must fire the platform wake — flag-only requests \
+             leave a parked event loop asleep and the screen frozen"
+        );
+    }
+
     #[test]
     fn two_realms_coexist_same_thread() {
         use std::cell::Cell;

--- a/crates/flui-platform/src/platforms/winit/events.rs
+++ b/crates/flui-platform/src/platforms/winit/events.rs
@@ -38,11 +38,19 @@ fn primary_mouse_info() -> PointerInfo {
 }
 
 /// Build a `PointerState` from position and scale factor.
+///
+/// `buttons` is the set of buttons HELD at this instant — the W3C
+/// `PointerEvent.buttons` field, and what the gesture layer uses to tell a
+/// drag-move from a hover (`flui-interaction`'s own move constructors stamp
+/// the held set the same way). A move that always reports an empty set is
+/// classified as a hover, so an active pan never receives updates and
+/// drag-scrolling in a live window silently does nothing.
 fn pointer_state(
     position: winit::dpi::PhysicalPosition<f64>,
     scale_factor: f64,
     pressure: f32,
     modifiers: KeyboardModifiers,
+    buttons: PointerButtons,
 ) -> PointerState {
     let logical_x = position.x / scale_factor;
     let logical_y = position.y / scale_factor;
@@ -50,7 +58,7 @@ fn pointer_state(
     PointerState {
         time: event_timestamp_ms(),
         position: PhysicalPosition::new(logical_x, logical_y),
-        buttons: PointerButtons::default(),
+        buttons,
         modifiers,
         count: 1,
         contact_geometry: PhysicalSize::new(1.0, 1.0),
@@ -62,7 +70,7 @@ fn pointer_state(
 }
 
 /// Convert winit MouseButton to W3C PointerButton
-fn convert_mouse_button(button: MouseButton) -> PointerButton {
+pub(crate) fn convert_mouse_button(button: MouseButton) -> PointerButton {
     match button {
         // `Other` carries a vendor-specific button id ui-events has no slot
         // for; treat it as the primary button like an unrecognized click.
@@ -96,12 +104,22 @@ pub fn convert_modifiers(modifiers: winit::event::Modifiers) -> KeyboardModifier
 }
 
 /// Convert winit CursorMoved to W3C PointerEvent::Move
+///
+/// `held_buttons` comes from the platform's tracked button state (winit's
+/// `CursorMoved` carries no button information of its own): with a button
+/// held this is a drag-move, without one a hover.
 pub fn cursor_moved_event(
     position: winit::dpi::PhysicalPosition<f64>,
     scale_factor: f64,
     modifiers: KeyboardModifiers,
+    held_buttons: PointerButtons,
 ) -> PlatformInput {
-    let state = pointer_state(position, scale_factor, 0.0, modifiers);
+    let pressure = if held_buttons == PointerButtons::default() {
+        0.0
+    } else {
+        0.5
+    };
+    let state = pointer_state(position, scale_factor, pressure, modifiers, held_buttons);
 
     let event = PointerEvent::Move(PointerUpdate {
         pointer: primary_mouse_info(),
@@ -114,17 +132,20 @@ pub fn cursor_moved_event(
 }
 
 /// Convert winit MouseInput to W3C PointerEvent::Down/Up
+/// `held_buttons` is the set held AFTER this transition (press included /
+/// release excluded), per the W3C `buttons` contract for down/up events.
 pub fn mouse_button_event(
     button: MouseButton,
     state: ElementState,
     position: winit::dpi::PhysicalPosition<f64>,
     scale_factor: f64,
     modifiers: KeyboardModifiers,
+    held_buttons: PointerButtons,
 ) -> PlatformInput {
     let is_down = state == ElementState::Pressed;
     let pointer_button = convert_mouse_button(button);
     let pressure = if is_down { 0.5 } else { 0.0 };
-    let pointer_state = pointer_state(position, scale_factor, pressure, modifiers);
+    let pointer_state = pointer_state(position, scale_factor, pressure, modifiers, held_buttons);
 
     let event = if is_down {
         PointerEvent::Down(PointerButtonEvent {
@@ -157,7 +178,13 @@ pub fn mouse_wheel_event(
         }
     };
 
-    let state = pointer_state(position, scale_factor, 0.0, modifiers);
+    let state = pointer_state(
+        position,
+        scale_factor,
+        0.0,
+        modifiers,
+        PointerButtons::default(),
+    );
 
     let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {
         pointer: primary_mouse_info(),
@@ -387,6 +414,77 @@ pub fn keyboard_event(
     };
 
     PlatformInput::Keyboard(keyboard_event)
+}
+
+#[cfg(test)]
+mod pointer_translation_tests {
+    use super::*;
+    use ui_events::pointer::PointerEvent;
+
+    /// A cursor move with a button held is a DRAG move: the emitted
+    /// `PointerState.buttons` carries the held set (what the gesture layer
+    /// uses to route the move to an active pan instead of the hover path)
+    /// and a non-zero pressure, mirroring `flui-interaction`'s own move
+    /// constructors. An empty set stays a hover.
+    #[test]
+    fn cursor_move_with_held_button_is_a_drag_not_a_hover() {
+        let held = PointerButtons::from(PointerButton::Primary);
+        let input = cursor_moved_event(
+            winit::dpi::PhysicalPosition::new(100.0, 100.0),
+            1.0,
+            KeyboardModifiers::empty(),
+            held,
+        );
+        let PlatformInput::Pointer(PointerEvent::Move(update)) = input else {
+            panic!("cursor move must translate to PointerEvent::Move");
+        };
+        assert_eq!(update.current.buttons, held);
+        assert!(update.current.pressure > 0.0);
+
+        let hover = cursor_moved_event(
+            winit::dpi::PhysicalPosition::new(100.0, 100.0),
+            1.0,
+            KeyboardModifiers::empty(),
+            PointerButtons::default(),
+        );
+        let PlatformInput::Pointer(PointerEvent::Move(update)) = hover else {
+            panic!("cursor move must translate to PointerEvent::Move");
+        };
+        assert_eq!(update.current.buttons, PointerButtons::default());
+        assert_eq!(update.current.pressure, 0.0);
+    }
+
+    /// Down/up events carry the post-transition held set — press included,
+    /// release excluded (the W3C `buttons` contract).
+    #[test]
+    fn button_events_carry_the_post_transition_held_set() {
+        let after_press = PointerButtons::from(PointerButton::Primary);
+        let down = mouse_button_event(
+            MouseButton::Left,
+            ElementState::Pressed,
+            winit::dpi::PhysicalPosition::new(0.0, 0.0),
+            1.0,
+            KeyboardModifiers::empty(),
+            after_press,
+        );
+        let PlatformInput::Pointer(PointerEvent::Down(event)) = down else {
+            panic!("press must translate to PointerEvent::Down");
+        };
+        assert_eq!(event.state.buttons, after_press);
+
+        let up = mouse_button_event(
+            MouseButton::Left,
+            ElementState::Released,
+            winit::dpi::PhysicalPosition::new(0.0, 0.0),
+            1.0,
+            KeyboardModifiers::empty(),
+            PointerButtons::default(),
+        );
+        let PlatformInput::Pointer(PointerEvent::Up(event)) = up else {
+            panic!("release must translate to PointerEvent::Up");
+        };
+        assert_eq!(event.state.buttons, PointerButtons::default());
+    }
 }
 
 #[cfg(test)]

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -242,6 +242,13 @@ struct WinitPlatformState {
 
     /// Current keyboard modifiers
     current_modifiers: KeyboardModifiers,
+
+    /// Mouse buttons currently held, tracked from `MouseInput` transitions —
+    /// winit's `CursorMoved` carries no button state of its own, and a move
+    /// with an empty button set is a HOVER to the gesture layer, so without
+    /// this the pan recognizer never receives drag updates (live
+    /// drag-scrolling did nothing).
+    pressed_buttons: ui_events::pointer::PointerButtons,
 }
 
 impl WinitPlatformState {
@@ -270,6 +277,7 @@ impl WinitPlatformState {
             },
             cursor_positions: HashMap::new(),
             current_modifiers: KeyboardModifiers::empty(),
+            pressed_buttons: ui_events::pointer::PointerButtons::default(),
         }
     }
 
@@ -943,32 +951,48 @@ impl ApplicationHandler for WinitApp {
                 );
             }
             WinitWindowEvent::CursorMoved { position, .. } => {
-                let modifiers = self.platform.with_state(|state| {
+                let (modifiers, held_buttons) = self.platform.with_state(|state| {
                     state.cursor_positions.insert(platform_id, position);
-                    state.current_modifiers
+                    (state.current_modifiers, state.pressed_buttons)
                 });
 
                 if let Some(ref win) = window {
                     let scale = win.scale_factor();
-                    let input = winit_events::cursor_moved_event(position, scale, modifiers);
+                    let input =
+                        winit_events::cursor_moved_event(position, scale, modifiers, held_buttons);
                     win.callbacks().dispatch_input(input);
                 }
             }
             WinitWindowEvent::MouseInput { state, button, .. } => {
-                let (modifiers, cursor_pos) = self.platform.with_state(|s| {
+                let (modifiers, cursor_pos, held_buttons) = self.platform.with_state(|s| {
+                    // Track the transition first: the emitted event's
+                    // `buttons` is the set held AFTER it (press included,
+                    // release excluded), per the W3C contract.
+                    let pointer_button = winit_events::convert_mouse_button(button);
+                    if state == winit::event::ElementState::Pressed {
+                        s.pressed_buttons.insert(pointer_button);
+                    } else {
+                        s.pressed_buttons.remove(pointer_button);
+                    }
                     (
                         s.current_modifiers,
                         s.cursor_positions
                             .get(&platform_id)
                             .copied()
                             .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                        s.pressed_buttons,
                     )
                 });
 
                 if let Some(ref win) = window {
                     let scale = win.scale_factor();
                     let input = winit_events::mouse_button_event(
-                        button, state, cursor_pos, scale, modifiers,
+                        button,
+                        state,
+                        cursor_pos,
+                        scale,
+                        modifiers,
+                        held_buttons,
                     );
                     win.callbacks().dispatch_input(input);
                 }

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -243,12 +243,29 @@ struct WinitPlatformState {
     /// Current keyboard modifiers
     current_modifiers: KeyboardModifiers,
 
-    /// Mouse buttons currently held, tracked from `MouseInput` transitions —
-    /// winit's `CursorMoved` carries no button state of its own, and a move
-    /// with an empty button set is a HOVER to the gesture layer, so without
-    /// this the pan recognizer never receives drag updates (live
-    /// drag-scrolling did nothing).
-    pressed_buttons: ui_events::pointer::PointerButtons,
+    /// Mouse buttons currently held, tracked as RAW winit buttons from
+    /// `MouseInput` transitions — winit's `CursorMoved` carries no button
+    /// state of its own, and a move with an empty button set is a HOVER to
+    /// the gesture layer, so without this the pan recognizer never receives
+    /// drag updates (live drag-scrolling did nothing).
+    ///
+    /// Raw, not normalized: `convert_mouse_button` maps every
+    /// `MouseButton::Other(_)` onto `Primary`, so a normalized set would
+    /// let releasing an aliased button clear `Primary` while the physical
+    /// left button is still down. The normalized set is DERIVED per event
+    /// by [`held_pointer_buttons`].
+    pressed_buttons: std::collections::HashSet<winit::event::MouseButton>,
+}
+
+/// The normalized W3C button set for the currently held raw buttons.
+fn held_pointer_buttons(
+    pressed: &std::collections::HashSet<winit::event::MouseButton>,
+) -> ui_events::pointer::PointerButtons {
+    let mut buttons = ui_events::pointer::PointerButtons::default();
+    for raw in pressed {
+        buttons.insert(winit_events::convert_mouse_button(*raw));
+    }
+    buttons
 }
 
 impl WinitPlatformState {
@@ -277,7 +294,7 @@ impl WinitPlatformState {
             },
             cursor_positions: HashMap::new(),
             current_modifiers: KeyboardModifiers::empty(),
-            pressed_buttons: ui_events::pointer::PointerButtons::default(),
+            pressed_buttons: std::collections::HashSet::new(),
         }
     }
 
@@ -928,8 +945,15 @@ impl ApplicationHandler for WinitApp {
                 self.platform.with_state(|state| {
                     if focused {
                         state.active_window = Some(platform_id);
-                    } else if state.active_window == Some(platform_id) {
-                        state.active_window = None;
+                    } else {
+                        if state.active_window == Some(platform_id) {
+                            state.active_window = None;
+                        }
+                        // A release delivered while unfocused never reaches
+                        // `MouseInput`, so a set left as-is would replay the
+                        // stale hold on refocus and misclassify the next
+                        // cursor move as a drag.
+                        state.pressed_buttons.clear();
                     }
                 });
 
@@ -953,7 +977,10 @@ impl ApplicationHandler for WinitApp {
             WinitWindowEvent::CursorMoved { position, .. } => {
                 let (modifiers, held_buttons) = self.platform.with_state(|state| {
                     state.cursor_positions.insert(platform_id, position);
-                    (state.current_modifiers, state.pressed_buttons)
+                    (
+                        state.current_modifiers,
+                        held_pointer_buttons(&state.pressed_buttons),
+                    )
                 });
 
                 if let Some(ref win) = window {
@@ -965,14 +992,15 @@ impl ApplicationHandler for WinitApp {
             }
             WinitWindowEvent::MouseInput { state, button, .. } => {
                 let (modifiers, cursor_pos, held_buttons) = self.platform.with_state(|s| {
-                    // Track the transition first: the emitted event's
+                    // Track the RAW transition first: the emitted event's
                     // `buttons` is the set held AFTER it (press included,
-                    // release excluded), per the W3C contract.
-                    let pointer_button = winit_events::convert_mouse_button(button);
+                    // release excluded), per the W3C contract. Raw tracking
+                    // keeps aliased buttons (`Other(_)` normalizes onto
+                    // `Primary`) from clearing each other's bits.
                     if state == winit::event::ElementState::Pressed {
-                        s.pressed_buttons.insert(pointer_button);
+                        s.pressed_buttons.insert(button);
                     } else {
-                        s.pressed_buttons.remove(pointer_button);
+                        s.pressed_buttons.remove(&button);
                     }
                     (
                         s.current_modifiers,
@@ -980,7 +1008,7 @@ impl ApplicationHandler for WinitApp {
                             .get(&platform_id)
                             .copied()
                             .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
-                        s.pressed_buttons,
+                        held_pointer_buttons(&s.pressed_buttons),
                     )
                 });
 


### PR DESCRIPTION
## What

Every live FLUI window on the winit backend had non-functional drag-scrolling: `CursorMoved` carries no button state in winit, and the translation stamped `PointerButtons::default()` into every move — so a move with the primary button held reached the gesture layer as a **hover**, and an active pan never received a single update. Found when a user tried to scroll the new `sliver_demo` window and nothing moved.

Why no test ever caught it: the synthetic-event harness's move constructors (`flui-interaction`'s `make_move_event_for_id`) stamp `buttons: PointerButtons::from(PointerButton::Primary)` — the correct W3C shape, which this fix adopts. Every gesture test exercised the correct contract while the live translation violated it. The macOS backend already tracks buttons natively (`extract_mouse_buttons`); winit now does the same in platform state.

## The fix

- `WinitPlatformState` tracks held buttons from `MouseInput` transitions.
- `cursor_moved_event` stamps the tracked set (and drag-grade pressure when held); an empty set stays a hover.
- `mouse_button_event` carries the post-transition set — press included, release excluded — per the W3C `buttons` contract.

## Evidence

- Diagnosed with probes at both ends of the wire under `xvfb-run` + `xdotool`: winit events arrived and `pan_start` fired, but seven cursor moves after the press produced **zero** `pan_update` calls. After the fix the updates flow, and before/after screen captures show the list scrolled and the bar collapsed to its pinned state.
- New unit tests pin the translation contract (`cursor_move_with_held_button_is_a_drag_not_a_hover`, `button_events_carry_the_post_transition_held_set`).
- Full `flui-platform --all-features` suite green under the standard two-device setup; flui-widgets/flui-interaction green; `just ci` green (log-verified `JUST_CI_EXIT: 0`).

Observed during the same verification, filed separately: wheel `PointerEvent::Scroll` is emitted but unconsumed downstream (#712); the process segfaults after a clean window-close teardown (#713).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM