### PR TITLE
fix(platform): Win32, Web and Android pointer events carry the buttons actually held

### DIFF
--- a/crates/flui-platform/src/platforms/android/input.rs
+++ b/crates/flui-platform/src/platforms/android/input.rs
@@ -46,7 +46,13 @@ pub fn convert_motion_event(
             let idx = event.pointer_index();
             let pointer = event.pointer_at_index(idx);
             let info = make_pointer_info(&pointer);
-            let state = make_pointer_state(&pointer, time_ns, scale_factor, modifiers);
+            let state = make_pointer_state(
+                &pointer,
+                time_ns,
+                scale_factor,
+                modifiers,
+                contact_buttons(),
+            );
 
             vec![PlatformInput::Pointer(PointerEvent::Down(
                 PointerButtonEvent {
@@ -61,7 +67,13 @@ pub fn convert_motion_event(
             let idx = event.pointer_index();
             let pointer = event.pointer_at_index(idx);
             let info = make_pointer_info(&pointer);
-            let state = make_pointer_state(&pointer, time_ns, scale_factor, modifiers);
+            let state = make_pointer_state(
+                &pointer,
+                time_ns,
+                scale_factor,
+                modifiers,
+                PointerButtons::default(),
+            );
 
             vec![PlatformInput::Pointer(PointerEvent::Up(
                 PointerButtonEvent {
@@ -78,7 +90,13 @@ pub fn convert_motion_event(
                 .pointers()
                 .map(|pointer| {
                     let info = make_pointer_info(&pointer);
-                    let state = make_pointer_state(&pointer, time_ns, scale_factor, modifiers);
+                    let state = make_pointer_state(
+                        &pointer,
+                        time_ns,
+                        scale_factor,
+                        modifiers,
+                        contact_buttons(),
+                    );
 
                     PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
                         pointer: info,
@@ -121,7 +139,13 @@ pub fn convert_motion_event(
                 .pointers()
                 .map(|pointer| {
                     let info = make_pointer_info(&pointer);
-                    let state = make_pointer_state(&pointer, time_ns, scale_factor, modifiers);
+                    let state = make_pointer_state(
+                        &pointer,
+                        time_ns,
+                        scale_factor,
+                        modifiers,
+                        PointerButtons::default(),
+                    );
 
                     PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
                         pointer: info,
@@ -181,6 +205,20 @@ pub fn convert_key_event(event: &android_activity::input::KeyEvent<'_>) -> Optio
 // Helpers
 // ============================================================================
 
+/// The held-button set for a pointer that is in contact with the screen.
+///
+/// Android reports no button mask for touch or stylus contact, but the W3C
+/// contract still requires one: a touch that is down reports the primary
+/// button held, exactly as a pressed mouse does. The framework's
+/// contact-vs-hover discrimination reads this, so reporting an empty set for
+/// an in-contact Move delivers a drag as a hover.
+#[inline]
+fn contact_buttons() -> PointerButtons {
+    let mut buttons = PointerButtons::default();
+    buttons.insert(PointerButton::Primary);
+    buttons
+}
+
 /// Build `PointerInfo` from an Android pointer.
 fn make_pointer_info(pointer: &android_activity::input::Pointer<'_>) -> PointerInfo {
     // Android pointer IDs start at 0. PointerId::PRIMARY is 1 (NonZeroU64::MIN).
@@ -195,11 +233,24 @@ fn make_pointer_info(pointer: &android_activity::input::Pointer<'_>) -> PointerI
 }
 
 /// Build `PointerState` from an Android pointer.
+///
+/// `buttons` is the set held AFTER this event (press included, release
+/// excluded), per the W3C `PointerEvent.buttons` contract — the same rule the
+/// winit backend tracks explicitly. It is a required argument rather than a
+/// defaulted field because the framework's contact-vs-hover discrimination
+/// reads it: a Move that reports an empty set is delivered as a *hover*, so a
+/// touch drag never reaches a recognizer and is silently re-interpreted as a
+/// tap when the finger lifts.
+///
+/// Android does not report a button mask for touch, but its `MotionAction`
+/// already states the answer: the `Down`/`Move` actions are contact, the
+/// `Hover*` actions are not, and `Up` is the release itself.
 fn make_pointer_state(
     pointer: &android_activity::input::Pointer<'_>,
     time_ns: u64,
     scale_factor: f64,
     modifiers: Modifiers,
+    buttons: PointerButtons,
 ) -> PointerState {
     // Android reports coordinates in physical (device) pixels
     let x = pointer.x() as f64;
@@ -225,7 +276,7 @@ fn make_pointer_state(
     PointerState {
         time: time_ns,
         position: PhysicalPosition::new(x, y),
-        buttons: PointerButtons::default(),
+        buttons,
         modifiers,
         count: 1,
         contact_geometry: contact,

--- a/crates/flui-platform/src/platforms/web/events.rs
+++ b/crates/flui-platform/src/platforms/web/events.rs
@@ -199,16 +199,41 @@ fn make_pointer_info(pe: &web_sys::PointerEvent) -> ui_events::pointer::PointerI
     }
 }
 
+/// Translate the DOM `MouseEvent.buttons` bitmask into `PointerButtons`.
+///
+/// This is the W3C field itself, so no derivation is needed: the browser
+/// already reports the set held *after* the event. Reporting an empty set for
+/// an in-contact move would make the framework classify a drag as a hover, so
+/// no gesture recognizer would ever see it.
+///
+/// Bit values are fixed by the UI Events spec: 1 primary, 2 secondary,
+/// 4 auxiliary; bits 8/16 (back/forward) have no `PointerButton` here.
+fn buttons_from_mask(mask: u16) -> ui_events::pointer::PointerButtons {
+    use ui_events::pointer::{PointerButton, PointerButtons};
+
+    let mut buttons = PointerButtons::default();
+    if mask & 0x01 != 0 {
+        buttons.insert(PointerButton::Primary);
+    }
+    if mask & 0x02 != 0 {
+        buttons.insert(PointerButton::Secondary);
+    }
+    if mask & 0x04 != 0 {
+        buttons.insert(PointerButton::Auxiliary);
+    }
+    buttons
+}
+
 fn make_pointer_state(pe: &web_sys::PointerEvent) -> ui_events::pointer::PointerState {
     use dpi::{PhysicalPosition, PhysicalSize};
-    use ui_events::pointer::{PointerButtons, PointerOrientation, PointerState};
+    use ui_events::pointer::{PointerOrientation, PointerState};
 
     let modifiers = extract_modifiers_from_mouse(pe);
 
     PointerState {
         time: 0, // Browser doesn't expose nanosecond timestamps easily
         position: PhysicalPosition::new(pe.offset_x() as f64, pe.offset_y() as f64),
-        buttons: PointerButtons::default(),
+        buttons: buttons_from_mask(pe.buttons()),
         modifiers,
         count: 0,
         contact_geometry: PhysicalSize::new(pe.width().max(1) as f64, pe.height().max(1) as f64),
@@ -294,7 +319,7 @@ fn convert_wheel_event(we: &web_sys::WheelEvent) -> PlatformInput {
         state: PointerState {
             time: 0,
             position: PhysicalPosition::new(we.offset_x() as f64, we.offset_y() as f64),
-            buttons: Default::default(),
+            buttons: buttons_from_mask(we.buttons()),
             modifiers,
             count: 0,
             contact_geometry: dpi::PhysicalSize::new(1.0, 1.0),

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -179,12 +179,53 @@ unsafe fn get_modifiers() -> KeyboardModifiers {
 // Pointer Event Conversion (W3C ui-events 0.3 API)
 // ============================================================================
 
+/// The set of mouse buttons Win32 reports as held in a message's `WPARAM`.
+///
+/// Every mouse message (`WM_MOUSEMOVE`, `WM_*BUTTONDOWN`, `WM_*BUTTONUP`,
+/// `WM_MOUSEWHEEL`) carries the `MK_*` mask in the low word of `WPARAM`, and
+/// Win32 already applies the W3C rule for us: the bit for a button is set on
+/// its DOWN message and clear on its UP message, i.e. the set held *after*
+/// the event. That makes this stateless — unlike the winit backend, which has
+/// to track the transition itself because winit does not surface a mask.
+///
+/// This matters beyond fidelity: the framework tells a drag-move from a hover
+/// by asking whether any button is held. A move that always reports an empty
+/// set is delivered as a hover, so no gesture recognizer ever sees it and the
+/// drag is silently re-interpreted as a tap on release.
+///
+/// `MK_LBUTTON`/`MK_RBUTTON`/`MK_MBUTTON` are `0x0001`/`0x0002`/`0x0010`
+/// (`winuser.h`); the X buttons have no `PointerButton` mapping here.
+#[inline]
+fn held_buttons(wparam: WPARAM) -> PointerButtons {
+    const MK_LBUTTON: usize = 0x0001;
+    const MK_RBUTTON: usize = 0x0002;
+    const MK_MBUTTON: usize = 0x0010;
+
+    let mask = wparam.0 & 0xffff;
+    let mut buttons = PointerButtons::default();
+    if mask & MK_LBUTTON != 0 {
+        buttons.insert(PointerButton::Primary);
+    }
+    if mask & MK_RBUTTON != 0 {
+        buttons.insert(PointerButton::Secondary);
+    }
+    if mask & MK_MBUTTON != 0 {
+        buttons.insert(PointerButton::Auxiliary);
+    }
+    buttons
+}
+
 /// Build a `PointerState` from LPARAM coordinates and scale factor.
+///
+/// `buttons` is the held set from [`held_buttons`]; it is a required argument
+/// rather than a defaulted field so a new message arm cannot silently ship an
+/// empty set.
 #[inline]
 fn pointer_state(
     lparam: LPARAM,
     scale_factor: f32,
     pressure: f32,
+    buttons: PointerButtons,
 ) -> (PointerState, KeyboardModifiers) {
     let x = get_x_lparam(lparam);
     let y = get_y_lparam(lparam);
@@ -197,7 +238,7 @@ fn pointer_state(
     let state = PointerState {
         time: event_timestamp_ms(),
         position: PhysicalPosition::new(logical_x as f64, logical_y as f64),
-        buttons: PointerButtons::default(),
+        buttons,
         modifiers,
         count: 1,
         contact_geometry: PhysicalSize::new(1.0, 1.0),
@@ -213,10 +254,16 @@ fn pointer_state(
 pub fn mouse_button_event(
     button: PointerButton,
     is_down: bool,
+    wparam: WPARAM,
     lparam: LPARAM,
     scale_factor: f32,
 ) -> PlatformInput {
-    let (state, modifiers) = pointer_state(lparam, scale_factor, if is_down { 0.5 } else { 0.0 });
+    let (state, modifiers) = pointer_state(
+        lparam,
+        scale_factor,
+        if is_down { 0.5 } else { 0.0 },
+        held_buttons(wparam),
+    );
 
     let _ = modifiers;
 
@@ -238,8 +285,8 @@ pub fn mouse_button_event(
 }
 
 /// Convert WM_MOUSEMOVE to W3C PointerEvent
-pub fn mouse_move_event(lparam: LPARAM, scale_factor: f32) -> PlatformInput {
-    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0);
+pub fn mouse_move_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
+    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
     let _ = modifiers;
 
     let event = PointerEvent::Move(PointerUpdate {
@@ -257,7 +304,7 @@ pub fn mouse_wheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> P
     let delta = ((wparam.0 as i32) >> 16) as i16 as f32;
     let lines = delta / 120.0; // WHEEL_DELTA = 120
 
-    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0);
+    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
     let _ = modifiers;
 
     let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {
@@ -335,12 +382,17 @@ mod tests {
     #[test]
     fn test_mouse_button_down() {
         let lparam = LPARAM(((0xC8 << 16) | 0x64) as isize); // y=200, x=100
-        let event = mouse_button_event(PointerButton::Primary, true, lparam, 1.0);
+        // WM_LBUTTONDOWN carries MK_LBUTTON in its own WPARAM.
+        let event = mouse_button_event(PointerButton::Primary, true, WPARAM(0x0001), lparam, 1.0);
 
         if let PlatformInput::Pointer(PointerEvent::Down(down_event)) = event {
             assert_eq!(down_event.state.position.x, 100.0);
             assert_eq!(down_event.state.position.y, 200.0);
             assert_eq!(down_event.button, Some(PointerButton::Primary));
+            assert!(
+                down_event.state.buttons.contains(PointerButton::Primary),
+                "a press must report its own button as held"
+            );
         } else {
             panic!("Expected Pointer Down event");
         }
@@ -349,13 +401,66 @@ mod tests {
     #[test]
     fn test_mouse_move() {
         let lparam = LPARAM(((0xC8 << 16) | 0x64) as isize); // y=200, x=100
-        let event = mouse_move_event(lparam, 1.0);
+        // A drag: WM_MOUSEMOVE with MK_LBUTTON still held.
+        let event = mouse_move_event(WPARAM(0x0001), lparam, 1.0);
 
         if let PlatformInput::Pointer(PointerEvent::Move(move_event)) = event {
             assert_eq!(move_event.current.position.x, 100.0);
             assert_eq!(move_event.current.position.y, 200.0);
+            assert!(
+                move_event.current.buttons.contains(PointerButton::Primary),
+                "a move with a button held is a drag, not a hover; reporting an \
+                 empty set here routes it to on_hover and no recognizer sees it"
+            );
         } else {
             panic!("Expected Pointer Move event");
         }
+
+        // The same message with nothing held is a genuine hover.
+        let hover = mouse_move_event(WPARAM(0), lparam, 1.0);
+        if let PlatformInput::Pointer(PointerEvent::Move(move_event)) = hover {
+            assert!(move_event.current.buttons.is_empty());
+        } else {
+            panic!("Expected Pointer Move event");
+        }
+    }
+}
+
+#[cfg(test)]
+mod held_button_tests {
+    use super::*;
+
+    /// Win32 reports the held set directly, and already applies the W3C
+    /// "after the event" rule — a DOWN message carries its own bit, an UP
+    /// message does not. Reporting an empty set for an in-contact move is
+    /// what makes the framework deliver a drag as a hover.
+    ///
+    /// If reverted (`pointer_state` back to `PointerButtons::default()`):
+    /// the first two assertions read an empty set.
+    #[test]
+    fn wparam_mask_becomes_the_held_button_set() {
+        assert!(
+            held_buttons(WPARAM(0x0001)).contains(PointerButton::Primary),
+            "MK_LBUTTON must report the primary button held"
+        );
+        assert!(
+            held_buttons(WPARAM(0x0002)).contains(PointerButton::Secondary),
+            "MK_RBUTTON must report the secondary button held"
+        );
+        assert!(
+            held_buttons(WPARAM(0x0010)).contains(PointerButton::Auxiliary),
+            "MK_MBUTTON must report the auxiliary button held"
+        );
+
+        // A move with no button held is a genuine hover.
+        assert!(held_buttons(WPARAM(0)).is_empty());
+
+        // The high word carries the wheel delta on WM_MOUSEWHEEL and must not
+        // leak into the mask.
+        assert!(held_buttons(WPARAM(0x0078_0000)).is_empty());
+
+        let both = held_buttons(WPARAM(0x0003));
+        assert!(both.contains(PointerButton::Primary));
+        assert!(both.contains(PointerButton::Secondary));
     }
 }

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -758,7 +758,7 @@ impl WindowsPlatform {
                         ctx.callbacks.dispatch_hover_status_change(true);
 
                         use super::events::mouse_move_event;
-                        let event = mouse_move_event(lparam, ctx.scale_factor.get());
+                        let event = mouse_move_event(wparam, lparam, ctx.scale_factor.get());
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)
@@ -790,6 +790,7 @@ impl WindowsPlatform {
                         let event = mouse_button_event(
                             PointerButton::Primary,
                             true,
+                            wparam,
                             lparam,
                             ctx.scale_factor.get(),
                         );
@@ -806,6 +807,7 @@ impl WindowsPlatform {
                         let event = mouse_button_event(
                             PointerButton::Secondary,
                             true,
+                            wparam,
                             lparam,
                             ctx.scale_factor.get(),
                         );
@@ -822,6 +824,7 @@ impl WindowsPlatform {
                         let event = mouse_button_event(
                             PointerButton::Auxiliary,
                             true,
+                            wparam,
                             lparam,
                             ctx.scale_factor.get(),
                         );
@@ -838,6 +841,7 @@ impl WindowsPlatform {
                         let event = mouse_button_event(
                             PointerButton::Primary,
                             false,
+                            wparam,
                             lparam,
                             ctx.scale_factor.get(),
                         );
@@ -854,6 +858,7 @@ impl WindowsPlatform {
                         let event = mouse_button_event(
                             PointerButton::Secondary,
                             false,
+                            wparam,
                             lparam,
                             ctx.scale_factor.get(),
                         );
@@ -870,6 +875,7 @@ impl WindowsPlatform {
                         let event = mouse_button_event(
                             PointerButton::Auxiliary,
                             false,
+                            wparam,
                             lparam,
                             ctx.scale_factor.get(),
                         );


### PR DESCRIPTION
## Summary

`Listener::handler` discriminates a drag-move from a hover by asking whether any button is held. Three backends hardcoded `PointerButtons::default()` for **every** pointer event, so on Win32, Web and Android every move was classified as a hover, `GestureDetector` (which wires only down/move/up, never hover) never forwarded it, and no recognizer crossed its slop threshold. On release the arena swept and the tap recognizer won — every drag, pan, scale, swipe-to-dismiss and drag-to-reorder was **silently delivered as a tap**.

winit was fixed in #714; macOS already read `NSEvent pressedMouseButtons`. It was three backends, not four.

Each backend already had the answer and was discarding it:

- **Win32** — every mouse message carries the `MK_*` mask in the low word of `WPARAM`, and Win32 already applies the W3C "held after the event" rule (set on DOWN, clear on UP). Thread `wparam` through `mouse_move_event`/`mouse_button_event` and read it. Stateless, unlike winit which must track the transition itself.
- **Web** — `PointerEvent.buttons` *is* the W3C field. Read it directly.
- **Android** — reports no mask for touch, but `MotionAction` states the answer: `Down`/`Move` are contact, `Hover*` are not, `Up` is the release itself.

`buttons` becomes a **required argument** of each backend's pointer-state builder rather than a defaulted struct field, so a new message arm cannot silently ship an empty set.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — not applicable (platform input translation)
- [x] New or changed behavior has tests that would fail without this change — **see the caveat below**
- [x] Public API changes are documented — internal to the backends

Ran the exact four cross-target commands CI runs:

```
clippy x86_64-pc-windows-msvc  = 0
clippy aarch64-apple-darwin    = 0
clippy aarch64-linux-android   = 0
cargo check wasm32-unknown-unknown = 0
```

199 flui-platform tests pass under `FLUI_HEADLESS=1`.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

**Coverage, stated honestly.** The Win32 unit tests added here are compiled by `cross-typecheck` and **never executed**; Android and Web have no executing tests at all. `cargo clippy --target` is the only gate these three backends have anywhere. The executable proof for this defect class belongs in the live-smoke harness (#715), which drives real input through a real window.

Ordering note for any follow-up: per-backend population must land **before** any ingest-seam synthesis helper, because such a helper passes `PointerType::Mouse` through untouched by design — landing the seam first would leave Win32/Web mouse drag still dead while the batch *reads* as fixed.

Deferred: the structural fix is to stop letting the widget layer re-derive contact-vs-hover at all. `PointerMotionKind::{Contact,Hover}` already exists and `GestureBinding` already computes the right answer from its cached Down route, then throws it away. Carrying it through the lane is ~800 LOC and a workspace-wide handler-signature break — cleanliness, not the bug fix, and it silently changes behavior on the backends that already work (press outside the window, drag in).

Found by a code-first runtime audit; one of six crate-disjoint P0 fixes that merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo