### PR TITLE
fix(app): a realm's scheduler carries the runtime frame wake

### DIFF
--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -1657,9 +1657,18 @@ mod wake_and_clipboard_tests {
 
     /// `AppRuntime::frame_wake_callback()` must be usable as the install-time
     /// `Send + Sync` handle wired onto a scheduler's `on_frame_scheduled`
-    /// hook (what `install_platform_realm` now does against the just-installed
-    /// realm's own `UpdateScheduler` — see that function's doc), never a callback
-    /// that re-resolves this thread-local `AppRuntime` when the hook fires.
+    /// hook (what `UiRealm::construct` does against the realm's own
+    /// `UpdateScheduler`, using the same `wake` its presentation and command
+    /// sender carry), never a callback that re-resolves this thread-local
+    /// `AppRuntime` when the hook fires.
+    ///
+    /// This test owns only the *handle* half of that contract: that the
+    /// callback survives being fired from a foreign thread. It deliberately
+    /// wires its own stand-in scheduler, so it says nothing about whether
+    /// production installs the hook at all — `UiRealm`'s
+    /// `a_scheduler_frame_request_reaches_the_realms_platform_wake` and its
+    /// cross-thread sibling own that half, through a realm built by the real
+    /// constructor.
     ///
     /// Proof shape: wire the handle onto a scheduler built right here (a
     /// stand-in for a realm's own), spawn a task on it, capture its `Waker`,
@@ -1681,8 +1690,8 @@ mod wake_and_clipboard_tests {
         let runtime = AppRuntime::new();
         assert!(!runtime.needs_redraw(), "precondition: no redraw pending");
 
-        // Stand-in for a realm's own scheduler; `install_platform_realm`
-        // wires this exact handle onto `realm.scheduler()` at install time.
+        // Stand-in for a realm's own scheduler. In production `UiRealm::
+        // construct` performs this same wiring with the realm's `wake`.
         let scheduler = flui_scheduler::UpdateScheduler::new();
         scheduler.set_on_frame_scheduled(Some(runtime.frame_wake_callback()));
 

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -768,6 +768,21 @@ impl UiRealm {
             async_driver,
             scheduler,
         } = services;
+
+        // The realm's scheduler fires the SAME platform wake its presentation
+        // and command sender use. This is the edge an async completion travels:
+        // a background task's `Waker::wake()` reaches `AsyncDriver`'s
+        // request-frame, which reaches `UpdateScheduler::request_frame`, whose
+        // `frame_scheduled` false->true transition fires this hook. Without it
+        // that demand is a bare atomic store only an already-running pump can
+        // observe, so an idle `ControlFlow::Wait` loop sleeps through it and
+        // the future silently stops advancing until unrelated input arrives.
+        //
+        // Installed here rather than at each constructor because `construct`
+        // is the single chokepoint every `UiRealm` is built through — a realm
+        // with an unwired scheduler wake is not constructible.
+        scheduler.set_on_frame_scheduled(Some(Arc::clone(&wake)));
+
         let interaction_lane = InteractionLane::try_new()?;
         let global_key_scope = GlobalKeyScope::new();
 
@@ -7328,6 +7343,82 @@ mod tests {
                 calls_b.load(AtomicOrdering::Relaxed),
                 1,
                 "dirtying B's own pipeline must poke B's own window"
+            );
+        }
+
+        /// A frame demanded through the realm's own `UpdateScheduler` must
+        /// reach the realm's platform wake.
+        ///
+        /// This is the edge an async completion travels: `TaskWaker::
+        /// wake_by_ref` -> `AsyncDriver`'s request-frame -> `UpdateScheduler::
+        /// request_frame` -> the `frame_scheduled` false->true edge -> the
+        /// `on_frame_scheduled` hook. If that hook is never installed the
+        /// scheduler's demand is a bare atomic store that only a pump already
+        /// in flight can observe, and an idle `ControlFlow::Wait` loop sleeps
+        /// through it — the window updates on the next unrelated event, or
+        /// never.
+        ///
+        /// If reverted (drop the `set_on_frame_scheduled` install in
+        /// `UiRealm::construct`): `on_frame_scheduled` stays `None`,
+        /// `request_frame_impl` returns after the swap, and this observes
+        /// zero wakes.
+        #[test]
+        fn a_scheduler_frame_request_reaches_the_realms_platform_wake() {
+            let wakes = Arc::new(AtomicU32::new(0));
+            let wake_counter = Arc::clone(&wakes);
+            let wake: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                wake_counter.fetch_add(1, AtomicOrdering::Relaxed);
+            });
+
+            let (window, _calls) = counting_window(1);
+            let realm = UiRealm::new(wake, window, 1.0, Arc::new(AtomicBool::new(false)))
+                .expect("realm constructs");
+
+            // Construction may legitimately have demanded a first frame;
+            // measure only the transition this test causes.
+            // Clear the `frame_scheduled` latch so the request below is a real
+            // false->true transition — the only edge the hook fires on.
+            realm.scheduler().finish_async_pump();
+            let before = wakes.load(AtomicOrdering::Relaxed);
+
+            realm.scheduler().request_frame();
+
+            assert!(
+                wakes.load(AtomicOrdering::Relaxed) > before,
+                "a scheduler frame request must reach the realm's platform wake; \
+                 without it an async completion cannot wake an idle event loop"
+            );
+        }
+
+        /// The same edge, fired from a foreign thread — the shape an async
+        /// task completing on a background executor actually takes.
+        ///
+        /// The wake handed to a realm is `Send + Sync` precisely so this is
+        /// legal; this pins that the scheduler seam preserves it.
+        #[test]
+        fn a_cross_thread_frame_request_reaches_the_realms_platform_wake() {
+            let wakes = Arc::new(AtomicU32::new(0));
+            let wake_counter = Arc::clone(&wakes);
+            let wake: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                wake_counter.fetch_add(1, AtomicOrdering::Relaxed);
+            });
+
+            let (window, _calls) = counting_window(1);
+            let realm = UiRealm::new(wake, window, 1.0, Arc::new(AtomicBool::new(false)))
+                .expect("realm constructs");
+            // Clear the `frame_scheduled` latch so the request below is a real
+            // false->true transition — the only edge the hook fires on.
+            realm.scheduler().finish_async_pump();
+            let before = wakes.load(AtomicOrdering::Relaxed);
+
+            let scheduler = realm.scheduler().clone();
+            std::thread::spawn(move || scheduler.request_frame())
+                .join()
+                .expect("waker thread completes");
+
+            assert!(
+                wakes.load(AtomicOrdering::Relaxed) > before,
+                "a frame request raised off the owner thread must still reach the wake"
             );
         }
     }


### PR DESCRIPTION
## Summary

`UpdateScheduler::set_on_frame_scheduled` had **no production call site**. Its only non-doc caller was a `#[cfg(test)]` test that installed the hook itself, so in a running app `on_frame_scheduled` was always `None` and `request_frame_impl` degenerated to a bare atomic store.

That store is only observable by a pump already in flight. The edge an async completion travels —

```
Waker::wake() → AsyncDriver request-frame → UpdateScheduler::request_frame
             → frame_scheduled false→true → the hook → PlatformWindow::request_redraw
```

— therefore ended at the transition. A winit loop parked in `ControlFlow::Wait` slept through it and the future stopped advancing until unrelated input arrived: a spinner that resolves only when you move the mouse.

The hook is installed in `UiRealm::construct` rather than at each constructor, because that is the single chokepoint every realm is built through — so a realm with an unwired scheduler wake is not constructible.

Also corrects the doc on `frame_wake_callback_survives_a_cross_thread_fire_once_wired_to_a_scheduler`, which asserted that `install_platform_realm` performed this wiring. It never did, and that claim is why the gap stayed invisible: the test wires its own stand-in scheduler, so it pinned the handle's cross-thread survival and nothing about production installing it.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — not applicable (no render/layout/paint/lifecycle/reconciliation change)
- [x] New or changed behavior has tests that would fail without this change
- [x] Public API changes are documented — no public API change

Two tests, both against a realm built by the **real** constructor, both observed failing before the fix:
- `a_scheduler_frame_request_reaches_the_realms_platform_wake`
- `a_cross_thread_frame_request_reaches_the_realms_platform_wake` (fires the request from a separate `std::thread`)

Revert the install and both observe zero wakes.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

The wake handle passed is the `Send + Sync` `frame_wake_callback()`, never a closure that re-resolves the `APP_RUNTIME` thread-local — it fires on foreign threads.

Deferred: making the hook a **required constructor argument** of `UpdateScheduler` (so the unwired state is unrepresentable) is the right general principle but a separate refactor whose value is preventing the *next* instance, not fixing this one. Worth pairing with `AsyncDriver::set_request_frame` so `flui-scheduler` takes one construction-shape change rather than two.

Found by a code-first runtime audit; one of six crate-disjoint P0 fixes that merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo