### PR TITLE
fix(interaction): a move-driven long press wins its arena before it fires

### DIFF
--- a/crates/flui-interaction/docs/GESTURES.md
+++ b/crates/flui-interaction/docs/GESTURES.md
@@ -106,7 +106,9 @@ Started → Ready (pointer_up → success)
 ```rust
 // Call periodically in event loop
 if recognizer.check_timer() {
-    // Timer elapsed, long press started
+    // Timer elapsed, long press started — and the arena is already
+    // resolved in this recognizer's favour, so competing members (a tap
+    // on the same region) have been rejected. Do not resolve it again.
 }
 ```
 

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -440,6 +440,20 @@ impl LongPressGestureRecognizer {
         // synchronously dispose or start another sequence on this recognizer.
         self.stop_deadline_polling();
 
+        // Winning the arena is part of firing, not a caller obligation.
+        // Whichever path notices the elapsed deadline — the frame poll, a move
+        // drifting inside the slop radius, or an embedder's `check_timer` tick
+        // — a fired long press must reject its competitors, or a tap on the
+        // same region also fires on release (long-pressing a list row opens the
+        // context menu AND navigates into it).
+        //
+        // Safe to resolve here: the `gesture_state` lock was released with the
+        // snapshot above, and the arena defers member notifications out of its
+        // own lock, so a callback re-entering recognizer API cannot deadlock.
+        // Ordered before the callbacks so application code observes an already
+        // resolved arena, matching `did_exceed_deadline`.
+        self.state.accept_tracked();
+
         if let Some(callback) = self.callbacks.borrow().on_long_press.clone() {
             callback();
         }
@@ -458,6 +472,14 @@ impl LongPressGestureRecognizer {
     ///
     /// This should be called periodically by the event loop. Returns
     /// `true` when the deadline fired this tick.
+    ///
+    /// # Arena resolution
+    ///
+    /// Firing also WINS the arena for this sequence, rejecting competing
+    /// members. That is not an optional extra a caller may skip: a long press
+    /// that fires without resolving leaves a competing tap live, so the tap
+    /// also fires on release. Callers that drive this tick therefore do not
+    /// need to — and must not separately — resolve the arena themselves.
     pub fn check_timer(&self) -> bool {
         let position = self
             .gesture_state
@@ -627,16 +649,12 @@ impl GestureArenaMember for LongPressGestureRecognizer {
         // pointer event arrives to drive it). `check_timer` is idempotent, so
         // polling every frame fires at most once.
         //
-        // When the deadline fires, ALSO win the arena — mirroring
-        // `did_exceed_deadline`. Without this, a held long-press in a
-        // multi-recognizer detector fires its callback but never rejects the
-        // competing tap, so the tap would still fire on release. `check_timer`
-        // returns having already dropped the gesture_state lock, so resolving
-        // here is re-entrancy-safe (the arena defers member notifications out
-        // of its own lock).
-        if self.check_timer() {
-            self.state.accept_tracked();
-        }
+        // Winning the arena on fire now lives in `try_fire_timer`, so every
+        // path that can notice the elapsed deadline resolves it — this one,
+        // `handle_move`, and the public `check_timer`. It used to be here
+        // alone, which left the move-driven path firing without rejecting its
+        // competitors.
+        self.check_timer();
     }
 
     fn has_pending_deadline(&self) -> bool {
@@ -1111,6 +1129,68 @@ mod tests {
         assert!(
             *rejected.lock(),
             "poll_deadline must win the arena and reject the competing member",
+        );
+    }
+
+    /// The same contract on the move-driven path.
+    ///
+    /// A long press whose deadline elapses while the finger is drifting inside
+    /// the slop radius fires from `handle_move`, not from the frame poll. That
+    /// path fired the callback without resolving the arena, so a competing tap
+    /// stayed live and ALSO fired on release: long-pressing a list row opened
+    /// the context menu and navigated into the row.
+    ///
+    /// If reverted (drop the `accept_tracked` from `try_fire_timer`): the
+    /// callback still fires but the competitor is never rejected.
+    #[test]
+    fn a_move_driven_long_press_wins_the_arena_when_it_fires() {
+        struct Competitor {
+            rejected: Arc<Mutex<bool>>,
+        }
+        impl crate::sealed::arena_member::Sealed for Competitor {}
+        impl crate::arena::GestureArenaMember for Competitor {
+            fn accept_gesture(&self, _: PointerId) {}
+            fn reject_gesture(&self, _: PointerId) {
+                *self.rejected.lock() = true;
+            }
+        }
+
+        let clock = flui_foundation::ManualClock::new();
+        let arena = GestureArena::with_clock(Arc::new(clock.clone()));
+        let recognizer = LongPressGestureRecognizer::with_settings(
+            arena.clone(),
+            GestureSettings::touch_defaults().with_long_press_timeout(Duration::from_millis(100)),
+        );
+        let pointer = PointerId::new(3).expect("nonzero pointer id");
+        let start = Offset::new(Pixels(10.0), Pixels(10.0));
+        recognizer.add_pointer(pointer, start);
+
+        let rejected = Arc::new(Mutex::new(false));
+        arena.add(
+            pointer,
+            Arc::new(Competitor {
+                rejected: rejected.clone(),
+            }),
+        );
+        arena.close(pointer);
+
+        let fired = Arc::new(Mutex::new(false));
+        let fired_flag = Arc::clone(&fired);
+        let recognizer = recognizer.with_on_long_press(move || *fired_flag.lock() = true);
+
+        // Hold past the deadline, then drift a hair — inside the slop radius,
+        // so this is still the same press, and the move is what notices the
+        // elapsed deadline.
+        clock.advance(Duration::from_millis(150));
+        let drift = Offset::new(Pixels(11.0), Pixels(11.0));
+        let mv = crate::events::make_move_event(drift, PointerType::Touch);
+        recognizer.handle_event(&mv);
+
+        assert!(*fired.lock(), "precondition: the move fired the long press");
+        assert!(
+            *rejected.lock(),
+            "a move-driven long press must win the arena too, or a competing \
+             tap also fires on release",
         );
     }
 

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -629,6 +629,17 @@ impl crate::recognizers::PrimaryPointerGestureRecognizer for LongPressGestureRec
             .or_else(|| self.initial_position())
             .unwrap_or_else(|| Offset::new(Pixels(0.0), Pixels(0.0)));
         self.try_fire_timer(position);
+        // Kept deliberately, even though `try_fire_timer` now also resolves on
+        // fire. This hook is the ARENA's deadline, and in the reference the
+        // arena's deadline is the authority — `didExceedDeadline` resolves
+        // unconditionally before firing ("Exceeding the deadline puts the
+        // gesture in the accepted state",
+        // .flutter/packages/flutter/lib/src/gestures/long_press.dart), with no
+        // re-check of elapsed time. Dropping this call would make acceptance
+        // conditional on `try_fire_timer`'s own clock comparison and diverge
+        // from that. The two agree in production — `deadline()` returns the
+        // same `long_press_timeout` `try_fire_timer` measures against — so the
+        // second resolve lands on an already-resolved arena and is a no-op.
         self.state.accept_tracked();
     }
 


### PR DESCRIPTION
## Summary

`poll_deadline` resolved the arena when the frame-driven deadline check fired, but the other two paths that can notice an elapsed deadline did not: `handle_move` (a finger drifting inside the slop radius) and the public `check_timer` embedder tick.

Both fired the callback and left competing members live, so a tap on the same region **also** fired on release — long-pressing a list row opened the context menu *and* navigated into the row.

The resolution moves into `try_fire_timer`, the single point all three paths funnel through, and the now-redundant call in `poll_deadline` is dropped. Winning the arena is part of firing, not a caller obligation.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — `did_exceed_deadline` resolves the arena as part of firing (`long_press.dart`); ordering the accept **before** the callbacks matches it, so application code observes an already-resolved arena
- [x] New or changed behavior has tests that would fail without this change
- [x] Public API changes are documented — see Notes

`a_move_driven_long_press_wins_the_arena_when_it_fires` holds past the deadline, drifts one pixel (inside slop), and asserts a competing arena member is rejected. Red before this change: the callback fired, the competitor did not. The existing `poll_deadline_wins_the_arena_when_it_fires` still passes, now via the shared path.

487 flui-interaction tests, and 3019 across interaction / widgets / material.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

**This changes the contract of a public, documented API.** `check_timer` is documented as an embedder event-loop tick in `crates/flui-interaction/docs/GESTURES.md:108`, and it now resolves the gesture arena as part of firing. Both its rustdoc and that snippet are updated to say so, and to say callers must not resolve it again.

Re-entrancy is safe at the new call site: the `gesture_state` lock is released with the snapshot above it, and the arena defers member notifications out of its own lock, so a callback re-entering recognizer API cannot deadlock.

Worth a reviewer's opinion, deliberately **not** done here: in Flutter a long press fires from exactly one place — `didExceedDeadline`, timer-driven; `handlePrimaryPointer`'s move path never reaches `_checkLongPressStart`. FLUI's `handle_move → try_fire_timer` is a FLUI-only compensating path that predates the frame-driven `poll_deadline`. **Deleting it** may be the more faithful fix now that `poll_deadline` exists, and would make this change unnecessary. I kept it because removing a firing path is a behavioural change I would not make without your call.

Found by a code-first runtime audit; one of six crate-disjoint P0 fixes that merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo