### PR TITLE
fix(engine): range-render text inside opacity-layer recursion at its z-position

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -2925,6 +2925,205 @@ mod gpu_tests {
         );
     }
 
+    /// Text drawn INSIDE an opacity layer, followed by covering geometry
+    /// inside the SAME layer, must be buried by that geometry — the layer's
+    /// own segments carry glyph ranges stamped at record time, and the
+    /// recursive offscreen replay must range-render them at their
+    /// z-position inside the layer, not leave them to the trailing gap
+    /// passes (which draw over everything on the main target, at full
+    /// opacity, ignoring the layer's own opacity).
+    ///
+    /// Born red: before the recursion range-rendered text, the pinned form
+    /// of this test observed the covered label floating above the later
+    /// fill (blue glyph pixels > 0).
+    #[test]
+    fn later_rect_covers_earlier_text_inside_an_opacity_layer() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let full = flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Alpha 250/255 ≈ 0.98 ≠ 1.0 forces the offscreen Composite path
+        // (the Reintegrate fast-path would splice the content back into the
+        // top-level draw order and never exercise the recursion).
+        painter.save_layer(None, &Paint::fill(Color::rgba(0, 0, 0, 250)));
+        painter.text(
+            "Covered",
+            flui_types::Point::new(Pixels(4.0), Pixels(30.0)),
+            20.0,
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        painter.rect(full, &Paint::fill(Color::rgb(0, 255, 0)));
+        painter.restore_layer();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Layer Text Order Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        // Count pure-blue glyph pixels over the whole region — center-pixel
+        // sampling misses this class.
+        let blue_pixels = pixels
+            .iter()
+            .filter(|p| p[2] > 200 && p[0] < 50 && p[1] < 50)
+            .count();
+        assert_eq!(
+            blue_pixels, 0,
+            "text followed by covering geometry inside the same opacity \
+             layer must be buried by that geometry; {blue_pixels} blue \
+             glyph pixels visible — the layer's glyphs composited out of \
+             draw order (trailing gap pass instead of in-layer range render)"
+        );
+        // The layer's fill must still composite (sanity that the layer path ran).
+        let center =
+            (SURFACE_HEIGHT as usize / 2) * SURFACE_WIDTH as usize + SURFACE_WIDTH as usize / 2;
+        let [r, g, _b, a] = pixels[center];
+        assert!(
+            g > 200 && r < 50 && a > 200,
+            "the layer's green fill must composite onto the surface; got center rgba=({r}, {g}, _, {a})"
+        );
+    }
+
+    /// Text that is the ONLY content of an opacity layer must still belong
+    /// to the layer: composited with the layer (subject to its opacity) and
+    /// buried by top-level geometry drawn AFTER the layer — not dropped as
+    /// an "empty" layer whose glyphs then float over everything.
+    ///
+    /// Born red: before the compositor counted text as layer content (and
+    /// before the recursion range-rendered it), the pinned form of this
+    /// test observed the text-only layer's glyphs floating above the later
+    /// top-level fill.
+    #[test]
+    fn opacity_layer_text_stays_under_later_top_level_geometry() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let full = flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer(None, &Paint::fill(Color::rgba(0, 0, 0, 250)));
+        painter.text(
+            "Ghost",
+            flui_types::Point::new(Pixels(4.0), Pixels(30.0)),
+            20.0,
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        painter.restore_layer();
+        // Top-level opaque fill AFTER the layer — must bury the layer's text.
+        painter.rect(full, &Paint::fill(Color::rgb(0, 255, 0)));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Text-Only Layer Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let blue_pixels = pixels
+            .iter()
+            .filter(|p| p[2] > 200 && p[0] < 50 && p[1] < 50)
+            .count();
+        assert_eq!(
+            blue_pixels, 0,
+            "a text-only opacity layer's glyphs must be buried by top-level \
+             geometry drawn after the layer; {blue_pixels} blue glyph pixels \
+             visible — the layer resolved to Empty and its text fell through \
+             to the trailing gap passes"
+        );
+    }
+
+    /// Complement guard: text ordering ACROSS the opacity boundary must not
+    /// regress. Top-level text recorded BEFORE the layer is buried by the
+    /// layer's fill; top-level text recorded AFTER the layer draws over it.
+    #[test]
+    fn text_ordering_across_an_opacity_layer_boundary() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let full = flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Top-level text BEFORE the layer — pure blue.
+        painter.text(
+            "Under",
+            flui_types::Point::new(Pixels(4.0), Pixels(30.0)),
+            20.0,
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        // Composite-path layer whose fill covers the whole surface.
+        painter.save_layer(None, &Paint::fill(Color::rgba(0, 0, 0, 250)));
+        painter.rect(full, &Paint::fill(Color::rgb(0, 255, 0)));
+        painter.restore_layer();
+        // Top-level text AFTER the layer — yellow, must stay visible.
+        painter.text(
+            "Over",
+            flui_types::Point::new(Pixels(4.0), Pixels(60.0)),
+            20.0,
+            &Paint::fill(Color::rgb(255, 255, 0)),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Boundary Text Order Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let blue_pixels = pixels
+            .iter()
+            .filter(|p| p[2] > 200 && p[0] < 50 && p[1] < 50)
+            .count();
+        assert_eq!(
+            blue_pixels, 0,
+            "top-level text recorded before the layer must be buried by the \
+             layer's fill; {blue_pixels} blue glyph pixels visible"
+        );
+        let yellow_pixels = pixels
+            .iter()
+            .filter(|p| p[0] > 200 && p[1] > 200 && p[2] < 50)
+            .count();
+        assert!(
+            yellow_pixels > 0,
+            "top-level text recorded after the layer must draw over its fill"
+        );
+    }
+
     // ── A4: Angular edges are anti-aliased (partial alpha) ───────────────────
 
     /// A4: The two angular edges of a ~90° arc must show partial alpha (anti-

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -584,10 +584,11 @@ impl DrawSegment {
     }
 
     /// Whether this segment records no geometry — text-only segments count
-    /// as geometry-empty. The layer compositor keys offscreen-composite
-    /// work on THIS: until recursive replay range-renders text, a
-    /// text-only saved layer would otherwise pay a full offscreen pass for
-    /// glyphs that actually draw in the submit's trailing gap passes.
+    /// as geometry-empty. Callers deciding whether a segment carries ANY
+    /// replayable content (the layer compositor's empty-layer check, draw
+    /// order finalization) must use [`Self::is_empty`] instead: recursive
+    /// replay range-renders a layer's text into its offscreen, so text alone
+    /// is real layer content.
     pub(crate) fn is_geometry_empty(&self) -> bool {
         self.rect_batch.is_empty()
             && self.circle_batch.is_empty()

--- a/crates/flui-engine/src/wgpu/layer_compositor.rs
+++ b/crates/flui-engine/src/wgpu/layer_compositor.rs
@@ -301,8 +301,15 @@ impl LayerCompositor {
         self.opacity_stack = saved.saved_opacity_stack;
         self.current_opacity = saved.saved_opacity;
 
+        // Text counts as content (`is_empty`, not `is_geometry_empty`): the
+        // recursive replay range-renders a layer's glyph ranges into its
+        // offscreen, so a text-only layer must reach the Composite/Reintegrate
+        // paths to have its text composited WITH the layer (subject to its
+        // opacity/tint) — routing it to Empty would drop the draw records and
+        // leave the glyphs to the submit's trailing gap passes, floating over
+        // everything at full opacity.
         let has_offscreen_content =
-            !offscreen_final_segment.is_geometry_empty() || !offscreen_items.is_empty();
+            !offscreen_final_segment.is_empty() || !offscreen_items.is_empty();
 
         if !has_offscreen_content {
             return RestoreOutcome::Empty {
@@ -487,6 +494,37 @@ mod tests {
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!(matches!(outcome, RestoreOutcome::Empty { .. }));
+    }
+
+    /// A layer whose only content is TEXT (glyph range stamped, no geometry)
+    /// must not resolve to `Empty`: recursive replay range-renders the
+    /// layer's text into its offscreen, so the text IS the layer's content
+    /// and must be composited with the layer's opacity. Routing it to
+    /// `Empty` drops the draw records and leaves the glyphs to the trailing
+    /// gap passes, floating over everything at full opacity.
+    #[test]
+    fn pop_layer_composites_a_text_only_layer() {
+        let mut compositor = LayerCompositor::new();
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            0.5, // not 1.0 → must composite (not reintegrate)
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+            LayerFilterChain::new(),
+        );
+        // Text-only segment: a stamped glyph range, zero geometry.
+        let mut text_only = DrawSegment::new();
+        text_only.text_start = 0;
+        text_only.text_end = 1;
+        assert!(text_only.is_geometry_empty() && !text_only.is_empty());
+
+        let outcome = compositor.pop_layer(text_only, Vec::new(), rect_bounds_100());
+        assert!(
+            matches!(outcome, RestoreOutcome::Composite { .. }),
+            "a text-only layer must reach the Composite path, not Empty"
+        );
     }
 
     #[test]

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -32,6 +32,8 @@
 
 use std::sync::Arc;
 
+use crate::error::EngineResult;
+
 use super::{
     advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
     blur::apply_blur,
@@ -46,6 +48,7 @@ use super::{
     render_target::RenderTarget,
     replay::GpuReplay,
     resources::GpuResources,
+    text::TextRenderer,
     texture_pool::PooledTexture,
 };
 
@@ -435,6 +438,17 @@ impl GpuReplay {
     /// actually-drawn pixels contribute to the composite.  All inner render
     /// passes (inside `flush_segment`, `flush_texture_batch*`) use
     /// `LoadOp::Load`, preserving prior offscreen content.
+    ///
+    /// ## Ordered text inside the layer
+    ///
+    /// The layer's segments carry `text_start..text_end` glyph ranges stamped
+    /// at record time exactly like top-level segments (the record path is
+    /// shared).  Each segment's range is range-rendered into the offscreen
+    /// right after that segment's geometry flush, so text inside the layer
+    /// participates in the layer's own z-order AND is composited with the
+    /// layer (subject to its opacity/tint/blend) instead of being drawn over
+    /// everything by the submit's trailing gap passes.  Every range rendered
+    /// here is pushed onto `claimed_text` so the gap passes skip it.
     pub(in crate::wgpu) fn render_layer_to_offscreen(
         &mut self,
         layer: &mut PendingOpacityLayer,
@@ -444,8 +458,10 @@ impl GpuReplay {
         queue: &Arc<wgpu::Queue>,
         pipelines: &mut PipelineSet,
         resources: &mut GpuResources,
+        text_renderer: &mut TextRenderer,
+        claimed_text: &mut Vec<std::ops::Range<usize>>,
         encoder: &mut wgpu::CommandEncoder,
-    ) -> PooledTexture {
+    ) -> EngineResult<PooledTexture> {
         let (vp_w, vp_h) = viewport_size;
 
         // Acquire a pooled offscreen texture for the layer's content.
@@ -498,6 +514,21 @@ impl GpuReplay {
                         encoder,
                         offscreen_view,
                     );
+                    // Ordered text: this segment's glyphs draw into the layer
+                    // offscreen HERE, at the segment's z-position within the
+                    // layer, and the range is claimed so the submit's trailing
+                    // gap passes don't draw it a second time over everything.
+                    text_renderer.render_range(
+                        device,
+                        queue,
+                        offscreen_view,
+                        encoder,
+                        viewport_size,
+                        seg.text_start..seg.text_end,
+                    )?;
+                    if seg.text_start < seg.text_end {
+                        claimed_text.push(seg.text_start..seg.text_end);
+                    }
                 }
                 DrawItem::OffscreenTexture(p) => {
                     // A nested OffscreenTexture (shader-mask / backdrop-blur
@@ -534,9 +565,11 @@ impl GpuReplay {
                         queue,
                         pipelines,
                         resources,
+                        text_renderer,
+                        claimed_text,
                         encoder,
                         offscreen_target,
-                    );
+                    )?;
                 }
                 DrawItem::AdvancedShape(mut op) => {
                     // An advanced shape nested inside a layer: the backdrop is the
@@ -748,9 +781,22 @@ impl GpuReplay {
                 encoder,
                 offscreen_view,
             );
+            // Ordered text for the final segment, same discipline as the
+            // Segment arm above (render_range no-ops on an empty range).
+            text_renderer.render_range(
+                device,
+                queue,
+                offscreen_view,
+                encoder,
+                viewport_size,
+                layer.final_segment.text_start..layer.final_segment.text_end,
+            )?;
+            if layer.final_segment.text_start < layer.final_segment.text_end {
+                claimed_text.push(layer.final_segment.text_start..layer.final_segment.text_end);
+            }
         }
 
-        offscreen
+        Ok(offscreen)
     }
 
     // =========================================================================
@@ -793,16 +839,20 @@ impl GpuReplay {
         queue: &Arc<wgpu::Queue>,
         pipelines: &mut PipelineSet,
         resources: &mut GpuResources,
+        text_renderer: &mut TextRenderer,
+        claimed_text: &mut Vec<std::ops::Range<usize>>,
         encoder: &mut wgpu::CommandEncoder,
         main_target: RenderTarget<'_>,
-    ) {
+    ) -> EngineResult<()> {
         // Zero-size viewports produce no visible pixels; skip GPU work entirely.
         // The UV composite below divides by vp_w/vp_h, so proceeding would push
         // inf/NaN into texture instances.  The pool clamps acquire to 1×1 but
-        // the resulting composite would be meaningless.
+        // the resulting composite would be meaningless.  The layer's text stays
+        // unclaimed here — the trailing gap passes draw it against the same
+        // zero-area viewport, producing no pixels either.
         let (vp_w, vp_h) = viewport_size;
         if vp_w == 0 || vp_h == 0 {
-            return;
+            return Ok(());
         }
 
         let layer_tex = self.render_layer_to_offscreen(
@@ -813,8 +863,10 @@ impl GpuReplay {
             queue,
             pipelines,
             resources,
+            text_renderer,
+            claimed_text,
             encoder,
-        );
+        )?;
 
         // ── Color-filter chain fold (ping-pong) ──────────────────────────────
         //
@@ -902,7 +954,7 @@ impl GpuReplay {
                     bounds = ?layer.bounds,
                     "GpuReplay: composited advanced-blend opacity layer"
                 );
-                return;
+                return Ok(());
             }
             // A `view_only` target has no sampleable backdrop; advanced modes
             // degrade to SrcOver here (warn once).  Production producers pass a
@@ -990,6 +1042,7 @@ impl GpuReplay {
         );
 
         // offscreen texture returned to pool when `offscreen` is dropped here.
+        Ok(())
     }
 }
 

--- a/crates/flui-engine/src/wgpu/replay/mod.rs
+++ b/crates/flui-engine/src/wgpu/replay/mod.rs
@@ -238,8 +238,10 @@ impl GpuReplay {
     /// - `DrawItem::OpacityLayer`     → `flush_opacity_layer` (recursive)
     ///
     /// Text renders IN draw order: each segment's glyph range draws at the
-    /// segment's z-position, and only text recorded outside top-level
-    /// segments (opacity-layer recursion) still composites in the trailing
+    /// segment's z-position — including segments replayed inside opacity-layer
+    /// recursion, which range-render into the layer's offscreen. Only text
+    /// captured by the non-layer isolating items (`Filter` inputs,
+    /// `AdvancedShape`/`SsaaPath` segments) still composites in the trailing
     /// gap passes.
     ///
     /// ## R2 — `texture_batch` drain invariant
@@ -324,6 +326,11 @@ impl GpuReplay {
                     // p.texture dropped here, returns to pool
                 }
                 DrawItem::OpacityLayer(layer) => {
+                    // The recursion range-renders the layer's own text into
+                    // its offscreen at each inner segment's z-position and
+                    // pushes those ranges onto `claimed_text`, so the gap
+                    // passes below don't draw the layer's glyphs a second
+                    // time over the composited result.
                     self.flush_opacity_layer(
                         layer,
                         viewport_size,
@@ -332,9 +339,11 @@ impl GpuReplay {
                         queue,
                         pipelines,
                         resources,
+                        text_renderer,
+                        &mut claimed_text,
                         encoder,
                         target,
-                    );
+                    )?;
                 }
                 // ── Advanced (dst-read) shape — DECISION 5 ─────────────────
                 //
@@ -573,15 +582,26 @@ impl GpuReplay {
             }
         }
 
-        // The gaps: text recorded outside any top-level segment (today:
-        // text inside recursive items — opacity layers and their kin —
-        // whose own flushes do not yet range-render). Claimed ranges are
-        // monotone (record order), so everything BETWEEN them, plus the
-        // tail, is exactly the unclaimed text; it keeps the old
-        // over-everything behavior — ordering it within the recursion is
-        // the follow-up named on the tracking issue.
+        // The gaps: text recorded into a segment no pass range-rendered.
+        // Opacity layers claim their own text inside the recursion now, so
+        // what remains unclaimed is exactly the text captured by the
+        // NON-layer isolating items — a `Filter`'s input segment and the
+        // `AdvancedShape`/`SsaaPath` segments — whose offscreen paths remap
+        // geometry into local coordinate frames that glyphon positions
+        // don't participate in. That class keeps the old over-everything
+        // behavior. Claimed ranges are monotone because replay visits items
+        // (and recursion contents) in record order — the debug assert below
+        // pins that; a violation would double- or skip-render glyph ranges.
         let mut cursor = 0usize;
         for claimed in &claimed_text {
+            debug_assert!(
+                claimed.start >= cursor,
+                "claimed text ranges must be monotone in record order \
+                 (claimed {}..{} behind cursor {})",
+                claimed.start,
+                claimed.end,
+                cursor
+            );
             text_renderer.render_range(
                 device,
                 queue,


### PR DESCRIPTION
Closes #720.

## What

Extends per-segment text z-ordering (#719) into the recursive layer replay. Text recorded inside an opacity layer (or nested layers) now draws at its segment's z-position **inside the layer's offscreen pass** and is composited with the layer — subject to its opacity/tint/blend — instead of floating over everything via the trailing gap passes.

## How

- `render_layer_to_offscreen` range-renders each inner segment's stamped `text_start..text_end` (and the final segment's) into the layer offscreen right after that segment's geometry flush, pushing each range onto the shared `claimed_text` list threaded down through `flush_opacity_layer`; nested layers recurse with the same bookkeeping. The ranges were already stamped at record time — the record path is shared with the top level — so no record-side change was needed for layers.
- `LayerCompositor::pop_layer` now keys "layer has content" on `is_empty()` (text counts) instead of `is_geometry_empty()`, so a text-only layer routes through Composite/Reintegrate rather than being dropped as Empty with its glyphs falling through to the gap passes.
- The gap-pass cursor walk in `submit` gains a monotonicity `debug_assert` (replay order == record order for glyph ranges, including recursion).
- The gap passes are **not** dead after this: they remain reachable for exactly the text captured by the non-layer isolating items — a `Filter`'s input segment and the `AdvancedShape`/`SsaaPath` segments — whose offscreen paths remap geometry into local coordinate frames that glyphon positions don't participate in. That class keeps the old over-everything behavior (named in the code comment).

## Evidence

Born-red (pinned first, then flipped):
- `later_rect_covers_earlier_text_inside_an_opacity_layer` — pinned form asserted the broken behavior (layer glyphs floating above a later in-layer fill) and PASSED against the old code; flipped to the fixed contract, now green. Sabotaging only the Segment-arm range render fails this test (196 floating blue glyph pixels) while the text-only-layer test stays green — the two replay arms are independently pinned.
- `opacity_layer_text_stays_under_later_top_level_geometry` — pinned form observed a text-only layer's glyphs floating above later top-level geometry; flipped, now green (exercises the final-segment arm plus the compositor keying change).
- `text_ordering_across_an_opacity_layer_boundary` — complement guard: text before the layer buried by the layer's fill, text after it draws on top (was already correct; pins no-regress).
- `pop_layer_composites_a_text_only_layer` — CPU unit test pinning the compositor keying.

Oracles count colored pixels over the full surface (no center-pixel sampling); text color rides the color the text path actually consumes.

Suites (all on the rebased branch unless noted):
- `cargo nextest run -p flui-engine` — 294/294 passed (pre-rebase; engine untouched by the rebased-in commits)
- `cargo nextest run -p flui-engine --features enable-wgpu-tests` — 553 passed, 7 skipped (re-run after rebase onto latest main)
- `just ci` — `JUST_CI_EXIT: 0` on first successful run (one retry: the first attempt died on the known rustc-SIGSEGV toolchain flake compiling the flui-widgets `parity` test, unrelated to this diff). The green gate ran on the pre-rebase tree; the commits rebased in (#721, #734, #735) touch interaction/objects/platform/app only — CI on this PR re-runs the aggregate on the merged result.

## Not done (deliberately)

- Text inside `Filter` inputs and `AdvancedShape`/`SsaaPath` segments still composites over everything (see How). Ordering it would require remapping glyph positions into those items' local coordinate frames (fb-local / supersampled), a different mechanism from this claim/range-render extension.
- The zero-viewport early return in `flush_opacity_layer` leaves that layer's text unclaimed; the gap pass then draws it against the same zero-area viewport — no visible pixels, documented at the return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text rendering order around opacity layers so text appears correctly relative to surrounding geometry.
  * Ensured text-only opacity layers are composited instead of being treated as empty.
  * Prevented duplicated text rendering when opacity layers contain nested or trailing content.
  * Improved handling of zero-size opacity-layer viewports and rendering errors.

* **Tests**
  * Added coverage for text ordering and visibility across opacity-layer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->