### PR TITLE
fix(engine): a rounded clip actually rounds circles and ovals

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3210,6 +3210,88 @@ mod gpu_tests {
         );
     }
 
+    /// A rounded clip actually rounds a circle.
+    ///
+    /// `apply_active_clip` — the one place an SDF clip is attached to a draw —
+    /// is called only for SrcOver rect/rrect fills and for textures, and
+    /// `ClippableInstance` is implemented only by `RectInstance` and
+    /// `TextureInstance`. Circles and ovals therefore receive only the clip's
+    /// axis-aligned bounding scissor, so a `ClipRRect` around an avatar leaves
+    /// square corners.
+    ///
+    /// The geometry is chosen so the assertion cannot pass by accident: the
+    /// circle is far LARGER than the clip and covers every corner of the
+    /// surface, so a sampled corner pixel is inside the drawn shape and outside
+    /// the clip. (Drawing a disc that happens to coincide with the clip is the
+    /// trap here — the corner would then be outside the geometry itself, and
+    /// the test would pass with no clip support at all.)
+    ///
+    /// If reverted (drop the `apply_active_clip` call at the circle record
+    /// sites, or the clip block in `circle_instanced.wgsl`): the corner is
+    /// painted and this fails.
+    #[test]
+    fn a_rounded_clip_rounds_a_circle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        const R: f32 = 40.0;
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            flui_types::Rect::from_xywh(
+                Pixels(0.0),
+                Pixels(0.0),
+                Pixels(SURFACE_WIDTH as f32),
+                Pixels(SURFACE_HEIGHT as f32),
+            ),
+            Pixels(R),
+        ));
+        // Radius 90 about the centre of a 128x128 surface: every corner of the
+        // surface is well inside this circle.
+        painter.circle(
+            flui_types::Point::new(
+                Pixels(SURFACE_WIDTH as f32 / 2.0),
+                Pixels(SURFACE_HEIGHT as f32 / 2.0),
+            ),
+            90.0,
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Circle Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        // Centre: inside both the circle and the clip — must be painted, or the
+        // test would pass by drawing nothing at all.
+        let centre = at(w / 2, SURFACE_HEIGHT as usize / 2);
+        assert!(
+            centre[2] > 200,
+            "precondition: the circle must paint inside the clip; got {centre:?}"
+        );
+
+        // Corner: inside the circle, OUTSIDE the rounded clip.
+        let corner = at(3, 3);
+        assert!(
+            corner[3] < 32,
+            "a rounded clip must round the circle inside it; corner rgba={corner:?} \
+             — the circle received only the clip's bounding scissor"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -428,12 +428,13 @@ impl DrawBatcher {
                     let transformed_center = state.apply_transform(center);
                     let sx = (m.x_axis.x * m.x_axis.x + m.x_axis.y * m.x_axis.y).sqrt();
                     let sy = (m.y_axis.x * m.y_axis.x + m.y_axis.y * m.y_axis.y).sqrt();
-                    let instance = super::super::instancing::CircleInstance::new(
-                        transformed_center,
-                        radius,
-                        color,
-                        [sx, sy],
-                    );
+                    let instance =
+                        state.apply_active_clip(super::super::instancing::CircleInstance::new(
+                            transformed_center,
+                            radius,
+                            color,
+                            [sx, sy],
+                        ));
                     Self::begin_phase(segment, draw_order, Phase::Circle);
                     let _ = segment.circle_batch.add(instance);
                     DrawSegment::push_scissor_region(
@@ -458,10 +459,12 @@ impl DrawBatcher {
                     // center is already in local space (pre-transform coordinates).
                     let tx = m.x_axis.x * center.x.0 + m.y_axis.x * center.y.0 + m.w_axis.x;
                     let ty = m.x_axis.y * center.x.0 + m.y_axis.y * center.y.0 + m.w_axis.y;
-                    let instance = super::super::instancing::CircleInstance::with_affine_transform(
-                        linear_cols,
-                        color,
-                        [tx, ty],
+                    let instance = state.apply_active_clip(
+                        super::super::instancing::CircleInstance::with_affine_transform(
+                            linear_cols,
+                            color,
+                            [tx, ty],
+                        ),
                     );
                     Self::begin_phase(segment, draw_order, Phase::Circle);
                     let _ = segment.circle_batch.add(instance);
@@ -591,10 +594,12 @@ impl DrawBatcher {
             let tx = m.x_axis.x * cx + m.y_axis.x * cy + m.w_axis.x;
             let ty = m.x_axis.y * cx + m.y_axis.y * cy + m.w_axis.y;
 
-            let instance = super::super::instancing::CircleInstance::with_affine_transform(
-                linear_cols,
-                color,
-                [tx, ty],
+            let instance = state.apply_active_clip(
+                super::super::instancing::CircleInstance::with_affine_transform(
+                    linear_cols,
+                    color,
+                    [tx, ty],
+                ),
             );
             Self::begin_phase(segment, draw_order, Phase::Circle);
             let _ = segment.circle_batch.add(instance);

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -351,6 +351,18 @@ pub struct CircleInstance {
     /// Affine path: device-space center = `M_w * center_local + t_w`.
     /// The `.zw` lanes are padding for 16-byte vec4 alignment.
     pub transform_translate: [f32; 4],
+    /// SDF clip rounded rectangle, in device space:
+    /// `[x, y, width, height, radius_tl, radius_tr, radius_br, radius_bl]`.
+    ///
+    /// All zeros means no clip. Identical slot and semantics to
+    /// [`RectInstance::clip_rrect`] — circles go through the same
+    /// [`ClippableInstance`] seam so the two cannot drift.
+    pub clip_rrect: [f32; 8],
+
+    /// Which SDF the fragment evaluates against `clip_rrect`:
+    /// `[0, _, _, _]` none, `[1, _, _, _]` rounded rect, `[2, _, _, _]`
+    /// rounded superellipse. Only `.x` is read; the rest is padding.
+    pub clip_kind: [u32; 4],
 }
 
 impl CircleInstance {
@@ -378,6 +390,9 @@ impl CircleInstance {
             // x-col = (sx, 0), y-col = (0, sy).
             transform: [scale_xy[0], 0.0, 0.0, scale_xy[1]],
             transform_translate: [center.x.0, center.y.0, 0.0, 0.0],
+            // No clip until `ClippableInstance::with_clip_*` attaches one.
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -409,6 +424,9 @@ impl CircleInstance {
             color: color.to_f32_array(),
             transform: linear_cols,
             transform_translate: [translation[0], translation[1], 0.0, 0.0],
+            // No clip until `ClippableInstance::with_clip_*` attaches one.
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -433,6 +451,12 @@ impl CircleInstance {
             4 => Float32x4,
             // Affine translation [tx, ty, 0, 0] (location 5)
             5 => Float32x4,
+            // SDF clip bounds [x, y, w, h] (location 6)
+            6 => Float32x4,
+            // SDF clip corner radii [tl, tr, br, bl] (location 7)
+            7 => Float32x4,
+            // Clip kind [kind, _, _, _] (location 8)
+            8 => Uint32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -759,6 +783,56 @@ impl ClippableInstance for RectInstance {
     }
 }
 
+impl ClippableInstance for CircleInstance {
+    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
+        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
+        // `RectInstance`/`TextureInstance` — the slot is assigned, never
+        // computed, so there is no ULP slop to tolerate.
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
+        )]
+        let is_empty = clip == [0.0; 8];
+        self.clip_rrect = clip;
+        self.clip_kind = if is_empty { [0; 4] } else { [1, 0, 0, 0] };
+        self
+    }
+
+    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+        )]
+        let is_empty = superellipse_clip == [0.0; 12];
+        if is_empty {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+            return self;
+        }
+        // Per-corner rx/ry averaged into one scalar, exactly as `RectInstance`
+        // does: the shared 8-float slot has room for one radius per corner, and
+        // `sdRoundedSuperellipse` takes one too. Elliptical corners therefore
+        // round to a circular approximation — a pre-existing divergence, kept
+        // identical here rather than given a second behaviour.
+        let tl = 0.5 * (superellipse_clip[4] + superellipse_clip[5]);
+        let tr = 0.5 * (superellipse_clip[6] + superellipse_clip[7]);
+        let br = 0.5 * (superellipse_clip[8] + superellipse_clip[9]);
+        let bl = 0.5 * (superellipse_clip[10] + superellipse_clip[11]);
+        self.clip_rrect = [
+            superellipse_clip[0],
+            superellipse_clip[1],
+            superellipse_clip[2],
+            superellipse_clip[3],
+            tl,
+            tr,
+            br,
+            bl,
+        ];
+        self.clip_kind = [2, 0, 0, 0];
+        self
+    }
+}
+
 impl ClippableInstance for TextureInstance {
     fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
         self.clip_rrect = clip;
@@ -1040,8 +1114,14 @@ mod tests {
         //   color:               [f32; 4]  = 16 bytes
         //   transform:           [f32; 4]  = 16 bytes  ← 2×2 linear affine
         //   transform_translate: [f32; 4]  = 16 bytes  ← appended for affine path
-        //   Total: 64 bytes
-        assert_eq!(std::mem::size_of::<CircleInstance>(), 64);
+        //   clip_rrect:          [f32; 8]  = 32 bytes  ← appended for the SDF clip
+        //   clip_kind:           [u32; 4]  = 16 bytes  ← appended for the SDF clip
+        //   Total: 112 bytes
+        //
+        // The clip pair is APPENDED, so every pre-existing field offset is
+        // byte-identical and the `vertex_attr_array!` offsets for locations
+        // 2–5 are unchanged; locations 6–8 are new at the end.
+        assert_eq!(std::mem::size_of::<CircleInstance>(), 112);
     }
 
     #[test]

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -170,6 +170,65 @@ impl GpuReplay {
     ///
     /// Cross-reference: `ssaa.rs` `GpuReplay::render_ssaa_path` lines 443-512
     /// for the analogous full-frame→tile remap at 2× scale.
+    /// Rebase and scale a device-space SDF clip slot into a grown offscreen's
+    /// local space.
+    ///
+    /// Every instance kind that carries `clip_rrect` needs exactly this, so it
+    /// lives in one function rather than once per batch loop: the rect loop had it
+    /// inline and the circle loop did not, which is precisely how a clip ends up
+    /// evaluated against the wrong coordinate space.
+    ///
+    /// Radii are dimension-like and scale proportionally. For a non-square
+    /// framebuffer crop (`scale_x != scale_y`) this slightly warps corner radii —
+    /// acceptable for a filter intermediate, since the composite restores the shape.
+    ///
+    /// A cleared slot (`clip_kind[0] == 0`) is left untouched: the all-zero sentinel
+    /// must stay bit-exact, and scaling zeros could introduce signed zeros.
+    /// Remap EVERY device-space SDF clip in `segment` into a grown offscreen's
+    /// local space.
+    ///
+    /// One call covering every clip-carrying batch, rather than a line inside each
+    /// batch's transform loop. That shape is deliberate: the rect loop carried this
+    /// inline and the circle loop did not, and a clip left in full-frame
+    /// coordinates is invisible until something is drawn inside a blur or filter
+    /// layer. A batch that gains a clip slot later is remapped by adding it here,
+    /// in the one place that already reads them all.
+    ///
+    /// Arcs are absent because `ArcInstance` carries no clip slot.
+    fn remap_segment_clips(
+        segment: &mut super::command_ir::DrawSegment,
+        origin: (f32, f32),
+        scale: (f32, f32),
+    ) {
+        for inst in &mut segment.rect_batch.instances {
+            Self::remap_clip_rrect(&mut inst.clip_rrect, inst.clip_kind, origin, scale);
+        }
+        for inst in &mut segment.circle_batch.instances {
+            Self::remap_clip_rrect(&mut inst.clip_rrect, inst.clip_kind, origin, scale);
+        }
+    }
+
+    fn remap_clip_rrect(
+        clip_rrect: &mut [f32; 8],
+        clip_kind: [u32; 4],
+        origin: (f32, f32),
+        scale: (f32, f32),
+    ) {
+        if clip_kind[0] == 0 {
+            return;
+        }
+        let (origin_x, origin_y) = origin;
+        let (scale_x, scale_y) = scale;
+        clip_rrect[0] = (clip_rrect[0] - origin_x) * scale_x;
+        clip_rrect[1] = (clip_rrect[1] - origin_y) * scale_y;
+        clip_rrect[2] *= scale_x;
+        clip_rrect[3] *= scale_y;
+        let avg_scale = (scale_x + scale_y) * 0.5;
+        for r in &mut clip_rrect[4..8] {
+            *r *= avg_scale;
+        }
+    }
+
     pub(in crate::wgpu) fn render_segment_to_grown_offscreen(
         &mut self,
         segment: &mut DrawSegment,
@@ -293,22 +352,6 @@ impl GpuReplay {
                 inst.transform[2] *= scale_x; // c: y-col.x  (cross-axis — scale_x)
                 inst.transform[3] *= scale_y; // d: y-col.y
             }
-
-            // Clip rrect (if active): [x, y, w, h, radii…].
-            // Radii are dimension-like; scale them proportionally. For non-square
-            // fb crops (scale_x ≠ scale_y) this slightly warps circle-corner radii —
-            // acceptable for a filter intermediate (the composite restores shape).
-            if inst.clip_kind[0] != 0 {
-                inst.clip_rrect[0] = (inst.clip_rrect[0] - origin_x) * scale_x;
-                inst.clip_rrect[1] = (inst.clip_rrect[1] - origin_y) * scale_y;
-                inst.clip_rrect[2] *= scale_x;
-                inst.clip_rrect[3] *= scale_y;
-                // Radii [4..8]: scale by average of scale_x and scale_y.
-                let avg_scale = (scale_x + scale_y) * 0.5;
-                for r in &mut inst.clip_rrect[4..8] {
-                    *r *= avg_scale;
-                }
-            }
         }
 
         // Circle and arc instances: center is in transform_translate; the linear
@@ -330,6 +373,15 @@ impl GpuReplay {
             inst.transform[2] *= scale_x;
             inst.transform[3] *= scale_y;
         }
+
+        // The SDF clip each instance carries is in DEVICE space, so it moves
+        // with them. One call covering every clip-carrying batch, rather than a
+        // line per transform loop above — see `remap_segment_clips`.
+        Self::remap_segment_clips(
+            &mut remapped_segment,
+            (origin_x, origin_y),
+            (scale_x, scale_y),
+        );
 
         // ── Scissor remap: full-frame → fb-local (non-negotiable #6) ─────────
         //
@@ -1249,4 +1301,73 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
         };
     }
     acc
+}
+
+#[cfg(test)]
+mod grown_offscreen_clip_tests {
+    use super::super::command_ir::DrawSegment;
+    use super::super::instancing::{CircleInstance, ClippableInstance, RectInstance};
+    use flui_types::{Color, Point, Rect, geometry::Pixels};
+
+    /// A device-space clip attached to a circle is remapped into a grown
+    /// offscreen exactly as the same clip on a rect is.
+    ///
+    /// `render_segment_to_grown_offscreen` rebases and scales instances into a
+    /// filter intermediate that is smaller than the viewport. `clip_rrect` is in
+    /// DEVICE space, so it has to move with them — otherwise the shader compares
+    /// a framebuffer-local `world_pos` against full-frame clip bounds, and the
+    /// rounded clip is displaced far enough to erase the filtered shape.
+    ///
+    /// The rect loop always did this inline; the circle loop did not, because
+    /// circles had no clip slot until they gained one. Asserting the two AGREE,
+    /// rather than asserting a literal, is what stops them drifting again.
+    ///
+    /// Reverted (drop the `remap_segment_clips` circle loop): the circle keeps
+    /// full-frame bounds and this fails on the final `assert_eq!`.
+    #[test]
+    fn a_circles_clip_is_remapped_like_a_rects() {
+        const ORIGIN: (f32, f32) = (40.0, 24.0);
+        const SCALE: (f32, f32) = (0.5, 0.25);
+        // [x, y, w, h, tl, tr, br, bl] in device space.
+        const CLIP: [f32; 8] = [60.0, 44.0, 200.0, 120.0, 8.0, 8.0, 8.0, 8.0];
+
+        let rect = RectInstance::rect(
+            Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(10.0), Pixels(10.0)),
+            Color::rgb(255, 0, 0),
+        )
+        .with_clip_rrect(CLIP);
+        let circle = CircleInstance::new(
+            Point::new(Pixels(5.0), Pixels(5.0)),
+            5.0,
+            Color::rgb(255, 0, 0),
+            [1.0, 1.0],
+        )
+        .with_clip_rrect(CLIP);
+
+        assert_eq!(
+            rect.clip_rrect, circle.clip_rrect,
+            "precondition: both kinds start from the same device-space clip"
+        );
+        assert_ne!(rect.clip_kind[0], 0, "precondition: the clip is active");
+
+        let mut segment = DrawSegment::new();
+        // `add` returns "batch is now full", not "succeeded".
+        assert!(!segment.rect_batch.add(rect), "rect batch not full");
+        assert!(!segment.circle_batch.add(circle), "circle batch not full");
+
+        super::GpuReplay::remap_segment_clips(&mut segment, ORIGIN, SCALE);
+
+        let remapped_rect = segment.rect_batch.instances[0].clip_rrect;
+        let remapped_circle = segment.circle_batch.instances[0].clip_rrect;
+        assert_ne!(
+            remapped_rect, CLIP,
+            "precondition: the remap actually changed the rect's clip"
+        );
+        assert_eq!(
+            remapped_circle, remapped_rect,
+            "a circle's clip must be remapped into the grown offscreen exactly as \
+             a rect's is; leaving it in full-frame device space displaces the \
+             rounded clip inside every blur/filter layer"
+        );
+    }
 }

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -194,7 +194,13 @@ impl GpuReplay {
     /// layer. A batch that gains a clip slot later is remapped by adding it here,
     /// in the one place that already reads them all.
     ///
-    /// Arcs are absent because `ArcInstance` carries no clip slot.
+    /// Two kinds are deliberately absent, neither by oversight. `ArcInstance`
+    /// carries no clip slot at all. `TextureInstance` carries one, but a segment
+    /// holding `cached_images`/`external_images` never reaches a shrunken
+    /// intermediate: `content_aabb` (`painter/layer.rs`) returns `None` for it, so
+    /// `fb_dim == viewport` and this remap would be the identity anyway. If that
+    /// fallback gate ever admits images, their clips must be added here in the
+    /// same change.
     fn remap_segment_clips(
         segment: &mut super::command_ir::DrawSegment,
         origin: (f32, f32),

--- a/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
@@ -59,6 +59,9 @@ struct InstanceInput {
     @location(3) color: vec4<f32>,              // [r, g, b, a] in 0-1 range
     @location(4) transform: vec4<f32>,          // 2×2 linear affine col-major: [a, b, c, d]
     @location(5) transform_translate: vec4<f32>,// [tx, ty, 0, 0] — translation part
+    @location(6) clip_bounds: vec4<f32>,        // [x, y, width, height] of the SDF clip
+    @location(7) clip_radii: vec4<f32>,         // [tl, tr, br, bl] of the SDF clip
+    @location(8) clip_kind: vec4<u32>,          // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
 }
 
 // Vertex output / Fragment input
@@ -70,6 +73,15 @@ struct VertexOutput {
     // The SDF evaluates `length(unit_pos) - 1.0`; the L2 gradient (dpdx/dpdy) gives
     // correct screen-space AA width regardless of the affine applied in the vertex shader.
     @location(1) unit_pos: vec2<f32>,
+    // Device-space position of the fragment, for the clip SDF. The vertex
+    // shader already computes it to produce `@builtin(position)`; passing it
+    // through costs one varying and no extra math.
+    @location(2) world_pos: vec2<f32>,
+    @location(3) clip_bounds: vec4<f32>,
+    @location(4) clip_radii: vec4<f32>,
+    // Flat: the clip is per-instance, so interpolating it would be both wrong
+    // and a source of branch divergence within a draw call.
+    @location(5) @interpolate(flat) clip_kind: u32,
 }
 
 // Viewport uniform (for screen-space to clip-space conversion)
@@ -80,6 +92,71 @@ struct Viewport {
 
 @group(0) @binding(0)
 var<uniform> viewport: Viewport;
+
+// =============================================================================
+// Shared SDF helpers
+// =============================================================================
+//
+// Inlined rather than imported: this project's WGSL sources are `include_str!`
+// constants with no preprocessor, so every shader that needs an SDF carries its
+// own copy. These three are byte-identical to `rect_instanced.wgsl`'s, so the
+// clip a circle evaluates is literally the same function a rect evaluates — the
+// point of routing both through `ClippableInstance`.
+
+
+// =============================================================================
+// SDF Functions (inline for this shader, can be extracted to common library)
+// =============================================================================
+
+/// Rounded box SDF with per-corner radii
+/// p: point to test (centered at origin)
+/// b: half-extents (half width, half height)
+/// r: corner radii [top-left, top-right, bottom-right, bottom-left]
+fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
+    // Select radius based on quadrant (branchless!)
+    // r2 = (top, bottom) radii for the active horizontal side:
+    //   right (p.x>0) → (tr=r.y, br=r.z); left → (tl=r.x, bl=r.w).
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    // r3 = bottom (p.y>0) → r2.y; top → r2.x.
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
+
+    let q = abs(p) - b + vec2<f32>(r3);
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
+}
+
+/// Rounded superellipse SDF (iOS-squircle, n=4) with per-corner radii.
+///
+/// Mirrors `sdRoundedSuperellipse` from `common/sdf.wgsl`; inlined here per
+/// the existing `sdRoundedBox` inlining convention. See the common-library
+/// version for full prose.
+fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
+    // (top, bottom) radii for the active side — see sdRoundedBox.
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
+
+    let q = abs(p) - b + vec2<f32>(r3);
+
+    if (q.x < 0.0 && q.y < 0.0) {
+        return max(q.x, q.y) - r3;
+    }
+
+    if (r3 <= 0.0) {
+        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0)));
+    }
+
+    let ax = max(q.x, 0.0) / r3;
+    let ay = max(q.y, 0.0) / r3;
+    let n_norm = sqrt(sqrt(ax * ax * ax * ax + ay * ay * ay * ay));
+    return (n_norm - 1.0) * r3;
+}
+
+/// Convert SDF distance to alpha with adaptive antialiasing.
+/// Uses the L2 (Euclidean) gradient magnitude so a diagonal/rotated edge
+/// receives ~1-device-px AA exactly, not ~1.41× as with L1/fwidth.
+fn sdfToAlpha(dist: f32) -> f32 {
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
+    return 1.0 - smoothstep(-edge_width, edge_width, dist);
+}
 
 // =============================================================================
 // Vertex Shader
@@ -158,6 +235,10 @@ fn vs_main(
     // `length(unit_pos) - 1.0` relative to the true unit-circle edge,
     // even on the expanded fringe (exp_unit ranges slightly outside [-1,1] there).
     out.unit_pos = exp_unit;
+    out.world_pos = device_pos;
+    out.clip_bounds = instance.clip_bounds;
+    out.clip_radii = instance.clip_radii;
+    out.clip_kind = instance.clip_kind.x;
 
     return out;
 }
@@ -190,10 +271,38 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let aa = length(vec2<f32>(dpdx(d), dpdy(d))) * 0.5;
     let alpha = 1.0 - smoothstep(-aa, aa, d);
 
+    // --- SDF Clip Test ---
+    // Identical to `rect_instanced.wgsl`: the clip_bounds + clip_radii slot is
+    // shared between clip kinds and the flat `clip_kind` selects the SDF. Kept
+    // byte-for-byte the same shape as the rect path so the two cannot drift —
+    // circles previously received only the clip's bounding scissor, leaving an
+    // avatar inside a `ClipRRect` with square corners.
+    var clip_alpha = 1.0;
+    if (in.clip_kind != 0u && in.clip_bounds.z > 0.0 && in.clip_bounds.w > 0.0) {
+        let clip_center = in.clip_bounds.xy + in.clip_bounds.zw * 0.5;
+        let clip_p = in.world_pos - clip_center;
+        let clip_half = in.clip_bounds.zw * 0.5;
+
+        var clip_dist = 0.0;
+        if (in.clip_kind == 2u) {
+            clip_dist = sdRoundedSuperellipse(clip_p, clip_half, in.clip_radii);
+        } else {
+            // clip_kind == 1u (rrect), and the safe default for any kind this
+            // shader has not learned about.
+            clip_dist = sdRoundedBox(clip_p, clip_half, in.clip_radii);
+        }
+        clip_alpha = sdfToAlpha(clip_dist);
+    }
+
+    let final_alpha = alpha * clip_alpha;
+
     // Discard fully transparent pixels to reduce overdraw on expanded fringe.
-    if (alpha < 0.001) {
+    if (final_alpha < 0.001) {
         discard;
     }
 
-    return vec4<f32>(in.color.rgb, in.color.a * alpha);
+    // Straight (non-premultiplied) alpha, as before: the blend state does the
+    // premultiply. Folding the clip into the alpha is therefore correct here —
+    // it would NOT be in a shader that returns `rgb * a`.
+    return vec4<f32>(in.color.rgb, in.color.a * final_alpha);
 }


### PR DESCRIPTION
## Summary

First slice of the clip step. `apply_active_clip` — the one place an SDF clip is attached to a draw — was called only for SrcOver rect/rrect fills and for textures, and `ClippableInstance` was implemented only by `RectInstance` and `TextureInstance`. **Circles and ovals received nothing but the clip's axis-aligned bounding scissor**, so a `ClipRRect` around an avatar left square corners.

`CircleInstance` now carries the same `clip_rrect` + `clip_kind` pair and goes through the same `ClippableInstance` seam, so the two cannot drift: the clip a circle evaluates is literally the same function a rect evaluates.

## Verification

- [x] `just ci`
- [x] Flutter reference checked — a clip applies to every primitive inside it; no primitive-kind exemption exists
- [x] New or changed behavior has tests that would fail without this change
- [x] Public API changes are documented — `CircleInstance`'s new fields and its `ClippableInstance` impl

`a_rounded_clip_rounds_a_circle`, with geometry chosen so it **cannot pass by accident**: the circle is far larger than the clip and covers every corner of the surface, so the sampled corner is inside the drawn shape and outside the clip. A centre assertion guards against passing by drawing nothing.

> Worth stating, because the obvious version of this test is vacuous: drawing a disc that coincides with the clip puts the corner outside the *geometry*, so it passes with no clip support at all.

Red before: `corner rgba=[0, 0, 255, 255]`. Re-verified non-vacuous by removing the `apply_active_clip` call at the record sites — it fails again.

9628 workspace tests, 562 flui-engine tests including every GPU readback oracle, clippy in both modes (workspace and `enable-wgpu-tests`), fmt, port-check.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md`
- [x] No new banned patterns from `docs/PORT.md`
- [x] New dependencies are declared through workspace dependencies when shared — none added

## Notes

**Why this stops at the instanced families.** Folding the clip into alpha is only correct for a shader returning **straight** alpha. `circle_instanced.wgsl` returns `color.a * alpha` and lets the blend state premultiply, exactly like `rect_instanced.wgsl` — so the block is copied byte-for-byte. `shape.wgsl` (tessellated paths and strokes) returns `vec4(c.rgb * c.a, c.a)`, **premultiplied**, where the same edit would be wrong. Gradients likewise need their own look. Those belong in the shared clip-uniform change, not here.

**Layout.** The fields are appended, so every pre-existing offset is byte-identical and the vertex attributes for locations 2–5 are unchanged; 6–8 are new. `test_circle_instance_size` is updated to the real layout (64 → 112 bytes) with its field table — not to whatever number made it pass.

**SDF helpers are inlined, not imported**, matching how every other shader here gets them: these WGSL sources are `include_str!` constants with no preprocessor.

**Still open, deliberately:**
- Elliptical clip corners collapse to one scalar radius per corner (the shared 8-float slot holds one, and `sdRoundedSuperellipse` takes one). Pre-existing divergence, inherited identically rather than given a second behaviour.
- Arcs, gradients, tessellated paths and strokes, shadows and text still take only the bounding scissor. Arcs are the same mechanical change as this one; the rest need the shared clip uniform.
- `clip_path` remains a documented no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo