### PR TITLE
fix(objects): persistent headers publish a hit-test extent, so the SliverAppBar family is tappable

### DIFF
--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -598,23 +598,18 @@ impl RenderSliverScrollingPersistentHeader {
         let raw_paint_extent = max_extent - constraints.scroll_offset;
         let cache_extent = self.calculate_cache_offset(constraints, 0.0, max_extent);
         let paint_extent = raw_paint_extent.clamp(0.0, constraints.remaining_paint_extent);
-        let geometry = SliverGeometry {
-            scroll_extent: max_extent,
-            paint_origin: constraints.overlap.min(0.0),
-            paint_extent,
-            // The oracle passes neither `layoutExtent` nor `visible`
-            // (`:374-381`), so `SliverGeometry`'s constructor defaults
-            // apply: layout = paint, visible = paint > 0
-            // (`sliver.dart:662-665`). A Rust struct literal has no such
-            // defaults — spell them out or the next sliver lays out at 0
-            // and the header reports itself invisible.
-            layout_extent: paint_extent,
-            visible: paint_extent > 0.0,
-            max_paint_extent: max_extent + stretch_offset,
-            cache_extent,
-            has_visual_overflow: true,
-            ..SliverGeometry::ZERO
-        };
+        // The oracle (`sliver_persistent_header.dart:374-381`) passes only
+        // scrollExtent/paintOrigin/paintExtent/maxPaintExtent/cacheExtent, so
+        // every other field takes `SliverGeometry`'s constructor default
+        // (`sliver.dart:662-665`). Going through `new` + `with_*` rather than
+        // a `..ZERO` struct literal is what makes those defaults apply: the
+        // struct-update form substitutes zero/false for whatever it omits,
+        // which is how `layout_extent`, `visible` and `hit_test_extent` were
+        // each silently dropped here in turn.
+        let geometry = SliverGeometry::new(max_extent, paint_extent, constraints.overlap.min(0.0))
+            .with_max_paint_extent(max_extent + stretch_offset)
+            .with_cache_extent(cache_extent)
+            .with_visual_overflow();
         let child_position = if stretch_offset > 0.0 {
             0.0
         } else {
@@ -790,25 +785,25 @@ impl RenderSliver for RenderSliverPinnedPersistentHeader {
         let stretch_offset = self.core.stretch_offset_for_geometry(&constraints);
 
         let paint_extent = child_extent.min(effective_remaining_paint_extent);
-        let geometry = SliverGeometry {
-            scroll_extent: max_extent,
-            paint_origin: constraints.overlap,
-            paint_extent,
-            // `visible` is not given by the oracle (`:435-444`) → the
-            // constructor default `paintExtent > 0` (`sliver.dart:665`):
-            // a pinned header stays visible while it holds at the edge.
-            visible: paint_extent > 0.0,
-            layout_extent,
-            max_paint_extent: max_extent + stretch_offset,
-            max_scroll_obstruction_extent: min_extent,
-            cache_extent: if layout_extent > 0.0 {
+        // `paint_origin` is `constraints.overlap` UNMODIFIED here — unlike the
+        // scrolling/floating variants, which clamp it with `.min(0.0)`. That
+        // is the pinned contract (oracle `:435-444`), not a transcription slip.
+        //
+        // `layout_extent` is deliberately narrower than `paint_extent`: a
+        // pinned header keeps painting at the edge after it has stopped
+        // consuming layout space. Everything the oracle omits takes the
+        // constructor default via `new` (`sliver.dart:662-665`) rather than
+        // `..ZERO`'s zero/false.
+        let geometry = SliverGeometry::new(max_extent, paint_extent, constraints.overlap)
+            .with_layout_extent(layout_extent)
+            .with_max_paint_extent(max_extent + stretch_offset)
+            .with_max_scroll_obstruction(min_extent)
+            .with_cache_extent(if layout_extent > 0.0 {
                 -constraints.cache_origin + layout_extent
             } else {
                 layout_extent
-            },
-            has_visual_overflow: true,
-            ..SliverGeometry::ZERO
-        };
+            })
+            .with_visual_overflow();
 
         position_persistent_header_child(ctx, &constraints, &geometry, 0.0, child_extent);
         geometry
@@ -922,23 +917,16 @@ impl FloatingHeaderMode for FloatingMode {
         let raw_layout_extent = max_extent - constraints.scroll_offset;
         let paint_extent = raw_paint_extent.clamp(0.0, constraints.remaining_paint_extent);
         let layout_extent = raw_layout_extent.clamp(0.0, constraints.remaining_paint_extent);
-        let geometry = SliverGeometry {
-            scroll_extent: max_extent,
-            paint_origin: constraints.overlap.min(0.0),
-            paint_extent,
-            // `visible` is not given by the oracle (`:588-595`) → the
-            // constructor default `paintExtent > 0` (`sliver.dart:665`).
-            visible: paint_extent > 0.0,
-            layout_extent,
-            max_paint_extent: max_extent + stretch_offset,
-            // `cacheExtent` was not given explicitly by the oracle here, so it
-            // falls back to `layoutExtent` per `SliverGeometry`'s own
-            // constructor default chain (`cacheExtent ?? layoutExtent ??
-            // paintExtent`, `sliver.dart:660-664`).
-            cache_extent: layout_extent,
-            has_visual_overflow: true,
-            ..SliverGeometry::ZERO
-        };
+        // The oracle (`:588-595`) omits `visible` and `hitTestExtent`, so both
+        // take `new`'s constructor defaults (`sliver.dart:662-665`).
+        // `cacheExtent` is also omitted there and falls back to `layoutExtent`
+        // per the same chain, which is narrower than `new`'s `paint_extent`
+        // default here — hence the explicit setter.
+        let geometry = SliverGeometry::new(max_extent, paint_extent, constraints.overlap.min(0.0))
+            .with_layout_extent(layout_extent)
+            .with_max_paint_extent(max_extent + stretch_offset)
+            .with_cache_extent(layout_extent)
+            .with_visual_overflow();
         // Uses the RAW (pre-clamp) `paint_extent` local, matching the
         // oracle's `paintExtent - childExtent` — not `geometry.paintExtent`.
         let child_position = if stretch_offset > 0.0 {
@@ -973,20 +961,19 @@ impl FloatingHeaderMode for FloatingPinnedMode {
         let layout_extent =
             (max_extent - constraints.scroll_offset).clamp(0.0, clamped_paint_extent);
         let stretch_offset = core.stretch_offset_for_geometry(constraints);
-        let geometry = SliverGeometry {
-            scroll_extent: max_extent,
-            paint_origin: constraints.overlap.min(0.0),
-            paint_extent: clamped_paint_extent,
-            // `visible` is not given by the oracle (`:825-833`) → the
-            // constructor default `paintExtent > 0` (`sliver.dart:665`).
-            visible: clamped_paint_extent > 0.0,
-            layout_extent,
-            max_paint_extent: max_extent + stretch_offset,
-            max_scroll_obstruction_extent: min_extent,
-            cache_extent: layout_extent,
-            has_visual_overflow: true,
-            ..SliverGeometry::ZERO
-        };
+        // As above: `visible` and `hitTestExtent` are omitted by the oracle
+        // (`:825-833`) and take `new`'s defaults; `cacheExtent` follows
+        // `layoutExtent`.
+        let geometry = SliverGeometry::new(
+            max_extent,
+            clamped_paint_extent,
+            constraints.overlap.min(0.0),
+        )
+        .with_layout_extent(layout_extent)
+        .with_max_paint_extent(max_extent + stretch_offset)
+        .with_max_scroll_obstruction(min_extent)
+        .with_cache_extent(layout_extent)
+        .with_visual_overflow();
         (geometry, 0.0)
     }
 }

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -10959,6 +10959,76 @@ fn harness_sliver_persistent_header_pinned_stays_at_zero_and_reports_max_scroll_
     );
 }
 
+/// Every persistent-header variant must be hit-testable across the extent it
+/// paints.
+///
+/// The driver's sliver gate rejects any `position.main_axis >=
+/// geometry.hit_test_extent` before it recurses into the header or its box
+/// child, so a header that commits `hit_test_extent: 0.0` paints normally and
+/// swallows every tap — the `SliverAppBar` family's action buttons and back
+/// arrow are simply dead. Flutter gives this field the same default the
+/// framework relies on here: `hitTestExtent ??= paintExtent`
+/// (`.flutter/packages/flutter/lib/src/rendering/sliver.dart:663`).
+///
+/// If reverted (the four geometry literals go back to `..SliverGeometry::ZERO`
+/// without naming `hit_test_extent`): `SliverGeometry::ZERO` supplies `0.0`
+/// and every assertion below reads `0.0`, with the hit path empty.
+#[test]
+fn harness_sliver_persistent_header_variants_are_hit_testable_across_their_paint_extent() {
+    // Pinned — the `SliverAppBar` shape, and the one a user taps most.
+    let run = RenderTester::mount(viewport_multi_with_scroll(
+        0.0,
+        [
+            sliver_node(RenderSliverPinnedPersistentHeader::new(40.0, 120.0))
+                .label("header")
+                .child(box_node(RenderColoredBox::red(300.0, 120.0)).label("child")),
+            filler_sliver(),
+        ],
+    ))
+    .with_size(Size::new(px(300.0), px(400.0)))
+    .run_layout();
+
+    let header_id = run.id("header");
+    let geometry = run.sliver_geometry(header_id);
+    assert!(
+        geometry.paint_extent > 0.0,
+        "precondition: the header paints something"
+    );
+    assert_eq!(
+        geometry.hit_test_extent, geometry.paint_extent,
+        "a pinned header must be hit-testable across everything it paints",
+    );
+
+    // The consequence the extent exists for: a tap inside the painted band
+    // reaches the header's own box child.
+    let child_id = run.id("child");
+    let hit = run.hit(150.0, geometry.paint_extent / 2.0);
+    assert!(
+        hit.contains(&child_id),
+        "a tap inside the pinned header's painted band must reach its child; \
+         got {hit:?}",
+    );
+
+    // Scrolling — the same contract, different variant.
+    let scrolling = RenderTester::mount(viewport_multi_with_scroll(
+        0.0,
+        [
+            sliver_node(RenderSliverScrollingPersistentHeader::new(40.0, 120.0))
+                .label("header")
+                .child(box_node(RenderColoredBox::red(300.0, 120.0)).label("child")),
+            filler_sliver(),
+        ],
+    ))
+    .with_size(Size::new(px(300.0), px(400.0)))
+    .run_layout();
+
+    let scrolling_geometry = scrolling.sliver_geometry(scrolling.id("header"));
+    assert_eq!(
+        scrolling_geometry.hit_test_extent, scrolling_geometry.paint_extent,
+        "a scrolling header must be hit-testable across everything it paints",
+    );
+}
+
 #[test]
 fn harness_sliver_persistent_header_floating_reveals_on_reverse_scroll_and_pointer_scroll_start_direction_permits_reveal()
  {

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -10970,62 +10970,66 @@ fn harness_sliver_persistent_header_pinned_stays_at_zero_and_reports_max_scroll_
 /// framework relies on here: `hitTestExtent ??= paintExtent`
 /// (`.flutter/packages/flutter/lib/src/rendering/sliver.dart:663`).
 ///
-/// If reverted (the four geometry literals go back to `..SliverGeometry::ZERO`
+/// All four variants, because all four committed the same
+/// `..SliverGeometry::ZERO` literal — covering only two would let the other two
+/// regress silently.
+///
+/// If reverted (the geometry literals go back to `..SliverGeometry::ZERO`
 /// without naming `hit_test_extent`): `SliverGeometry::ZERO` supplies `0.0`
 /// and every assertion below reads `0.0`, with the hit path empty.
 #[test]
 fn harness_sliver_persistent_header_variants_are_hit_testable_across_their_paint_extent() {
-    // Pinned — the `SliverAppBar` shape, and the one a user taps most.
-    let run = RenderTester::mount(viewport_multi_with_scroll(
-        0.0,
-        [
-            sliver_node(RenderSliverPinnedPersistentHeader::new(40.0, 120.0))
-                .label("header")
-                .child(box_node(RenderColoredBox::red(300.0, 120.0)).label("child")),
-            filler_sliver(),
-        ],
-    ))
-    .with_size(Size::new(px(300.0), px(400.0)))
-    .run_layout();
+    /// Mount `header` under a viewport, then assert it is hit-testable across
+    /// everything it paints and that a tap reaches its box child.
+    fn assert_hit_testable<H>(header: H, label: &str)
+    where
+        H: flui_rendering::RenderObject<flui_rendering::SliverProtocol> + 'static,
+    {
+        let run = RenderTester::mount(viewport_multi_with_scroll(
+            0.0,
+            [
+                sliver_node(header)
+                    .label("header")
+                    .child(box_node(RenderColoredBox::red(300.0, 120.0)).label("child")),
+                filler_sliver(),
+            ],
+        ))
+        .with_size(Size::new(px(300.0), px(400.0)))
+        .run_layout();
 
-    let header_id = run.id("header");
-    let geometry = run.sliver_geometry(header_id);
-    assert!(
-        geometry.paint_extent > 0.0,
-        "precondition: the header paints something"
+        let geometry = run.sliver_geometry(run.id("header"));
+        assert!(
+            geometry.paint_extent > 0.0,
+            "{label}: precondition — the header paints something"
+        );
+        assert_eq!(
+            geometry.hit_test_extent, geometry.paint_extent,
+            "{label}: must be hit-testable across everything it paints",
+        );
+
+        let child_id = run.id("child");
+        let hit = run.hit(150.0, geometry.paint_extent / 2.0);
+        assert!(
+            hit.contains(&child_id),
+            "{label}: a tap inside the painted band must reach the header's child; got {hit:?}",
+        );
+    }
+
+    assert_hit_testable(
+        RenderSliverPinnedPersistentHeader::new(40.0, 120.0),
+        "pinned",
     );
-    assert_eq!(
-        geometry.hit_test_extent, geometry.paint_extent,
-        "a pinned header must be hit-testable across everything it paints",
+    assert_hit_testable(
+        RenderSliverScrollingPersistentHeader::new(40.0, 120.0),
+        "scrolling",
     );
-
-    // The consequence the extent exists for: a tap inside the painted band
-    // reaches the header's own box child.
-    let child_id = run.id("child");
-    let hit = run.hit(150.0, geometry.paint_extent / 2.0);
-    assert!(
-        hit.contains(&child_id),
-        "a tap inside the pinned header's painted band must reach its child; \
-         got {hit:?}",
+    assert_hit_testable(
+        RenderSliverFloatingPersistentHeader::new(40.0, 120.0, None),
+        "floating",
     );
-
-    // Scrolling — the same contract, different variant.
-    let scrolling = RenderTester::mount(viewport_multi_with_scroll(
-        0.0,
-        [
-            sliver_node(RenderSliverScrollingPersistentHeader::new(40.0, 120.0))
-                .label("header")
-                .child(box_node(RenderColoredBox::red(300.0, 120.0)).label("child")),
-            filler_sliver(),
-        ],
-    ))
-    .with_size(Size::new(px(300.0), px(400.0)))
-    .run_layout();
-
-    let scrolling_geometry = scrolling.sliver_geometry(scrolling.id("header"));
-    assert_eq!(
-        scrolling_geometry.hit_test_extent, scrolling_geometry.paint_extent,
-        "a scrolling header must be hit-testable across everything it paints",
+    assert_hit_testable(
+        RenderSliverFloatingPinnedPersistentHeader::new(40.0, 120.0, None),
+        "floating-pinned",
     );
 }
 

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -125,9 +125,18 @@ impl SliverGeometry {
     /// Creates geometry with basic extents.
     ///
     /// Applies Flutter's constructor default chain
-    /// (`.flutter/packages/flutter/lib/src/rendering/sliver.dart:662-665`):
+    /// (`.flutter/packages/flutter/lib/src/rendering/sliver.dart:662-665`) as
+    /// it resolves for a call that passes only these three arguments:
     /// `layout_extent`, `hit_test_extent` and `cache_extent` all default to
-    /// `paint_extent`, and `visible` to `paint_extent > 0.0`. Prefer this plus
+    /// `paint_extent`, and `visible` to `paint_extent > 0.0`.
+    ///
+    /// Note the chain is resolved ONCE, here — these are plain field values,
+    /// not lazy rules. Flutter's `cacheExtent ?? layoutExtent ?? paintExtent`
+    /// means a caller that narrows `layout_extent` also narrows `cache_extent`;
+    /// with a builder the two are independent, so
+    /// [`with_layout_extent`](Self::with_layout_extent) does NOT drag
+    /// `cache_extent` down with it. Narrow both when that is what you mean —
+    /// every persistent-header variant does. Prefer this plus
     /// the `with_*` setters over a struct literal with `..ZERO` — the
     /// struct-update form silently substitutes zero/false for every field it
     /// omits, which is a *different* contract and has produced three separate

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -124,8 +124,21 @@ impl SliverGeometry {
 
     /// Creates geometry with basic extents.
     ///
-    /// Sets paint_extent as layout and cache extent, visible if paint_extent >
-    /// 0.
+    /// Applies Flutter's constructor default chain
+    /// (`.flutter/packages/flutter/lib/src/rendering/sliver.dart:662-665`):
+    /// `layout_extent`, `hit_test_extent` and `cache_extent` all default to
+    /// `paint_extent`, and `visible` to `paint_extent > 0.0`. Prefer this plus
+    /// the `with_*` setters over a struct literal with `..ZERO` — the
+    /// struct-update form silently substitutes zero/false for every field it
+    /// omits, which is a *different* contract and has produced three separate
+    /// header bugs (`layout_extent`, `visible`, and `hit_test_extent`).
+    ///
+    /// # Divergence from Flutter
+    ///
+    /// This also sets `max_paint_extent = paint_extent`, where Flutter
+    /// requires it explicitly and defaults it to `0.0`. Callers that know
+    /// their unconstrained extent must say so with
+    /// [`with_max_paint_extent`](Self::with_max_paint_extent).
     #[inline]
     #[must_use]
     pub const fn new(scroll_extent: f32, paint_extent: f32, paint_origin: f32) -> Self {
@@ -241,6 +254,40 @@ impl SliverGeometry {
     #[must_use]
     pub const fn with_max_scroll_obstruction(mut self, extent: f32) -> Self {
         self.max_scroll_obstruction_extent = extent;
+        self
+    }
+
+    /// Sets layout extent — the space this sliver takes from the following
+    /// sliver's layout offset, which may be less than what it paints.
+    ///
+    /// Only needed to *narrow* it: [`new`](Self::new) already defaults it to
+    /// `paint_extent`, matching Flutter's `layoutExtent ??= paintExtent`.
+    #[inline]
+    #[must_use]
+    pub const fn with_layout_extent(mut self, extent: f32) -> Self {
+        self.layout_extent = extent;
+        self
+    }
+
+    /// Sets cache extent.
+    ///
+    /// Only needed to widen or narrow it: [`new`](Self::new) already defaults
+    /// it to `paint_extent`.
+    #[inline]
+    #[must_use]
+    pub const fn with_cache_extent(mut self, extent: f32) -> Self {
+        self.cache_extent = extent;
+        self
+    }
+
+    /// Sets visibility explicitly.
+    ///
+    /// Only needed to override it: [`new`](Self::new) already derives it as
+    /// `paint_extent > 0.0`, matching Flutter's `visible ??= paintExtent > 0`.
+    #[inline]
+    #[must_use]
+    pub const fn with_visible(mut self, visible: bool) -> Self {
+        self.visible = visible;
         self
     }
 


### PR DESCRIPTION
## Summary

All four persistent-header variants committed their geometry as a struct literal ending in `..SliverGeometry::ZERO`, which supplies `hit_test_extent: 0.0`. The pipeline's sliver gate rejects any `position.main_axis >= geometry.hit_test_extent` **before** it recurses into the header or its box child, so every one of them painted normally and swallowed every tap — the `SliverAppBar` shipped in #702 has a dead back arrow and dead action buttons.

`rg -c hit_test_extent crates/flui-objects/src/sliver/sliver_persistent_header.rs` returned **0** across 1300 lines.

This is the **third** field lost to the same idiom here, after `layout_extent` and `visible`. So rather than naming the field at four sites, the sites are converted: `SliverGeometry::new` already applies the whole Flutter default chain, and the `// BUILDER PATTERN` block already carried `with_hit_test_extent` and five siblings. Three setters were missing (`with_layout_extent`, `with_cache_extent`, `with_visible`); adding them lets the literals become `new(..)` plus explicit narrowing, with no `..ZERO` left to omit a field from.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — `hitTestExtent ??= paintExtent` at `.flutter/packages/flutter/lib/src/rendering/sliver.dart:663`; the constructor default chain at `:662-665`
- [x] New or changed behavior has tests that would fail without this change
- [x] Public API changes are documented — the three new `with_*` setters and the `new` divergence note

`harness_sliver_persistent_header_variants_are_hit_testable_across_their_paint_extent` asserts committed `hit_test_extent == paint_extent` and that a tap inside the painted band reaches the header's box child. Before this it read `0.0` against a paint extent of `120.0`, with an empty hit path.

4293 tests across flui-objects / flui-rendering / flui-widgets / flui-material unchanged, including the 22-case persistent-header parity suite.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

Two contract details preserved deliberately, both previously implicit and now commented:

- the **pinned** variant's `paint_origin` is `constraints.overlap` **unmodified**, where the other three clamp with `.min(0.0)`;
- `SliverGeometry::new` sets `max_paint_extent = paint_extent` where Flutter defaults it to `0.0`, so every converted site names it explicitly. Documented on `new` as a divergence.

Deferred: `#[non_exhaustive]` on `SliverGeometry` is the real structural fix, but its precondition is converting **all 15** `..ZERO` sites in flui-objects (FRU on a non_exhaustive struct is E0639 from another crate). Four are converted here; eleven remain.

Found by a code-first runtime audit; one of six crate-disjoint P0 fixes that merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo