### PR TITLE
fix(interaction): cursor leaving the window clears hover state and fires on_exit

### DIFF
--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -681,12 +681,10 @@ pub(super) enum PlatformToUi {
     /// crosses the window edge keeps its hover visuals forever. Enter is a
     /// no-op today: the next `CursorMoved` re-primes hover from a fresh hit
     /// test on its own.
-    // Constructed by the shared desktop bootstrap's registration, so every
-    // backend whose `PlatformWindow` dispatches `on_hover_status_change`
-    // (winit, headless, and the native backends that implement it) routes
-    // here; a backend that never fires the callback simply never constructs
-    // the event.
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    // Constructed by both the desktop and web bootstraps' registrations, so
+    // every backend whose `PlatformWindow` dispatches
+    // `on_hover_status_change` routes here; a backend that never fires the
+    // callback simply never constructs the event.
     WindowHover(bool),
     /// Drive a lifecycle target that requires owner-local realm cleanup (most
     /// notably Detached during platform shutdown).
@@ -10475,6 +10473,15 @@ where
             let _ = dispatch_platform_realm(
                 realm_dispatch,
                 RealmTask::Event(PlatformToUi::WindowFocus(focused)),
+            );
+        }));
+        // The web translation already emits hover-status changes for DOM
+        // pointerenter/pointerleave; route them like the desktop bootstrap
+        // does so a cursor leaving the canvas sweeps hover state.
+        window.on_hover_status_change(Box::new(move |is_hovered| {
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::WindowHover(is_hovered)),
             );
         }));
 

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -681,9 +681,11 @@ pub(super) enum PlatformToUi {
     /// crosses the window edge keeps its hover visuals forever. Enter is a
     /// no-op today: the next `CursorMoved` re-primes hover from a fresh hit
     /// test on its own.
-    // Only the winit desktop bootstrap constructs this so far; other
-    // backends keep dispatching the platform-level callback with no realm
-    // consumer, exactly as before.
+    // Constructed by the shared desktop bootstrap's registration, so every
+    // backend whose `PlatformWindow` dispatches `on_hover_status_change`
+    // (winit, headless, and the native backends that implement it) routes
+    // here; a backend that never fires the callback simply never constructs
+    // the event.
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     WindowHover(bool),
     /// Drive a lifecycle target that requires owner-local realm cleanup (most

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -673,6 +673,19 @@ pub(super) enum PlatformToUi {
     // its `on_active_status_change` registration).
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     WindowVisibility(bool),
+    /// The pointer entered (`true`) or left (`false`) the window (winit's
+    /// `CursorEntered`/`CursorLeft`, via
+    /// `PlatformWindow::on_hover_status_change`). Leave sweeps the addressed
+    /// presentation's hover state — `MouseRegion::on_exit` fires and the
+    /// cursor resets; without this a widget hovered at the moment the cursor
+    /// crosses the window edge keeps its hover visuals forever. Enter is a
+    /// no-op today: the next `CursorMoved` re-primes hover from a fresh hit
+    /// test on its own.
+    // Only the winit desktop bootstrap constructs this so far; other
+    // backends keep dispatching the platform-level callback with no realm
+    // consumer, exactly as before.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    WindowHover(bool),
     /// Drive a lifecycle target that requires owner-local realm cleanup (most
     /// notably Detached during platform shutdown).
     Lifecycle(AppLifecycleState),
@@ -853,6 +866,9 @@ impl PlatformToUi {
                     realm.notify_presentation_focus_gained(presentation_id);
                 }
                 emit_lifecycle_transition(realm, old, new);
+            }
+            Self::WindowHover(inside) => {
+                realm.handle_window_hover_addressed(presentation_id, inside);
             }
             Self::WindowVisibility(visible) => {
                 // Presentation-level `FrameClock` gate — finer
@@ -9052,6 +9068,12 @@ where
             let _ = dispatch_platform_realm(
                 realm_dispatch,
                 RealmTask::Event(PlatformToUi::WindowVisibility(visible)),
+            );
+        }));
+        window.on_hover_status_change(Box::new(move |is_hovered| {
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::WindowHover(is_hovered)),
             );
         }));
 

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -2923,6 +2923,32 @@ impl UiRealm {
         }
     }
 
+    /// The pointer entered (`true`) or left (`false`) `presentation_id`'s
+    /// native window. Leave sweeps that presentation's hover state —
+    /// `MouseRegion::on_exit` fires for every hovered region and the cursor
+    /// resets — then pumps a frame so the un-hovered visuals actually paint.
+    /// Enter is a no-op: the next pointer move re-primes hover from a fresh
+    /// hit test on its own. A stale or unknown `presentation_id` is a traced
+    /// no-op, the same posture as every other addressed signal.
+    pub(crate) fn handle_window_hover_addressed(
+        &self,
+        presentation_id: PresentationId,
+        inside: bool,
+    ) {
+        if inside {
+            return;
+        }
+        let Some(presentation) = self.presentations.get(presentation_id) else {
+            tracing::trace!(
+                { flui_foundation::diagnostics::PRESENTATION_ID } = presentation_id.as_u64(),
+                "dropping a window-hover signal for a presentation this realm no longer hosts"
+            );
+            return;
+        };
+        presentation.gestures().handle_pointer_left_window();
+        self.request_redraw_for(presentation);
+    }
+
     /// Record that `presentation_id`'s native window just gained OS focus —
     /// [`FocusCoordinator::note_focus_gained`]'s sole write side. A stale or
     /// unknown `presentation_id` (already closed, or a forged/mixed address)

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -489,6 +489,16 @@ impl GestureBinding {
         &self.pointer_router
     }
 
+    /// The pointer left the hosting window: fire `on_exit` for every
+    /// hovered region and reset the cursor. The platform's window-leave
+    /// signal (winit `CursorLeft`) routes here; without it a widget hovered
+    /// at the moment the cursor crosses the window edge stays hovered
+    /// forever. Must run inside the owner lane scope, like every other
+    /// dispatch on this binding.
+    pub fn handle_pointer_left_window(&self) {
+        self.mouse_tracker.dispatch_window_left();
+    }
+
     /// Mouse tracking state owned by the same presentation as gesture routes.
     #[inline]
     #[must_use]

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -229,6 +229,67 @@ impl MouseTracker {
             .any(|state| state.pointer_type == PointerType::Mouse);
     }
 
+    /// Fires exit callbacks for every region every device currently hovers,
+    /// clears that hover state, and resets the cursor — the cursor has left
+    /// the window, so nothing is hovered any more.
+    ///
+    /// Flutter parity: `MouseTracker.updateWithEvent` reaches the same end
+    /// state through a `PointerRemovedEvent`/empty-hit-test update when the
+    /// platform reports the pointer leaving the view; FLUI's winit wire has
+    /// no synthetic remove event, so the window-leave signal calls this
+    /// directly. Without it, a widget hovered at the moment the cursor
+    /// crosses the window edge keeps its hover visuals forever and
+    /// `MouseRegion::on_exit` never fires.
+    ///
+    /// Device registrations survive (the pointer will come back); only the
+    /// hover/cursor state is swept. Calling with nothing hovered is a no-op.
+    /// Per-callback panics are isolated exactly like a motion update's: the
+    /// first is resumed after every callback ran.
+    pub fn dispatch_window_left(&self) {
+        let sweeps: Vec<DeviceWork> = {
+            let mut inner = self.inner.borrow_mut();
+            let inner = &mut *inner;
+            inner
+                .devices
+                .iter_mut()
+                .filter_map(|(&device_id, state)| {
+                    if state.active_order.is_empty() && state.current_cursor == CursorIcon::Default
+                    {
+                        return None;
+                    }
+                    let exit_callbacks: SmallVec<[MouseExitCallback; 4]> = state
+                        .active_order
+                        .iter()
+                        .filter_map(|id| {
+                            inner
+                                .annotations
+                                .get(id)
+                                .and_then(|ann| ann.cell.snapshot().on_exit)
+                        })
+                        .collect();
+                    let cursor_callback = (state.current_cursor != CursorIcon::Default)
+                        .then(|| inner.cursor_change_callback.clone())
+                        .flatten();
+                    let position = state.last_position;
+                    state.active_regions.clear();
+                    state.active_order.clear();
+                    state.current_cursor = CursorIcon::Default;
+                    Some(DeviceWork {
+                        device_id,
+                        position,
+                        enter_callbacks: SmallVec::new(),
+                        exit_callbacks,
+                        cursor_callback,
+                        new_cursor: CursorIcon::Default,
+                    })
+                })
+                .collect()
+        };
+        for work in sweeps {
+            work.invoke();
+        }
+    }
+
     /// Updates tracking state from one freshly hit-tested pointer move.
     pub fn update_with_motion(
         &self,
@@ -995,6 +1056,75 @@ mod tests {
             later_exit.get(),
             1,
             "a later mouse callback must still run before the first panic resumes"
+        );
+    }
+    /// The window-leave sweep fires `on_exit` for every hovered region,
+    /// resets the cursor, and is idempotent — the pin for the fix where a
+    /// cursor crossing the window edge left widgets hovered forever.
+    #[test]
+    fn window_left_sweep_fires_exits_resets_cursor_and_is_idempotent() {
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let tracker = MouseTracker::new();
+        let exits = Rc::new(Cell::new(0));
+        let cursor_resets = Rc::new(Cell::new(0));
+
+        let cursor_probe = Rc::clone(&cursor_resets);
+        tracker.set_cursor_change_callback(Rc::new(move |_device, cursor| {
+            if cursor == CursorIcon::Default {
+                cursor_probe.set(cursor_probe.get() + 1);
+            }
+        }));
+
+        let target = lane.enter(|| {
+            let exit_count = Rc::clone(&exits);
+            handle
+                .register_mouse_region(MouseRegionCallbacks {
+                    on_enter: None,
+                    on_exit: Some(Rc::new(move |_device, _position| {
+                        exit_count.set(exit_count.get() + 1);
+                    })),
+                    on_hover: None,
+                })
+                .expect("register mouse region")
+        });
+
+        let region_id = RenderId::new(1);
+        let inside_event =
+            make_move_event(Offset::new(Pixels(10.0), Pixels(10.0)), PointerType::Mouse);
+        let mut inside = HitTestResult::new();
+        inside.add(
+            HitTestEntry::new(region_id)
+                .cursor(CursorIcon::Pointer)
+                .mouse_annotation(MouseTrackerAnnotation::new(region_id, target)),
+        );
+
+        add_primary_mouse(&tracker);
+        lane.enter(|| {
+            tracker.update_with_motion(&inside_event, PointerMotionKind::Hover, &inside);
+        });
+        assert_eq!(exits.get(), 0, "hovering fires no exit");
+
+        lane.enter(|| tracker.dispatch_window_left());
+        assert_eq!(
+            exits.get(),
+            1,
+            "leaving the window exits the hovered region"
+        );
+        assert_eq!(
+            cursor_resets.get(),
+            1,
+            "the non-default cursor resets when the pointer leaves"
+        );
+        assert_eq!(tracker.device_cursor(0), CursorIcon::Default);
+
+        // Idempotent: nothing hovered any more, so nothing fires again.
+        lane.enter(|| tracker.dispatch_window_left());
+        assert_eq!(exits.get(), 1);
+        assert_eq!(cursor_resets.get(), 1);
+        assert!(
+            tracker.mouse_is_connected(),
+            "the device registration survives"
         );
     }
 }

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -114,6 +114,12 @@ struct DeviceState {
     active_order: Vec<RegionId>,
     /// Current mouse cursor for this device.
     current_cursor: CursorIcon,
+    /// Whether the device's pointer is inside the hosting window. Cleared by
+    /// the window-leave sweep, restored by any subsequent motion — while
+    /// false, ambient re-hit-testing (`update_all_devices`) must skip the
+    /// device, or the frame requested right after a sweep would re-enter the
+    /// regions at the stale last-known position and undo the sweep.
+    inside_window: bool,
 }
 
 impl DeviceState {
@@ -124,6 +130,7 @@ impl DeviceState {
             active_regions: HashSet::new(),
             active_order: Vec::new(),
             current_cursor: CursorIcon::Default,
+            inside_window: true,
         }
     }
 }
@@ -274,6 +281,7 @@ impl MouseTracker {
                     state.active_regions.clear();
                     state.active_order.clear();
                     state.current_cursor = CursorIcon::Default;
+                    state.inside_window = false;
                     Some(DeviceWork {
                         device_id,
                         position,
@@ -285,8 +293,25 @@ impl MouseTracker {
                 })
                 .collect()
         };
+        // Every device is swept even if an earlier device's callback
+        // panics — the first panic resumes only after the loop, the same
+        // all-callbacks-run-first posture `DeviceWork::invoke` has within
+        // one device.
+        let mut first_panic = None;
         for work in sweeps {
-            work.invoke();
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| work.invoke())) {
+                if first_panic.is_none() {
+                    first_panic = Some(payload);
+                } else {
+                    tracing::error!(
+                        "window-leave sweep panicked for a later device after an earlier \
+                         device's callback already panicked; only the first is resumed"
+                    );
+                }
+            }
+        }
+        if let Some(payload) = first_panic {
+            resume_unwind(payload);
         }
     }
 
@@ -332,6 +357,7 @@ impl MouseTracker {
                 .entry(device_id)
                 .or_insert_with(|| DeviceState::new(pointer_type, position));
             state.pointer_type = pointer_type;
+            state.inside_window = true;
 
             let entered: SmallVec<[RegionId; 4]> = resolved
                 .order
@@ -465,6 +491,10 @@ impl MouseTracker {
             .borrow()
             .devices
             .iter()
+            // A device swept by a window-leave is not re-hit-tested at its
+            // stale in-window position — that would re-enter the regions the
+            // sweep just exited. Its next real motion re-primes it.
+            .filter(|(_, state)| state.inside_window)
             .map(|(id, state)| (*id, state.last_position))
             .collect();
 
@@ -1126,5 +1156,71 @@ mod tests {
             tracker.mouse_is_connected(),
             "the device registration survives"
         );
+    }
+    /// The frame requested right after a window-leave sweep re-hit-tests all
+    /// devices ambiently (`update_all_devices`); a swept device must be
+    /// SKIPPED there — its last-known position is inside the window and
+    /// would re-enter the region the sweep just exited. The next real
+    /// motion re-primes it.
+    #[test]
+    fn a_swept_device_is_not_re_entered_by_ambient_re_hit_testing() {
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let tracker = MouseTracker::new();
+        let enters = Rc::new(Cell::new(0));
+        let exits = Rc::new(Cell::new(0));
+
+        let target = lane.enter(|| {
+            let enter_count = Rc::clone(&enters);
+            let exit_count = Rc::clone(&exits);
+            handle
+                .register_mouse_region(MouseRegionCallbacks {
+                    on_enter: Some(Rc::new(move |_device, _position| {
+                        enter_count.set(enter_count.get() + 1);
+                    })),
+                    on_exit: Some(Rc::new(move |_device, _position| {
+                        exit_count.set(exit_count.get() + 1);
+                    })),
+                    on_hover: None,
+                })
+                .expect("register mouse region")
+        });
+
+        let region_id = RenderId::new(1);
+        let hits_region = move || {
+            let mut result = HitTestResult::new();
+            result.add(
+                HitTestEntry::new(region_id)
+                    .mouse_annotation(MouseTrackerAnnotation::new(region_id, target)),
+            );
+            result
+        };
+
+        add_primary_mouse(&tracker);
+        let inside_event =
+            make_move_event(Offset::new(Pixels(10.0), Pixels(10.0)), PointerType::Mouse);
+        lane.enter(|| {
+            tracker.update_with_motion(&inside_event, PointerMotionKind::Hover, &hits_region());
+        });
+        assert_eq!((enters.get(), exits.get()), (1, 0));
+
+        lane.enter(|| tracker.dispatch_window_left());
+        assert_eq!((enters.get(), exits.get()), (1, 1));
+
+        // The post-sweep frame's ambient refresh: the hit test would still
+        // find the region at the stale position — the swept device must not
+        // be offered to it.
+        lane.enter(|| tracker.update_all_devices(|_| hits_region()));
+        assert_eq!(
+            (enters.get(), exits.get()),
+            (1, 1),
+            "a swept device must not be re-entered at its stale position"
+        );
+
+        // A real motion back inside re-primes normally.
+        lane.enter(|| {
+            tracker.update_with_motion(&inside_event, PointerMotionKind::Hover, &hits_region());
+        });
+        assert_eq!((enters.get(), exits.get()), (2, 1));
     }
 }

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -1058,7 +1058,11 @@ impl LaidOut {
     /// (winit `CursorLeft`): sweep hover state — every hovered
     /// `MouseRegion` gets its `on_exit`, and the cursor resets.
     pub fn dispatch_window_hover_left(&self) {
-        self.binding.gestures().handle_pointer_left_window();
+        // Inside the owner-lane scope, matching how the production realm
+        // wraps every addressed window signal (`UiRealm::enter`) and how
+        // `dispatch_pointer` above enters it for pointer input.
+        self.binding
+            .enter_owner_scope(|| self.binding.gestures().handle_pointer_left_window());
     }
 
     pub fn dispatch_pointer_event(&self, event: &PointerEvent) {

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -1054,6 +1054,13 @@ impl LaidOut {
 
     /// Dispatch an already-constructed pointer event through the same complete
     /// binding pipeline as platform input.
+    /// The platform reported the pointer leaving the hosting window
+    /// (winit `CursorLeft`): sweep hover state — every hovered
+    /// `MouseRegion` gets its `on_exit`, and the cursor resets.
+    pub fn dispatch_window_hover_left(&self) {
+        self.binding.gestures().handle_pointer_left_window();
+    }
+
     pub fn dispatch_pointer_event(&self, event: &PointerEvent) {
         self.binding
             .dispatch_pointer(event, |position| self.hit_test_pointer(position));

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -1458,3 +1458,46 @@ fn hover_fires_leaf_first_through_a_mouse_region_wrapping_a_listener() {
          on_pointer_hover before the outer MouseRegion's on_hover"
     );
 }
+
+/// The cursor leaving the WINDOW (not just the region) fires `on_exit` and
+/// clears hover state — before this wire existed, a widget hovered at the
+/// moment the cursor crossed the window edge kept its hover visuals forever
+/// and `on_exit` never fired (the platform emitted `CursorLeft`, nothing
+/// consumed it). FLUI-added coverage for that wire; Flutter reaches the
+/// same end state via a synthetic pointer-removed update.
+#[test]
+fn the_cursor_leaving_the_window_fires_on_exit_for_the_hovered_region() {
+    let enters: Rc<RefCell<Vec<Offset>>> = Rc::new(RefCell::new(Vec::new()));
+    let exits: Rc<RefCell<Vec<Offset>>> = Rc::new(RefCell::new(Vec::new()));
+    let on_enter = Rc::clone(&enters);
+    let on_exit = Rc::clone(&exits);
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_device, position| on_enter.borrow_mut().push(position))
+                .on_exit(move |_device, position| on_exit.borrow_mut().push(position))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert_eq!(
+        enters.borrow().len(),
+        1,
+        "precondition: the region is hovered"
+    );
+    assert!(exits.borrow().is_empty());
+
+    laid.dispatch_window_hover_left();
+    assert_eq!(
+        exits.borrow().as_slice(),
+        &[offset(150.0, 150.0)],
+        "leaving the window exits the hovered region at its last position"
+    );
+
+    // Idempotent: a second leave (some platforms repeat it) fires nothing.
+    laid.dispatch_window_hover_left();
+    assert_eq!(exits.borrow().len(), 1);
+}


### PR DESCRIPTION
## What

Closes #724 (from the live-wire audit). `CursorLeft` was translated and dispatched by the platform, but nothing consumed it — a widget hovered when the cursor crossed the window edge stayed visually hovered forever, `MouseRegion::on_exit` never fired, and a custom cursor never reset.

## How

`MouseTracker::dispatch_window_left()` sweeps every device's hovered regions — exit callbacks in hit order, cursor reset through the cursor-change callback, panic isolation identical to a motion update's, device registrations retained — then: binding wrapper `handle_pointer_left_window()` → runner registers `on_hover_status_change` → `PlatformToUi::WindowHover(bool)` through the same addressed dispatch as every other window signal → the realm's leave arm sweeps the addressed presentation and pumps a frame. Enter is a documented no-op (the next pointer move re-primes from a fresh hit test). Flutter parity note: Flutter reaches the same end state via a synthetic pointer-removed update; FLUI's wire has no synthetic remove event, so the leave signal calls the sweep directly.

## Evidence

- Tracker unit test (`window_left_sweep_fires_exits_resets_cursor_and_is_idempotent`) and widget-level test (`the_cursor_leaving_the_window_fires_on_exit_for_the_hovered_region`) — both red-verified by no-op'ing the sweep / the binding wrapper respectively; both pin idempotence (platforms can repeat the leave signal).
- Honest scope: the realm arm + runner registration are thin addressed-routing plumbing on the `WindowFocus` pattern and are exercised transitively, not by a dedicated live-loop test.
- `just ci` green, log-verified (`JUST_CI_EXIT: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM