### PR TITLE
fix(engine): glyph runs carry their clip and their transform scale

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -2998,6 +2998,145 @@ mod gpu_tests {
         );
     }
 
+    /// Text obeys an active clip.
+    ///
+    /// Every glyph run in a frame is handed to glyphon with the SAME
+    /// `TextBounds`, built from the whole viewport, and the text pass sets no
+    /// scissor — so no clip of any kind reaches text. A `ListView`'s rows paint
+    /// straight through the app bar above them, and a `ClipRRect` avatar spills
+    /// its label past the rounded corner.
+    ///
+    /// Driven through `WgpuPainter`, deliberately: the clip is discarded at the
+    /// RECORD seam, so a test that calls `TextRenderer::add_text` directly with
+    /// a hand-built bound would pass with the production read reverted.
+    ///
+    /// If reverted (`build_text_areas` back to a shared whole-viewport bound):
+    /// glyph pixels appear below the clip and this fails.
+    #[test]
+    fn text_is_clipped_by_the_active_clip_rect() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        const CLIP_BOTTOM: f32 = 24.0;
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.clip_rect(flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(CLIP_BOTTOM),
+        ));
+        // Positioned so the run straddles the clip edge: some of it is legally
+        // inside, the rest must be cut.
+        painter.text(
+            "Spill",
+            flui_types::Point::new(Pixels(4.0), Pixels(12.0)),
+            28.0,
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Text Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let inked = |p: &[u8; 4]| p[3] > 16;
+
+        let above: usize = (0..CLIP_BOTTOM as usize)
+            .flat_map(|y| (0..w).map(move |x| (x, y)))
+            .filter(|&(x, y)| inked(&pixels[y * w + x]))
+            .count();
+        assert!(
+            above > 0,
+            "precondition: the run must actually paint inside the clip"
+        );
+
+        let below: usize = ((CLIP_BOTTOM as usize)..SURFACE_HEIGHT as usize)
+            .flat_map(|y| (0..w).map(move |x| (x, y)))
+            .filter(|&(x, y)| inked(&pixels[y * w + x]))
+            .count();
+        assert_eq!(
+            below, 0,
+            "text must not paint outside the active clip; {below} glyph pixels \
+             below y={CLIP_BOTTOM} — the clip never reached the glyph run"
+        );
+    }
+
+    /// Glyphs scale with the transform, like every other primitive.
+    ///
+    /// The framework paints in logical pixels and puts the device-pixel ratio on
+    /// the root transform, so a 2x display multiplies every extent by two. Glyph
+    /// runs escape that: only the run's ORIGIN crosses the CTM, while the raster
+    /// is emitted at `scale: 1.0`. A 16px label then occupies 16 physical pixels
+    /// in a box that reserved 32 — the most visible defect on HiDPI hardware.
+    ///
+    /// Ink coverage is the oracle rather than a sampled pixel: doubling the
+    /// linear scale must roughly quadruple the painted area, which no amount of
+    /// repositioning can fake.
+    ///
+    /// If reverted (`TextArea::scale` back to a hard `1.0`): both renders ink
+    /// the same number of pixels and the ratio collapses to ~1.
+    #[test]
+    fn glyphs_scale_with_the_current_transform() {
+        fn ink_at_scale(scale: f32) -> usize {
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface_texture, surface_view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &surface_view);
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.save();
+            painter.scale(scale, scale);
+            painter.text(
+                "Ab",
+                flui_types::Point::new(Pixels(4.0), Pixels(10.0)),
+                16.0,
+                &Paint::fill(Color::rgb(0, 0, 255)),
+            );
+            painter.restore();
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Text Scale Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+
+            readback_pixels(&device, &queue, &surface_texture)
+                .iter()
+                .filter(|p| p[3] > 16)
+                .count()
+        }
+
+        let one = ink_at_scale(1.0);
+        let two = ink_at_scale(2.0);
+        assert!(one > 0, "precondition: the label paints at scale 1");
+
+        // Exactly 4x is not expected — antialiasing and hinting shift coverage —
+        // but 2.5x is far outside what those can explain, and a scale-blind
+        // raster lands at ~1.0x.
+        let ratio = two as f32 / one as f32;
+        assert!(
+            ratio > 2.5,
+            "doubling the transform scale must roughly quadruple glyph ink; got \
+             {two}/{one} = {ratio:.2}x — the raster ignored the transform"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3003,8 +3003,13 @@ mod gpu_tests {
     /// Every glyph run in a frame is handed to glyphon with the SAME
     /// `TextBounds`, built from the whole viewport, and the text pass sets no
     /// scissor — so no clip of any kind reaches text. A `ListView`'s rows paint
-    /// straight through the app bar above them, and a `ClipRRect` avatar spills
-    /// its label past the rounded corner.
+    /// straight through the app bar above them.
+    ///
+    /// Scope: this is the RECTANGULAR clip. A `ClipRRect` still leaks its
+    /// label past the rounded corner, because `current_scissor()` carries only
+    /// the rounded rect's bounding box — the per-corner SDF lives in a separate
+    /// slot that no glyph pipeline reads. Text should join the shared clip
+    /// uniform when that lands rather than grow a second clip model.
     ///
     /// Driven through `WgpuPainter`, deliberately: the clip is discarded at the
     /// RECORD seam, so a test that calls `TextRenderer::add_text` directly with
@@ -3134,6 +3139,74 @@ mod gpu_tests {
             ratio > 2.5,
             "doubling the transform scale must roughly quadruple glyph ink; got \
              {two}/{one} = {ratio:.2}x — the raster ignored the transform"
+        );
+    }
+
+    /// KNOWN LIMIT, pinned: a non-uniform transform stretches glyphs uniformly.
+    ///
+    /// `TextPlacement::scale` is one `f32` because `glyphon::TextArea::scale`
+    /// is one `f32`; glyphon 0.11 cannot express a different scale per axis. So
+    /// under `scale(2.0, 1.0)` the larger axis wins and a run is stretched both
+    /// ways, while the geometry around it stretches one way.
+    ///
+    /// This is not a regression — before, glyphs ignored the transform entirely
+    /// and were wrong on both axes — and it does not affect the case the scale
+    /// exists for, the device-pixel ratio, which is uniform by construction.
+    ///
+    /// It is pinned rather than left implicit so that carrying a real transform
+    /// for text (a per-area matrix, or routing such runs through the
+    /// tessellated path) is a deliberate change: this test will fail, and
+    /// whoever makes it should read the note on `TextPlacement::scale` and
+    /// replace the assertion with the correct anisotropic one.
+    #[test]
+    fn anisotropic_scale_stretches_glyphs_uniformly() {
+        fn ink(sx: f32, sy: f32) -> usize {
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface_texture, surface_view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &surface_view);
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.save();
+            painter.scale(sx, sy);
+            painter.text(
+                "Ab",
+                flui_types::Point::new(Pixels(4.0), Pixels(10.0)),
+                16.0,
+                &Paint::fill(Color::rgb(0, 0, 255)),
+            );
+            painter.restore();
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Anisotropic Text Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+
+            readback_pixels(&device, &queue, &surface_texture)
+                .iter()
+                .filter(|p| p[3] > 16)
+                .count()
+        }
+
+        let uniform_2x = ink(2.0, 2.0);
+        let wide_only = ink(2.0, 1.0);
+        assert!(uniform_2x > 0, "precondition: the label paints");
+
+        // Correct anisotropic behaviour would put `wide_only` near HALF of
+        // `uniform_2x` (twice the width, unchanged height). It sits near
+        // parity instead, because `max_scale()` reports 2.0 for both.
+        let ratio = wide_only as f32 / uniform_2x as f32;
+        assert!(
+            ratio > 0.75,
+            "known limit: scale(2,1) is expected to stretch glyphs like scale(2,2) \
+             until text can carry a real transform; got {wide_only}/{uniform_2x} = \
+             {ratio:.2} — if this now reports ~0.5, anisotropic scaling started \
+             working and this test should be replaced, not relaxed"
         );
     }
 

--- a/crates/flui-engine/src/wgpu/painter/draw.rs
+++ b/crates/flui-engine/src/wgpu/painter/draw.rs
@@ -261,10 +261,31 @@ impl super::WgpuPainter {
             "WgpuPainter::text"
         );
         let transformed_position = self.state.apply_transform(position);
+        let placement = self.text_placement();
         let entry_index = self.text_renderer.text_count();
-        self.text_renderer
-            .add_text(text, transformed_position, font_size, paint.color);
+        self.text_renderer.add_text(
+            text,
+            transformed_position,
+            font_size,
+            paint.color,
+            placement,
+        );
         self.claim_text_entry(entry_index);
+    }
+
+    /// Capture the painter state a glyph run needs at raster time.
+    ///
+    /// Only the run's ORIGIN crosses the CTM (`apply_transform` above); the
+    /// scale and the active clip have to be carried explicitly, because glyphon
+    /// rasterises from a `TextArea` rather than from the painter's state. Read
+    /// here, at the record seam, so the values are the ones in force when the
+    /// run was issued — reading them at flush time would give whatever the last
+    /// draw of the frame left behind.
+    fn text_placement(&self) -> super::super::text::TextPlacement {
+        super::super::text::TextPlacement {
+            scale: self.state.max_scale(),
+            clip: self.state.current_scissor(),
+        }
     }
 
     /// Stamp a freshly-recorded text batch entry onto the CURRENT segment's
@@ -322,6 +343,7 @@ impl super::WgpuPainter {
             "WgpuPainter::rich_text"
         );
         let transformed_position = self.state.apply_transform(position);
+        let placement = self.text_placement();
         let entry_index = self.text_renderer.text_count();
         self.text_renderer.add_rich_text(
             runs,
@@ -329,6 +351,7 @@ impl super::WgpuPainter {
             base_font_size,
             base_color,
             wrap_width,
+            placement,
         );
         self.claim_text_entry(entry_index);
     }

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -316,21 +316,65 @@ struct CachedBuffer {
     last_used_frame: u64,
 }
 
+/// The GPU draw state a glyph run has to carry from record time to its raster.
+///
+/// A glyph run is recorded with only its transformed ORIGIN; everything else
+/// about the painter's state used to be dropped. These two travel together
+/// because they are the same fact — "what was true when this run was recorded"
+/// — and because each was independently missing:
+///
+/// * `scale` — the framework paints in logical pixels and puts the device-pixel
+///   ratio on the root transform, so every other primitive is scaled by the CTM.
+///   Rasterising glyphs at a fixed 1.0 made a 16px label occupy 16 physical
+///   pixels in a box that reserved 32 on a 2x display.
+/// * `clip` — every run was handed the whole viewport as its bound, so no clip
+///   of any kind reached text: scrolled rows painted through the app bar above
+///   them.
+#[derive(Debug, Clone, Copy)]
+pub struct TextPlacement {
+    /// Uniform scale taken from the CTM at record time.
+    ///
+    /// Applied as `TextArea::scale`, which glyphon scales the shaped buffer by
+    /// about `(left, top)` — and `(left, top)` is already the transformed
+    /// origin, so the run grows from where it was placed.
+    pub scale: f32,
+    /// The scissor active at record time, `(x, y, w, h)` in device pixels, or
+    /// `None` for "unclipped".
+    pub clip: Option<(u32, u32, u32, u32)>,
+}
+
+impl Default for TextPlacement {
+    /// Unscaled and unclipped — the identity, not the all-zero value.
+    ///
+    /// `scale: 1.0` rather than `f32::default()`, for the same reason an
+    /// identity matrix is not the zero matrix: a run recorded with no painter
+    /// state should rasterise at its nominal size, and a zero scale would make
+    /// it vanish.
+    fn default() -> Self {
+        Self {
+            scale: 1.0,
+            clip: None,
+        }
+    }
+}
+
 /// Discriminated batch entry: either a plain-text buffer or a rich-text buffer.
 ///
-/// Both variants carry the screen position and the glyphon default color (used
+/// Both variants carry the screen position, the glyphon default color (used
 /// as `TextArea::default_color`; per-run colors come from `Attrs::color` on the
-/// rich path).
+/// rich path), and the [`TextPlacement`] captured when the run was recorded.
 enum BatchEntry {
     Plain {
         key: TextCacheKey,
         position: Point<Pixels>,
         color: GlyphonColor,
+        placement: TextPlacement,
     },
     Rich {
         key: RichTextCacheKey,
         position: Point<Pixels>,
         default_color: GlyphonColor,
+        placement: TextPlacement,
     },
 }
 
@@ -580,7 +624,14 @@ impl TextRenderer {
     ///
     /// Buffers are cached by `(text, font_size)` to avoid re-layout when the
     /// same string appears in subsequent frames.
-    pub fn add_text(&mut self, text: &str, position: Point<Pixels>, font_size: f32, color: Color) {
+    pub fn add_text(
+        &mut self,
+        text: &str,
+        position: Point<Pixels>,
+        font_size: f32,
+        color: Color,
+        placement: TextPlacement,
+    ) {
         // `text_len`, never `text`. This string is every label, message body,
         // and text-field value the UI draws, and a tracing field is world-
         // readable in Apple's unified log and in logcat. The length and the
@@ -600,6 +651,7 @@ impl TextRenderer {
             key,
             position,
             color: glyphon_color,
+            placement,
         });
     }
 
@@ -625,6 +677,7 @@ impl TextRenderer {
         base_font_size: f32,
         base_color: Color,
         wrap_width: Option<f32>,
+        placement: TextPlacement,
     ) {
         if runs.is_empty() {
             return;
@@ -694,6 +747,7 @@ impl TextRenderer {
             key,
             position,
             default_color,
+            placement,
         });
     }
 
@@ -914,7 +968,7 @@ fn build_text_areas<'cache>(
     batch: &[BatchEntry],
     plain_cache: &'cache HashMap<TextCacheKey, CachedBuffer>,
     rich_cache: &'cache HashMap<RichTextCacheKey, CachedBuffer>,
-    bounds: TextBounds,
+    viewport: TextBounds,
 ) -> Vec<TextArea<'cache>> {
     batch
         .iter()
@@ -923,12 +977,13 @@ fn build_text_areas<'cache>(
                 key,
                 position,
                 color,
+                placement,
             } => plain_cache.get(key).map(|c| TextArea {
                 buffer: &c.buffer,
                 left: position.x.0,
                 top: position.y.0,
-                scale: 1.0,
-                bounds,
+                scale: placement.scale,
+                bounds: clip_bounds(placement.clip, viewport),
                 default_color: *color,
                 custom_glyphs: &[],
             }),
@@ -936,17 +991,45 @@ fn build_text_areas<'cache>(
                 key,
                 position,
                 default_color,
+                placement,
             } => rich_cache.get(key).map(|c| TextArea {
                 buffer: &c.buffer,
                 left: position.x.0,
                 top: position.y.0,
-                scale: 1.0,
-                bounds,
+                scale: placement.scale,
+                bounds: clip_bounds(placement.clip, viewport),
                 default_color: *default_color,
                 custom_glyphs: &[],
             }),
         })
         .collect()
+}
+
+/// The `TextBounds` a run recorded under `clip` must rasterise within.
+///
+/// `None` means the run was unclipped, so the viewport is the only limit.
+/// Otherwise the scissor is intersected with the viewport — a scissor may sit
+/// partly outside the attachment, and glyphon offers no clamping of its own.
+///
+/// An empty intersection is returned as an empty rect rather than skipped, so a
+/// fully-clipped run still occupies its slot in the batch: replay addresses
+/// glyph ranges by index (`DrawSegment::text_start..text_end`), and dropping an
+/// entry here would shift every later run into the wrong segment.
+#[allow(clippy::cast_possible_wrap)]
+fn clip_bounds(clip: Option<(u32, u32, u32, u32)>, viewport: TextBounds) -> TextBounds {
+    let Some((x, y, w, h)) = clip else {
+        return viewport;
+    };
+    let left = (x as i32).max(viewport.left);
+    let top = (y as i32).max(viewport.top);
+    let right = (x.saturating_add(w) as i32).min(viewport.right);
+    let bottom = (y.saturating_add(h) as i32).min(viewport.bottom);
+    TextBounds {
+        left,
+        top,
+        right: right.max(left),
+        bottom: bottom.max(top),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1313,7 +1396,7 @@ mod gpu_tests {
     use flui_painting::PaintingBinding;
     use flui_types::{geometry::Pixels, geometry::Point, styling::Color};
 
-    use super::TextRenderer;
+    use super::{TextPlacement, TextRenderer};
 
     const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
     const W: u32 = 128;
@@ -1482,13 +1565,20 @@ mod gpu_tests {
                 Point::new(Pixels(2.0), Pixels(2.0)),
                 10.0 + (frame % 8) as f32,
                 white,
+                TextPlacement::default(),
             );
             render_one(&mut tr, &device, &queue, &view);
             tr.atlas_trim();
         }
 
         // Final known frame: opaque white text on a transparent target.
-        tr.add_text("FLUI", Point::new(Pixels(4.0), Pixels(8.0)), 16.0, white);
+        tr.add_text(
+            "FLUI",
+            Point::new(Pixels(4.0), Pixels(8.0)),
+            16.0,
+            white,
+            TextPlacement::default(),
+        );
         render_one(&mut tr, &device, &queue, &view);
         tr.atlas_trim();
 

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -334,9 +334,28 @@ struct CachedBuffer {
 pub struct TextPlacement {
     /// Uniform scale taken from the CTM at record time.
     ///
-    /// Applied as `TextArea::scale`, which glyphon scales the shaped buffer by
-    /// about `(left, top)` — and `(left, top)` is already the transformed
-    /// origin, so the run grows from where it was placed.
+    /// Applied as `TextArea::scale`, which glyphon threads into
+    /// `glyph.physical(offset, scale)` — so the glyph is rasterised at
+    /// `font_size * scale` and cached under it, rather than upscaled from a 1x
+    /// atlas. `(left, top)` is already the transformed origin, so the run grows
+    /// from where it was placed.
+    ///
+    /// # Known limit: anisotropic transforms
+    ///
+    /// This is ONE number because `glyphon::TextArea::scale` is one `f32`;
+    /// glyphon 0.11 has no way to express a different scale per axis. Under a
+    /// non-uniform CTM such as `scale(2.0, 1.0)` the larger axis wins, so a
+    /// glyph run is stretched on both axes while the geometry around it
+    /// stretches on one. Neither this nor the previous behaviour (a hard `1.0`,
+    /// ignoring the transform entirely) is correct there; this one is at least
+    /// right on one axis, and exactly right for the case that motivated it —
+    /// the device-pixel ratio, which is always uniform.
+    ///
+    /// Fixing it properly means giving text a transform glyphon cannot carry:
+    /// either a per-area matrix, or routing rotated/skewed/anisotropic runs
+    /// through the tessellated path. `anisotropic_scale_stretches_glyphs_
+    /// uniformly` pins the current behaviour so the day that lands is a
+    /// deliberate change rather than a silent one.
     pub scale: f32,
     /// The scissor active at record time, `(x, y, w, h)` in device pixels, or
     /// `None` for "unclipped".
@@ -395,7 +414,16 @@ enum BatchEntry {
 /// let mut text_renderer = TextRenderer::new(&device, &queue, surface_format, font_system);
 ///
 /// // Add plain text during frame
-/// text_renderer.add_text("Hello, World!", Point::new(10.0, 10.0), 16.0, Color::BLACK);
+/// // `TextPlacement` carries the CTM scale and the active clip; a caller with
+/// // no painter state uses the identity. `WgpuPainter::text` reads the real
+/// // values from its own state stack at record time.
+/// text_renderer.add_text(
+///     "Hello, World!",
+///     Point::new(10.0, 10.0),
+///     16.0,
+///     Color::BLACK,
+///     TextPlacement::default(),
+/// );
 ///
 /// // Render a batch range at its draw-order position, then finish the pass
 /// text_renderer.render_range(&device, &queue, &view, &mut encoder, (800, 600), 0..usize::MAX)?;


### PR DESCRIPTION
## Summary

Step 2 of the audit remediation. The draw-order work (#719, #737, #743) gave text a z-position; this gives it the rest of the painter state it was recorded without.

Text was recorded with only its transformed **origin**. Two things were dropped:

**Clips never reached text.** `build_text_areas` handed every `TextArea` in the frame one shared `TextBounds` built from the whole viewport, and the text pass sets no scissor — so no `ClipRect`, `ClipRRect`, viewport clip or damage rect had any effect on a glyph. A `ListView`'s rows painted straight through the app bar above them.

**Glyphs ignored the transform.** The framework paints in logical pixels and puts the device-pixel ratio on the root transform, so every other primitive is scaled by the CTM; glyphs were emitted at a hard `scale: 1.0`. On a 2× display a 16px label occupied 16 physical pixels inside a box that reserved 32.

Both are now captured together in a `TextPlacement` at the record seam and consumed in `build_text_areas`. One struct rather than two loose parameters — they are the same fact ("what was true when this run was recorded"), and `add_rich_text` would otherwise reach clippy's argument limit.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — layout in logical pixels, raster at physical size is the same split Flutter makes for `devicePixelRatio`
- [x] New or changed behavior has tests that would fail without this change
- [x] Public API changes are documented — `TextPlacement` and its `Default` are documented; `TextRenderer::add_text`/`add_rich_text` gain one argument

Both tests are driven through `WgpuPainter`, **not** `TextRenderer::add_text` — deliberately, because the defect is at the record seam and a test that hand-builds a bound would pass with the production read reverted:

| Test | Red state before |
| --- | --- |
| `text_is_clipped_by_the_active_clip_rect` | 417 glyph pixels below the clip edge |
| `glyphs_scale_with_the_current_transform` | `124/124 = 1.00x` ink ratio between scale 1 and scale 2 |

Both re-verified non-vacuous by neutering `WgpuPainter::text_placement` to the identity — both fail.

9626 workspace tests, 560 flui-engine tests including every GPU readback oracle, clippy (workspace **and** `enable-wgpu-tests`), fmt, port-check, and `cargo doc --document-private-items` with `-D warnings`.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

**`TextArea::scale` is the right lever, not a compromise.** I checked whether it upscales a 1× atlas: it does not. glyphon threads it into `glyph.physical(offset, scale)`, which builds the swash cache key with `font_size * scale` (`cosmic-text-0.18.2/src/layout.rs`). Glyphs are rasterised at the target physical size and cached under it — crisp, and with no cache collision between scales.

**Unscaled, unclipped content is byte-identical.** `max_scale()` is `1.0` at identity and `current_scissor()` is `None`, which yields exactly the previous viewport bound.

**A fully-clipped run is emitted as an empty rect rather than skipped**, because replay addresses glyph ranges by index (`DrawSegment::text_start..text_end`); dropping an entry would shift every later run into the wrong segment.

Still open after this, and deliberately out of scope:

- **Rounded and path clips** do not apply to text — this wires the rect scissor only. Getting `ClipRRect` to round a glyph run needs the shared clip uniform from the clip step of the RFC, so text should join that change rather than grow a second clip model.
- **`maxLines`/ellipsis** still measures one thing and paints another: `TextPainter::paint` passes the original untruncated span and the engine re-shapes it. That needs transporting a shaped paragraph instead of the inputs, which also deletes the duplicate shaping pass — a larger change with its own review.
- The accessibility text scaler (`TextPainter::text_scale_factor`) remains unwired to any `MediaQuery`; it is a separate multiplier from the device scale and should stay so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo