### PR TITLE
fix(engine): draw order follows record order across primitive kinds

### DIFF
--- a/crates/flui-engine/src/wgpu/batches/gradients.rs
+++ b/crates/flui-engine/src/wgpu/batches/gradients.rs
@@ -62,8 +62,13 @@ impl DrawBatcher {
         // gradients keep exactly today's ordering — wrong relative to earlier
         // primitives, but not newly wrong. Making them orderable means giving
         // each segment its own slice of the stop buffer (a dynamic offset, or
-        // one buffer per segment); `a_gradient_after_a_kind_seal_reads_its_own_
-        // stop_table` in `shape_blend_tests` is the acceptance test for that.
+        // one buffer per segment). Until then `begin_phase` additionally
+        // refuses to seal a segment that already carries stops, because
+        // skipping the seal HERE does not stop a backward transition between
+        // two other kinds from splitting this segment anyway.
+        // `a_kind_seal_never_splits_gradient_bearing_content` (batches/mod.rs)
+        // and `two_gradients_separated_by_a_rect_keep_their_own_colours`
+        // (shape_blend_tests) are the guards.
 
         let stop_count = stops.len().min(8);
         let current_len = segment.current_gradient_stops.len();
@@ -151,8 +156,13 @@ impl DrawBatcher {
         // gradients keep exactly today's ordering — wrong relative to earlier
         // primitives, but not newly wrong. Making them orderable means giving
         // each segment its own slice of the stop buffer (a dynamic offset, or
-        // one buffer per segment); `a_gradient_after_a_kind_seal_reads_its_own_
-        // stop_table` in `shape_blend_tests` is the acceptance test for that.
+        // one buffer per segment). Until then `begin_phase` additionally
+        // refuses to seal a segment that already carries stops, because
+        // skipping the seal HERE does not stop a backward transition between
+        // two other kinds from splitting this segment anyway.
+        // `a_kind_seal_never_splits_gradient_bearing_content` (batches/mod.rs)
+        // and `two_gradients_separated_by_a_rect_keep_their_own_colours`
+        // (shape_blend_tests) are the guards.
 
         let stop_count = stops.len().min(8);
         let current_len = segment.current_gradient_stops.len();
@@ -240,8 +250,13 @@ impl DrawBatcher {
         // gradients keep exactly today's ordering — wrong relative to earlier
         // primitives, but not newly wrong. Making them orderable means giving
         // each segment its own slice of the stop buffer (a dynamic offset, or
-        // one buffer per segment); `a_gradient_after_a_kind_seal_reads_its_own_
-        // stop_table` in `shape_blend_tests` is the acceptance test for that.
+        // one buffer per segment). Until then `begin_phase` additionally
+        // refuses to seal a segment that already carries stops, because
+        // skipping the seal HERE does not stop a backward transition between
+        // two other kinds from splitting this segment anyway.
+        // `a_kind_seal_never_splits_gradient_bearing_content` (batches/mod.rs)
+        // and `two_gradients_separated_by_a_rect_keep_their_own_colours`
+        // (shape_blend_tests) are the guards.
 
         let stop_count = stops.len().min(8);
         let current_len = segment.current_gradient_stops.len();

--- a/crates/flui-engine/src/wgpu/batches/gradients.rs
+++ b/crates/flui-engine/src/wgpu/batches/gradients.rs
@@ -49,6 +49,22 @@ impl DrawBatcher {
         use super::super::instancing::LinearGradientInstance;
 
         // Append gradient stops to global buffer (max 8 per gradient).
+        // NOT sealed by kind. Gradients are deliberately excluded from
+        // `DrawBatcher::begin_phase`'s draw-order seal, because two segments in
+        // one frame cannot both carry gradient stops today: every segment's
+        // table is uploaded to the SAME `gradient_stops_buffer` at offset 0
+        // (`PipelineSet::refresh_gradient_bind_group`), and since all passes
+        // are recorded into one `CommandEncoder` before submission, the last
+        // `write_buffer` wins and every gradient pass in the frame samples that
+        // one table.
+        //
+        // Sealing here would turn a rare latent bug into a common one, so
+        // gradients keep exactly today's ordering — wrong relative to earlier
+        // primitives, but not newly wrong. Making them orderable means giving
+        // each segment its own slice of the stop buffer (a dynamic offset, or
+        // one buffer per segment); `a_gradient_after_a_kind_seal_reads_its_own_
+        // stop_table` in `shape_blend_tests` is the acceptance test for that.
+
         let stop_count = stops.len().min(8);
         let current_len = segment.current_gradient_stops.len();
         if current_len + stop_count > effects_pipeline::MAX_GRADIENT_STOPS {
@@ -121,6 +137,22 @@ impl DrawBatcher {
         corner_radius: f32,
     ) {
         use super::super::instancing::RadialGradientInstance;
+
+        // NOT sealed by kind. Gradients are deliberately excluded from
+        // `DrawBatcher::begin_phase`'s draw-order seal, because two segments in
+        // one frame cannot both carry gradient stops today: every segment's
+        // table is uploaded to the SAME `gradient_stops_buffer` at offset 0
+        // (`PipelineSet::refresh_gradient_bind_group`), and since all passes
+        // are recorded into one `CommandEncoder` before submission, the last
+        // `write_buffer` wins and every gradient pass in the frame samples that
+        // one table.
+        //
+        // Sealing here would turn a rare latent bug into a common one, so
+        // gradients keep exactly today's ordering — wrong relative to earlier
+        // primitives, but not newly wrong. Making them orderable means giving
+        // each segment its own slice of the stop buffer (a dynamic offset, or
+        // one buffer per segment); `a_gradient_after_a_kind_seal_reads_its_own_
+        // stop_table` in `shape_blend_tests` is the acceptance test for that.
 
         let stop_count = stops.len().min(8);
         let current_len = segment.current_gradient_stops.len();
@@ -195,6 +227,22 @@ impl DrawBatcher {
     ) {
         use super::super::instancing::SweepGradientInstance;
 
+        // NOT sealed by kind. Gradients are deliberately excluded from
+        // `DrawBatcher::begin_phase`'s draw-order seal, because two segments in
+        // one frame cannot both carry gradient stops today: every segment's
+        // table is uploaded to the SAME `gradient_stops_buffer` at offset 0
+        // (`PipelineSet::refresh_gradient_bind_group`), and since all passes
+        // are recorded into one `CommandEncoder` before submission, the last
+        // `write_buffer` wins and every gradient pass in the frame samples that
+        // one table.
+        //
+        // Sealing here would turn a rare latent bug into a common one, so
+        // gradients keep exactly today's ordering — wrong relative to earlier
+        // primitives, but not newly wrong. Making them orderable means giving
+        // each segment its own slice of the stop buffer (a dynamic offset, or
+        // one buffer per segment); `a_gradient_after_a_kind_seal_reads_its_own_
+        // stop_table` in `shape_blend_tests` is the acceptance test for that.
+
         let stop_count = stops.len().min(8);
         let current_len = segment.current_gradient_stops.len();
         if current_len + stop_count > effects_pipeline::MAX_GRADIENT_STOPS {
@@ -249,6 +297,7 @@ impl DrawBatcher {
     /// * `params`         — shadow offset, blur sigma, and color
     pub(in super::super) fn shadow_rect(
         segment: &mut DrawSegment,
+        draw_order: &mut Vec<super::super::command_ir::DrawItem>,
         rect_pos: [f32; 2],
         rect_size: [f32; 2],
         corner_radius: f32,
@@ -257,6 +306,7 @@ impl DrawBatcher {
         use super::super::instancing::ShadowInstance;
 
         let instance = ShadowInstance::new(rect_pos, rect_size, corner_radius, params);
+        Self::begin_phase(segment, draw_order, super::super::command_ir::Phase::Shadow);
         let _ = segment.shadow_batch.add(instance);
     }
 

--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -77,7 +77,7 @@ use flui_types::{
 
 use super::{
     super::{
-        command_ir::{AdvancedShapeOp, DrawItem, DrawSegment},
+        command_ir::{AdvancedShapeOp, DrawItem, DrawSegment, Phase},
         state_stack::GpuStateStack,
         texture_cache::TextureCache,
     },
@@ -107,6 +107,7 @@ impl DrawBatcher {
     /// upstream — advanced blend is unreachable here by construction.
     pub(in super::super) fn texture(
         segment: &mut DrawSegment,
+        draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
         texture_id: flui_types::painting::TextureId,
         dst_rect: Rect<Pixels>,
@@ -133,6 +134,7 @@ impl DrawBatcher {
         // Store the ID in the IR. Resolution happens at replay time in
         // flush_segment_external_images, which calls
         // ExternalTextureRegistry::get(id) immediately before the GPU draw.
+        Self::begin_phase(segment, draw_order, Phase::ExternalImage);
         segment
             .external_images
             .push((texture_id, instance, state.current_scissor()));
@@ -260,6 +262,7 @@ impl DrawBatcher {
                 // Keep cached image draws in segment order for correct layer compositing.
                 // Capture the active scissor so flush_segment_cached_images can clip
                 // images that live inside a clip_rect region.
+                Self::begin_phase(segment, draw_order, Phase::CachedImage);
                 segment
                     .cached_images
                     .push((texture_id, instance, state.current_scissor()));
@@ -1319,6 +1322,7 @@ impl DrawBatcher {
                     let instance = state.apply_active_clip(
                         super::super::instancing::TextureInstance::with_uv(dst_rect, src_uv, tint),
                     );
+                    Self::begin_phase(segment, draw_order, Phase::CachedImage);
                     segment.cached_images.push((
                         cache_id.clone(),
                         instance,
@@ -1361,6 +1365,7 @@ impl DrawBatcher {
     )]
     pub(in super::super) fn draw_texture(
         segment: &mut DrawSegment,
+        draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
         src_uv_registry: Option<(u32, u32)>,
         texture_id: flui_types::painting::TextureId,
@@ -1419,6 +1424,7 @@ impl DrawBatcher {
 
         // Push the ID into the IR. Resolution to a `wgpu::TextureView` happens
         // at replay time in flush_segment_external_images.
+        Self::begin_phase(segment, draw_order, Phase::ExternalImage);
         segment
             .external_images
             .push((texture_id, instance, state.current_scissor()));

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -47,7 +47,7 @@ use flui_painting::BlendMode;
 use flui_types::{Rect, geometry::Pixels};
 
 use super::{
-    command_ir::{AdvancedShapeOp, DrawItem, DrawSegment, SsaaPathOp, TessellatedBatch},
+    command_ir::{AdvancedShapeOp, DrawItem, DrawSegment, Phase, SsaaPathOp, TessellatedBatch},
     path_cache::PathCache,
     pipeline::PipelineKey,
     state_stack::GpuStateStack,
@@ -136,6 +136,31 @@ impl DrawBatcher {
         // default from `take`.
     }
 
+    /// Declare that the next primitive recorded into `segment` belongs to
+    /// `phase`, sealing the segment first if the fixed replay order would put
+    /// it BEFORE something already recorded.
+    ///
+    /// Call this immediately before every push into a `DrawSegment` batch.
+    /// Together the calls make `flush_segment`'s fixed phase order equal record
+    /// order within each segment, which is what gives the painter's algorithm
+    /// back across primitive kinds — a circle followed by an overlapping rect
+    /// previously drew the rect first and let the circle paint over it.
+    ///
+    /// A forward transition (rect then circle) never seals, so correctly
+    /// ordered content costs nothing: it stays in one segment and one pass.
+    /// Only genuinely interleaved content splits, and that is exactly the
+    /// content whose output was wrong before.
+    pub(super) fn begin_phase(
+        segment: &mut DrawSegment,
+        draw_order: &mut Vec<DrawItem>,
+        phase: Phase,
+    ) {
+        if segment.would_reorder(phase) {
+            Self::finish_current_segment(segment, draw_order);
+        }
+        segment.last_phase = Some(phase);
+    }
+
     /// Append tessellated vertices/indices to `segment` under the given pipeline
     /// key, starting a new `TessellatedBatch` on a key or scissor change.
     ///
@@ -221,6 +246,12 @@ impl DrawBatcher {
         }
 
         // ── Normal path (SrcOver + Porter-Duff) ──────────────────────────────
+
+        // Seal BEFORE reading the buffer lengths: `base_index`/`index_start`
+        // are offsets into THIS segment's vertex/index buffers, so sealing
+        // after reading them would rebase the appended geometry onto a fresh,
+        // empty segment while the offsets still describe the sealed one.
+        Self::begin_phase(segment, draw_order, Phase::Tess);
 
         let base_index = segment.vertices.len() as u32;
         let index_start = segment.indices.len() as u32;
@@ -463,6 +494,94 @@ mod unit_tests {
     ];
 
     // ── Helper: build the minimal geometry for a quad ─────────────────────────
+
+    /// Every `TessellatedBatch` in a segment indexes within that same segment's
+    /// vertex and index buffers.
+    ///
+    /// `add_tessellated_with_key` rebases indices by
+    /// `base_index = segment.vertices.len()` and records
+    /// `index_start = segment.indices.len()`. Both describe THIS segment, so
+    /// the kind seal has to fire before they are read. Read them first and the
+    /// geometry is appended to a fresh segment while the offsets still describe
+    /// the sealed one — the batch then points past the end of its own buffers.
+    ///
+    /// Sequence: tessellated geometry, then an image (a forward transition, so
+    /// no seal — the segment now holds BOTH), then more tessellated geometry,
+    /// which IS a backward transition and seals. Both preconditions matter: a
+    /// seal with empty buffers leaves `base_index == 0` and hides the bug,
+    /// which is why the obvious GPU readback versions of this test pass either
+    /// way.
+    ///
+    /// If reverted (move `begin_phase` below the two `let` bindings in
+    /// `add_tessellated_with_key`): the final segment reports
+    /// `index_start` beyond its own `indices.len()`.
+    #[test]
+    fn tessellated_batches_index_within_their_own_segment() {
+        use super::super::command_ir::Phase;
+
+        let state = GpuStateStack::new();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let key = PipelineKey::alpha_blend();
+        let indices: [u32; 6] = [0, 1, 2, 0, 2, 3];
+
+        // 1. Tessellated geometry — fills the segment's vertex/index buffers.
+        DrawBatcher::add_tessellated_with_key(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            rect_vertices(0.0, 0.0, 10.0, 10.0),
+            &indices,
+            key,
+        );
+        assert!(
+            !segment.vertices.is_empty(),
+            "precondition: the segment carries tessellated vertices"
+        );
+
+        // 2. An image. CachedImage replays after Tess, so this is a forward
+        //    transition and must NOT seal — the segment keeps its vertices.
+        DrawBatcher::begin_phase(&mut segment, &mut draw_order, Phase::CachedImage);
+        assert!(
+            draw_order.is_empty(),
+            "a forward kind transition must not seal the segment"
+        );
+
+        // 3. More tessellated geometry — a backward transition, so this seals
+        //    with non-empty buffers.
+        DrawBatcher::add_tessellated_with_key(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            rect_vertices(20.0, 20.0, 30.0, 30.0),
+            &indices,
+            key,
+        );
+        assert_eq!(
+            draw_order.len(),
+            1,
+            "a backward kind transition must seal exactly once"
+        );
+
+        for (i, batch) in segment.tess_batches.iter().enumerate() {
+            let end = batch.index_start + batch.index_count;
+            assert!(
+                end as usize <= segment.indices.len(),
+                "tess_batches[{i}] spans {}..{end} but its segment holds only {} indices — \
+                 the batch was recorded against a different segment's buffers",
+                batch.index_start,
+                segment.indices.len(),
+            );
+        }
+        for (i, index) in segment.indices.iter().enumerate() {
+            assert!(
+                (*index as usize) < segment.vertices.len(),
+                "indices[{i}] = {index} but its segment holds only {} vertices — \
+                 base_index was taken from a different segment",
+                segment.vertices.len(),
+            );
+        }
+    }
 
     /// Build the four vertices for an axis-aligned rectangle in device pixels.
     ///

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -140,7 +140,10 @@ impl DrawBatcher {
     /// `phase`, sealing the segment first if the fixed replay order would put
     /// it BEFORE something already recorded.
     ///
-    /// Call this immediately before every push into a `DrawSegment` batch.
+    /// Call this immediately before every push into a `DrawSegment` batch —
+    /// with one deliberate exception: the gradient recorders do NOT call it.
+    /// See `DrawBatcher::gradient_rect` for why, and do not "fix" that by
+    /// following this sentence literally.
     /// Together the calls make `flush_segment`'s fixed phase order equal record
     /// order within each segment, which is what gives the painter's algorithm
     /// back across primitive kinds — a circle followed by an overlapping rect
@@ -155,7 +158,19 @@ impl DrawBatcher {
         draw_order: &mut Vec<DrawItem>,
         phase: Phase,
     ) {
-        if segment.would_reorder(phase) {
+        // Never split gradient-bearing content. Gradients skip this seal
+        // entirely (see `DrawBatcher::gradient_rect`), but skipping it is not
+        // enough on its own: a backward transition between two OTHER kinds —
+        // gradient, circle, rect — would still finalize a segment that carries
+        // gradient stops, and every segment's table is uploaded to the same
+        // buffer at offset 0, so the earlier gradient would sample the later
+        // table. Holding the segment together keeps such content at exactly
+        // today's ordering rather than making it newly wrong.
+        //
+        // This gives up kind-ordering for the rest of a segment once a
+        // gradient is in it. That is the conservative half of the trade and it
+        // disappears once stop tables are per-segment.
+        if segment.would_reorder(phase) && segment.current_gradient_stops.is_empty() {
             Self::finish_current_segment(segment, draw_order);
         }
         segment.last_phase = Some(phase);
@@ -581,6 +596,74 @@ mod unit_tests {
                 segment.vertices.len(),
             );
         }
+    }
+
+    /// No kind seal may finalize a segment that carries gradient stops.
+    ///
+    /// Gradients skip `begin_phase`, but that alone does not protect them: a
+    /// backward transition between two OTHER kinds still seals the segment they
+    /// live in. Every segment's stop table is uploaded to the same
+    /// `gradient_stops_buffer` at offset 0 and all passes are recorded into one
+    /// `CommandEncoder` before submission, so the last write wins — two
+    /// gradient-bearing segments in a frame cannot both be correct.
+    ///
+    /// Sequence: gradient, then circle, then rect. The circle -> rect step is
+    /// the backward transition; without the guard it seals a segment holding
+    /// the gradient's stops.
+    ///
+    /// If reverted (drop `&& segment.current_gradient_stops.is_empty()` from
+    /// `begin_phase`): one sealed segment carries stops and this fails.
+    #[test]
+    fn a_kind_seal_never_splits_gradient_bearing_content() {
+        use super::super::command_ir::Phase;
+        use super::super::effects::GradientStop;
+        use flui_types::geometry::Pixels;
+
+        let state = GpuStateStack::new();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let stops = [
+            GradientStop {
+                color: [1.0, 0.0, 0.0, 1.0],
+                position: 0.0,
+                padding: [0.0; 3],
+            },
+            GradientStop {
+                color: [1.0, 0.0, 0.0, 1.0],
+                position: 1.0,
+                padding: [0.0; 3],
+            },
+        ];
+
+        DrawBatcher::gradient_rect(
+            &mut segment,
+            &state,
+            Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(10.0), Pixels(10.0)),
+            glam::Vec2::new(0.0, 0.0),
+            glam::Vec2::new(10.0, 0.0),
+            &stops,
+            0.0,
+        );
+        assert!(
+            !segment.current_gradient_stops.is_empty(),
+            "precondition: the segment carries gradient stops"
+        );
+
+        DrawBatcher::begin_phase(&mut segment, &mut draw_order, Phase::Circle);
+        DrawBatcher::begin_phase(&mut segment, &mut draw_order, Phase::Rect);
+
+        let sealed_with_stops = draw_order
+            .iter()
+            .filter(
+                |it| matches!(it, DrawItem::Segment(seg) if !seg.current_gradient_stops.is_empty()),
+            )
+            .count();
+        assert_eq!(
+            sealed_with_stops, 0,
+            "a kind seal finalized a gradient-bearing segment; its stop table and the \
+             next one both upload to the same buffer, so the earlier gradient renders \
+             with the later colours"
+        );
     }
 
     /// Build the four vertices for an axis-aligned rectangle in device pixels.

--- a/crates/flui-engine/src/wgpu/batches/paths.rs
+++ b/crates/flui-engine/src/wgpu/batches/paths.rs
@@ -107,7 +107,7 @@ impl DrawBatcher {
         // a 1.0-elevation card otherwise gets a single ~0.75px-offset copy,
         // i.e. no visible soft shadow at all.
         if let Some(rrect) = path.rrect_hint() {
-            Self::draw_analytic_rrect_shadow(segment, state, &rrect, color, elevation);
+            Self::draw_analytic_rrect_shadow(segment, draw_order, state, &rrect, color, elevation);
             return;
         }
 
@@ -178,6 +178,7 @@ impl DrawBatcher {
     /// reproduction — shadow shaping is a sanctioned leapfrog area.
     fn draw_analytic_rrect_shadow(
         segment: &mut DrawSegment,
+        draw_order: &mut Vec<super::super::command_ir::DrawItem>,
         state: &GpuStateStack,
         rrect: &flui_types::geometry::RRect,
         color: Color,
@@ -208,7 +209,14 @@ impl DrawBatcher {
         let shadow_color = Color::rgba(color.r, color.g, color.b, alpha);
 
         let params = super::super::effects::ShadowParams::new(offset, blur_sigma, shadow_color);
-        Self::shadow_rect(segment, rect_pos, rect_size, corner_radius, &params);
+        Self::shadow_rect(
+            segment,
+            draw_order,
+            rect_pos,
+            rect_size,
+            corner_radius,
+            &params,
+        );
     }
 
     /// Record a filled or stroked path, using the per-frame tessellation cache

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -8,8 +8,8 @@ use flui_types::{
 
 use super::{
     super::{
-        command_ir::DrawItem, command_ir::DrawSegment, pipeline, state_stack::GpuStateStack,
-        vertex::Vertex,
+        command_ir::DrawItem, command_ir::DrawSegment, command_ir::Phase, pipeline,
+        state_stack::GpuStateStack, vertex::Vertex,
     },
     DrawBatcher,
 };
@@ -81,6 +81,7 @@ impl DrawBatcher {
                     let instance = state.apply_active_clip(
                         super::super::instancing::RectInstance::rect(device_rect, color),
                     );
+                    Self::begin_phase(segment, draw_order, Phase::Rect);
                     let _ = segment.rect_batch.add(instance);
                     DrawSegment::push_scissor_region(
                         &mut segment.rect_scissors,
@@ -107,6 +108,7 @@ impl DrawBatcher {
                             translation,
                         ),
                     );
+                    Self::begin_phase(segment, draw_order, Phase::Rect);
                     let _ = segment.rect_batch.add(instance);
                     // Scissor = the active damage/clip region, exactly as the
                     // axis-aligned path. The shape is bounded by its own quad +
@@ -307,6 +309,7 @@ impl DrawBatcher {
                         radius_bottom_left,
                     ),
                 );
+                Self::begin_phase(segment, draw_order, Phase::Rect);
                 let _ = segment.rect_batch.add(instance);
                 DrawSegment::push_scissor_region(
                     &mut segment.rect_scissors,
@@ -343,6 +346,7 @@ impl DrawBatcher {
                         translation,
                     ),
                 );
+                Self::begin_phase(segment, draw_order, Phase::Rect);
                 let _ = segment.rect_batch.add(instance);
                 // Scissor = the active damage/clip region (same as the axis-aligned
                 // path); the shape is bounded by its own quad + SDF, so a per-shape
@@ -430,6 +434,7 @@ impl DrawBatcher {
                         color,
                         [sx, sy],
                     );
+                    Self::begin_phase(segment, draw_order, Phase::Circle);
                     let _ = segment.circle_batch.add(instance);
                     DrawSegment::push_scissor_region(
                         &mut segment.circle_scissors,
@@ -458,6 +463,7 @@ impl DrawBatcher {
                         color,
                         [tx, ty],
                     );
+                    Self::begin_phase(segment, draw_order, Phase::Circle);
                     let _ = segment.circle_batch.add(instance);
                     DrawSegment::push_scissor_region(
                         &mut segment.circle_scissors,
@@ -590,6 +596,7 @@ impl DrawBatcher {
                 color,
                 [tx, ty],
             );
+            Self::begin_phase(segment, draw_order, Phase::Circle);
             let _ = segment.circle_batch.add(instance);
             DrawSegment::push_scissor_region(&mut segment.circle_scissors, state.current_scissor());
         } else if paint.style == PaintStyle::Fill {
@@ -776,6 +783,7 @@ impl DrawBatcher {
                     color,
                     [tx, ty],
                 );
+                Self::begin_phase(segment, draw_order, Phase::Arc);
                 let _ = segment.arc_batch.add(instance);
                 DrawSegment::push_scissor_region(
                     &mut segment.arc_scissors,

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -530,6 +530,57 @@ pub(crate) struct DrawSegment {
     ///
     /// The third element is the scissor rect active at draw time.
     pub(crate) external_images: Vec<(ExternalTextureId, TextureInstance, ScissorRect)>,
+
+    /// The replay phase of the most recent primitive recorded into this
+    /// segment, or `None` while it is still geometry-empty.
+    ///
+    /// Read only by [`Self::would_reorder`]. Not part of the replayed IR —
+    /// `flush_segment` never looks at it — so it does not affect the
+    /// deterministic-replay snapshot's meaning, only its `Debug` output.
+    pub(crate) last_phase: Option<Phase>,
+}
+
+/// Where a primitive lands in `flush_segment`'s replay order.
+///
+/// `flush_segment` drains a `DrawSegment` in a FIXED sequence — instanced
+/// (shadows, then rects, then circles, then arcs), gradients, tessellated
+/// geometry, cached images, external images — so a segment's contents replay
+/// in *kind* order, not in the order they were recorded. The discriminants
+/// below ARE that sequence, which is what lets [`DrawSegment::would_reorder`]
+/// detect a recording that the fixed order would invert.
+///
+/// Keep these in lockstep with `replay/flush.rs::flush_segment` and its
+/// instanced sub-order; the variants are ordered, not arbitrary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Phase {
+    /// `shadow_batch` — drawn first inside the instanced pass.
+    Shadow,
+    /// `rect_batch`.
+    Rect,
+    /// `circle_batch`.
+    Circle,
+    /// `arc_batch` — last inside the instanced pass.
+    Arc,
+    /// The three gradient batches, which share one pass.
+    ///
+    /// Deliberately never constructed: gradients are excluded from the
+    /// draw-order seal because every segment's stop table is uploaded to one
+    /// shared buffer at offset 0, so two gradient-bearing segments in a frame
+    /// would both sample the last one written. The variant stays so this enum
+    /// remains a faithful mirror of `flush_segment`'s replay order, and so the
+    /// ordinals either side of it are the real ones. See
+    /// `DrawBatcher::gradient_rect`.
+    #[expect(
+        dead_code,
+        reason = "ordinal placeholder; constructing it requires per-segment gradient stop tables first"
+    )]
+    Gradient,
+    /// `vertices`/`indices`/`tess_batches`.
+    Tess,
+    /// `cached_images`.
+    CachedImage,
+    /// `external_images` — drawn last.
+    ExternalImage,
 }
 
 impl DrawSegment {
@@ -558,7 +609,24 @@ impl DrawSegment {
             external_images: Vec::new(),
             text_start: 0,
             text_end: 0,
+            last_phase: None,
         }
+    }
+
+    /// Whether recording `next` now would replay BEFORE something already in
+    /// this segment.
+    ///
+    /// `flush_segment` drains by kind, so a segment holding a circle that then
+    /// receives a rect would draw the rect first and let the circle — recorded
+    /// EARLIER — paint over it. Sealing on this predicate makes the fixed
+    /// phase order equal record order within every segment, which is the whole
+    /// mechanism: no new IR, no ordered op list, just a boundary in the right
+    /// place.
+    ///
+    /// Returns `false` for a forward transition (rect then circle), so
+    /// correctly-ordered content is never split and pays nothing.
+    pub(crate) fn would_reorder(&self, next: Phase) -> bool {
+        self.last_phase.is_some_and(|prev| next < prev)
     }
 
     /// Record an instance addition for a given scissor region tracker.
@@ -635,6 +703,7 @@ impl Default for DrawSegment {
             external_images: Vec::new(),
             text_start: 0,
             text_end: 0,
+            last_phase: None,
         }
     }
 }

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -534,9 +534,9 @@ pub(crate) struct DrawSegment {
     /// The replay phase of the most recent primitive recorded into this
     /// segment, or `None` while it is still geometry-empty.
     ///
-    /// Read only by [`Self::would_reorder`]. Not part of the replayed IR —
-    /// `flush_segment` never looks at it — so it does not affect the
-    /// deterministic-replay snapshot's meaning, only its `Debug` output.
+    /// Record-time only: `flush_segment` never reads it, so it changes no
+    /// replayed output. It IS carried by `Clone` and therefore visible to
+    /// anything that inspects a whole `DrawSegment` (test helpers, `Debug`).
     pub(crate) last_phase: Option<Phase>,
 }
 

--- a/crates/flui-engine/src/wgpu/painter/draw.rs
+++ b/crates/flui-engine/src/wgpu/painter/draw.rs
@@ -350,6 +350,7 @@ impl super::WgpuPainter {
         self.seal_text_tail();
         super::super::batches::DrawBatcher::texture(
             &mut self.current_segment,
+            &mut self.draw_order,
             &self.state,
             texture_id,
             dst_rect,
@@ -616,6 +617,7 @@ impl super::WgpuPainter {
         });
         super::super::batches::DrawBatcher::draw_texture(
             &mut self.current_segment,
+            &mut self.draw_order,
             &self.state,
             src_dimensions,
             texture_id,

--- a/crates/flui-engine/src/wgpu/painter/gradient.rs
+++ b/crates/flui-engine/src/wgpu/painter/gradient.rs
@@ -162,6 +162,7 @@ impl WgpuPainter {
     ) {
         DrawBatcher::shadow_rect(
             &mut self.current_segment,
+            &mut self.draw_order,
             rect_pos,
             rect_size,
             corner_radius,

--- a/crates/flui-engine/src/wgpu/shape_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/shape_blend_tests.rs
@@ -681,8 +681,18 @@ mod gpu_tests {
             0.0,
         );
 
-        // 2. A rect between them. Rect replays before Gradient, so this WOULD
-        //    seal if gradients participated in the kind seal.
+        // 2. A circle then a rect. Circle -> Rect is a genuine BACKWARD kind
+        //    transition, so `begin_phase` would seal here — and the segment it
+        //    would seal is the one holding the first gradient's stop table.
+        //    Gradients skipping `begin_phase` themselves does not prevent this;
+        //    only the explicit gradient guard in `begin_phase` does. A version
+        //    of this test with just a rect between the gradients never reaches
+        //    a backward transition and passes either way.
+        painter.circle(
+            flui_types::Point::new(Pixels(6.0), Pixels(52.0)),
+            4.0,
+            &Paint::fill(Color::rgba(0, 0, 0, 255)),
+        );
         painter.rect(
             Rect::from_xywh(Pixels(0.0), Pixels(40.0), Pixels(8.0), Pixels(8.0)),
             &Paint::fill(Color::rgba(0, 0, 0, 255)),

--- a/crates/flui-engine/src/wgpu/shape_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/shape_blend_tests.rs
@@ -534,6 +534,264 @@ mod gpu_tests {
         );
     }
 
+    // ── Painter's algorithm across primitive KINDS ──────────────────────────
+
+    /// Two overlapping SrcOver draws of DIFFERENT primitive kinds composite in
+    /// the order they were recorded.
+    ///
+    /// This is the canvas contract every retained renderer rests on: a command
+    /// recorded later paints over one recorded earlier. `DrawSegment` stores
+    /// primitives in parallel per-kind batches and `flush_segment` replays them
+    /// in a fixed phase order (shadows -> rects -> circles -> arcs -> gradients
+    /// -> tessellated -> images), so without an explicit seal the circle — a
+    /// LATER phase — composites over a rect recorded after it.
+    ///
+    /// Neither draw triggers any existing seal: `seal_text_tail` is a no-op
+    /// with no text recorded, and `Paint::fill` yields `BlendMode::SrcOver`, so
+    /// the non-SrcOver and advanced-blend seals do not fire either.
+    ///
+    /// If reverted (drop the backward-kind-transition seal): the centre pixel
+    /// reads red — the circle painting over a rect that was recorded after it.
+    #[test]
+    fn a_later_rect_paints_over_an_earlier_circle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        // Opaque white backdrop, so any read-back colour is unambiguous.
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            },
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // 1. A red circle covering the middle of the surface.
+        painter.circle(
+            flui_types::Point::new(
+                Pixels(SURFACE_WIDTH as f32 / 2.0),
+                Pixels(SURFACE_HEIGHT as f32 / 2.0),
+            ),
+            20.0,
+            &Paint::fill(Color::rgba(255, 0, 0, 255)),
+        );
+
+        // 2. An opaque blue rect recorded AFTER it, covering the same area.
+        painter.rect(
+            Rect::from_xywh(
+                Pixels(SURFACE_WIDTH as f32 / 4.0),
+                Pixels(SURFACE_HEIGHT as f32 / 4.0),
+                Pixels(SURFACE_WIDTH as f32 / 2.0),
+                Pixels(SURFACE_HEIGHT as f32 / 2.0),
+            ),
+            &Paint::fill(Color::rgba(0, 0, 255, 255)),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("kind-order encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let centre = pixels
+            [(SURFACE_HEIGHT as usize / 2) * SURFACE_WIDTH as usize + (SURFACE_WIDTH as usize / 2)];
+
+        assert!(
+            centre[2] > 200 && centre[0] < 50,
+            "the rect was recorded after the circle and must composite over it; \
+             got {centre:?} (R high means the circle won, i.e. draw order is \
+             decided by primitive kind rather than record order)"
+        );
+    }
+
+    /// Two gradients with a rect between them both render their own colours.
+    ///
+    /// This pins the reason gradients are EXCLUDED from the draw-order kind
+    /// seal. Every segment's stop table is uploaded to the same
+    /// `gradient_stops_buffer` at offset 0
+    /// (`PipelineSet::refresh_gradient_bind_group`), and all passes are
+    /// recorded into one `CommandEncoder` before submission — so the last
+    /// `write_buffer` wins and every gradient pass in the frame samples that
+    /// one table. Two gradient-bearing segments therefore cannot both be
+    /// correct today.
+    ///
+    /// Sealing on `Phase::Gradient` would create exactly that situation
+    /// routinely, so `DrawBatcher::gradient_rect` and its siblings do not call
+    /// `begin_phase`. This test is the guard: add gradients to the seal without
+    /// first giving each segment its own slice of the stop buffer (a dynamic
+    /// offset, or one buffer per segment) and the first gradient here reads the
+    /// second's colour.
+    ///
+    /// It is also the acceptance test for that follow-up: once per-segment stop
+    /// tables land, gradients can join the seal and this stays green.
+    #[test]
+    fn two_gradients_separated_by_a_rect_keep_their_own_colours() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            },
+        );
+
+        let solid = |rgba: [f32; 4]| {
+            [
+                crate::wgpu::effects::GradientStop {
+                    color: rgba,
+                    position: 0.0,
+                    padding: [0.0; 3],
+                },
+                crate::wgpu::effects::GradientStop {
+                    color: rgba,
+                    position: 1.0,
+                    padding: [0.0; 3],
+                },
+            ]
+        };
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // 1. A green gradient in the top-left quadrant — fills the first
+        //    segment's stop table so the second gradient's offset is non-zero.
+        let top_left = Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(24.0), Pixels(24.0));
+        painter.gradient_rect(
+            top_left,
+            glam::Vec2::new(0.0, 0.0),
+            glam::Vec2::new(24.0, 0.0),
+            &solid([0.0, 1.0, 0.0, 1.0]),
+            0.0,
+        );
+
+        // 2. A rect between them. Rect replays before Gradient, so this WOULD
+        //    seal if gradients participated in the kind seal.
+        painter.rect(
+            Rect::from_xywh(Pixels(0.0), Pixels(40.0), Pixels(8.0), Pixels(8.0)),
+            &Paint::fill(Color::rgba(0, 0, 0, 255)),
+        );
+
+        // 3. A blue gradient recorded into the post-seal segment.
+        let bottom_right = Rect::from_xywh(Pixels(36.0), Pixels(36.0), Pixels(24.0), Pixels(24.0));
+        painter.gradient_rect(
+            bottom_right,
+            glam::Vec2::new(0.0, 0.0),
+            glam::Vec2::new(24.0, 0.0),
+            &solid([0.0, 0.0, 1.0, 1.0]),
+            0.0,
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("gradient stop-table encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let sample = |x: usize, y: usize| pixels[y * SURFACE_WIDTH as usize + x];
+
+        let first = sample(12, 12);
+        assert!(
+            first[1] > 200 && first[2] < 60,
+            "the first gradient must render green; got {first:?} — reading the \
+             SECOND gradient's colour here means the two ended up in different \
+             segments, which the shared stop buffer cannot represent"
+        );
+
+        let second = sample(48, 48);
+        assert!(
+            second[2] > 200 && second[1] < 60,
+            "the second gradient must render blue; got {second:?}"
+        );
+    }
+
+    /// The reverse direction, so the fix cannot be a blanket "always seal
+    /// between kinds" that happens to satisfy the case above.
+    ///
+    /// Circle replays in a LATER phase than rect, so a circle recorded after a
+    /// rect is already correct today and must stay correct — and must NOT pay
+    /// for a segment split, since nothing is out of order.
+    #[test]
+    fn a_later_circle_paints_over_an_earlier_rect() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            },
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        painter.rect(
+            Rect::from_xywh(
+                Pixels(SURFACE_WIDTH as f32 / 4.0),
+                Pixels(SURFACE_HEIGHT as f32 / 4.0),
+                Pixels(SURFACE_WIDTH as f32 / 2.0),
+                Pixels(SURFACE_HEIGHT as f32 / 2.0),
+            ),
+            &Paint::fill(Color::rgba(0, 0, 255, 255)),
+        );
+        painter.circle(
+            flui_types::Point::new(
+                Pixels(SURFACE_WIDTH as f32 / 2.0),
+                Pixels(SURFACE_HEIGHT as f32 / 2.0),
+            ),
+            20.0,
+            &Paint::fill(Color::rgba(255, 0, 0, 255)),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("kind-order encoder (forward)"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let centre = pixels
+            [(SURFACE_HEIGHT as usize / 2) * SURFACE_WIDTH as usize + (SURFACE_WIDTH as usize / 2)];
+
+        assert!(
+            centre[0] > 200 && centre[2] < 50,
+            "the circle was recorded after the rect and must composite over it; \
+             got {centre:?}"
+        );
+    }
+
     // ── S8: Scissor-respecting foreground — advanced shape inside clip_rect ──────
 
     /// S8: A `clip_rect` scissor applied to an advanced shape correctly confines


### PR DESCRIPTION
## Summary

`flush_segment` replays a `DrawSegment` in a fixed phase order — instanced (shadows, rects, circles, arcs), gradients, tessellated, cached images, external images — under the comment `// R1: five-phase order is load-bearing`. Because primitives are stored in parallel per-kind batches with **no sequence index**, that order is applied to the *kinds*, not to the order commands were recorded.

`draw_circle(red); draw_rect(blue)` overlapping rendered **red on top**. A photo + scrim + badge rendered the scrim underneath the photo.

Rather than build an ordered op-list IR, this reuses the mechanism already in the tree. `DrawBatcher::finish_current_segment` is how this exact bug class was fixed twice before — `seal_text_tail` for geometry-after-text, and the non-SrcOver contract in `add_tessellated_with_key`. Both work by making the fixed phase order *true* within each segment. So: add a per-kind ordinal (`Phase`, whose discriminants **are** that replay order) and seal when an incoming draw would replay before something already recorded.

**A forward transition never seals.** Each phase opens at most one render pass, so a correctly ordered sequence costs exactly what it did before — it stays in one segment and one pass. Only genuinely interleaved content splits, and that is precisely the content whose output was wrong.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — the canvas contract: a command recorded later paints over one recorded earlier
- [x] New or changed behavior has tests that would fail without this change
- [x] Public API changes are documented — all new items are `pub(crate)`/`pub(super)`

- `a_later_rect_paints_over_an_earlier_circle` — GPU readback. Red before this change: `[255, 0, 0, 255]` at the centre.
- `a_later_circle_paints_over_an_earlier_rect` — the forward-direction control, so the fix cannot be a blanket "always seal".
- `tessellated_batches_index_within_their_own_segment` — IR-level; reverted it prints `tess_batches[0] spans 6..12 but its segment holds only 6 indices`.
- `two_gradients_separated_by_a_rect_keep_their_own_colours` — guards the gradient exclusion below.

9624 workspace tests; 557 flui-engine tests including every GPU readback oracle.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

**Gradients are deliberately EXCLUDED from the seal**, and this is the main thing to review.

Every segment's stop table is uploaded to the same `gradient_stops_buffer` at offset 0 (`PipelineSet::refresh_gradient_bind_group`), and since all passes are recorded into one `CommandEncoder` before submission, the last `write_buffer` wins. **Two gradient-bearing segments in a frame cannot both be correct today.** Sealing on `Phase::Gradient` would turn a rare latent bug into a routine one, so gradients keep exactly today's ordering — wrong relative to earlier primitives, but not *newly* wrong. Lifting this needs per-segment stop tables (a dynamic offset, or one buffer per segment); the gradient test above is the acceptance test for that follow-up. `Phase::Gradient` stays in the enum, `#[expect(dead_code)]`, so the ordinals either side of it remain the real ones.

**Hazard class found while wiring this**: a seal placed *after* an offset is read strands that offset in the sealed segment. It applies to `add_tessellated_with_key`'s `base_index`/`index_start` and to gradient `stop_offset`. The seal now precedes both reads.

Worth knowing for future reviews: **three successive GPU readback tests for that offset bug were all vacuous** — they passed with the fix reverted. stroke→fill→stroke seals on the *fill*, not the second stroke; image→stroke seals with empty buffers so `base_index == 0` either way. The invariant is about IR offsets, so the honest oracle is the IR-level unit test. The vacuous GPU version was deleted rather than kept.

Deferred: the full ordered-op IR remains the right end state as a **pass-count** change, landing behind the readback tests this PR adds. Its cost here would be more segments for alternating content (`circle, rect, circle, rect` → 3 segments where an ordered walk makes 1).

Found by a code-first runtime audit; one of six crate-disjoint P0 fixes that merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo