### PR TITLE
refactor(engine): one shared SDF clip block instead of a copy per shader

### DIFF
--- a/crates/flui-engine/src/wgpu/sdf_smoke_test.rs
+++ b/crates/flui-engine/src/wgpu/sdf_smoke_test.rs
@@ -1,8 +1,8 @@
 //! CPU-side smoke test for `sdRoundedSuperellipse` math correctness.
 //!
 //! Transliterates the WGSL `sdRoundedBox` and `sdRoundedSuperellipse`
-//! functions from [`shaders/common/sdf.wgsl`](crate::wgpu::shaders) into
-//! Rust helpers, then samples both at known points to verify:
+//! functions from `shaders/common/clip.wgsl` into Rust helpers, then samples
+//! both at known points to verify:
 //!
 //! 1. **Corner-region divergence:** At a sample inside the
 //!    corner-curvature zone, the superellipse SDF produces a measurably
@@ -22,16 +22,24 @@
 //! corner radii = 80, large enough that corner curvature is visible and
 //! the SDF difference is well above floating-point noise.
 //!
-//! These helpers must stay in sync with the WGSL functions. Future edits
-//! to either side that change behavior trigger the divergence test
-//! failure, surfacing the desync.
+//! **What these tests do NOT pin.** Both sides of every comparison here are
+//! the Rust transliterations, so editing the WGSL changes nothing that runs
+//! in this file — a desync between Rust and WGSL passes silently. What they
+//! DO pin is the math relationship the squircle has to satisfy: it must
+//! differ from an rrect in the corner zone and agree everywhere else, so a
+//! silent regression to the rrect fallback fails here without a GPU.
+//!
+//! The shader itself is pinned by the readback oracles in `aa_oracle_tests`
+//! (`a_rounded_clip_rounds_a_circle` and its neighbours), which run the real
+//! WGSL and read back pixels. Those are the tests to extend when the clip's
+//! observable behavior changes.
 
 #![cfg(test)]
 
 /// CPU transliteration of WGSL `sdRoundedBox`.
 ///
-/// Must stay in sync with [`shaders/common/sdf.wgsl::sdRoundedBox`]
-/// (and the inlined copy in `shaders/rect_instanced.wgsl`).
+/// Mirrors `sdRoundedBox` in `shaders/common/clip.wgsl` by hand — nothing
+/// checks the two agree; see the module docs.
 fn sd_rounded_box(p: [f32; 2], b: [f32; 2], r: [f32; 4]) -> f32 {
     // Per-corner radius selection (branchless equivalent of WGSL `select`)
     // (top, bottom) radii for the active horizontal side — see WGSL sdRoundedBox:
@@ -52,8 +60,8 @@ fn sd_rounded_box(p: [f32; 2], b: [f32; 2], r: [f32; 4]) -> f32 {
 
 /// CPU transliteration of WGSL `sdRoundedSuperellipse`.
 ///
-/// Must stay in sync with [`shaders/common/sdf.wgsl::sdRoundedSuperellipse`]
-/// (and the inlined copy in `shaders/rect_instanced.wgsl`).
+/// Mirrors `sdRoundedSuperellipse` in `shaders/common/clip.wgsl` by hand —
+/// nothing checks the two agree; see the module docs.
 fn sd_rounded_superellipse(p: [f32; 2], b: [f32; 2], r: [f32; 4]) -> f32 {
     // (top, bottom) radii for the active horizontal side — see WGSL sdRoundedBox:
     //   right (p.x>0) → (tr=r[1], br=r[2]); left → (tl=r[0], bl=r[3]).

--- a/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
@@ -103,60 +103,9 @@ var<uniform> viewport: Viewport;
 // clip a circle evaluates is literally the same function a rect evaluates — the
 // point of routing both through `ClippableInstance`.
 
-
 // =============================================================================
 // SDF Functions (inline for this shader, can be extracted to common library)
 // =============================================================================
-
-/// Rounded box SDF with per-corner radii
-/// p: point to test (centered at origin)
-/// b: half-extents (half width, half height)
-/// r: corner radii [top-left, top-right, bottom-right, bottom-left]
-fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    // Select radius based on quadrant (branchless!)
-    // r2 = (top, bottom) radii for the active horizontal side:
-    //   right (p.x>0) → (tr=r.y, br=r.z); left → (tl=r.x, bl=r.w).
-    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
-    // r3 = bottom (p.y>0) → r2.y; top → r2.x.
-    let r3 = select(r2.x, r2.y, p.y > 0.0);
-
-    let q = abs(p) - b + vec2<f32>(r3);
-    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
-}
-
-/// Rounded superellipse SDF (iOS-squircle, n=4) with per-corner radii.
-///
-/// Mirrors `sdRoundedSuperellipse` from `common/sdf.wgsl`; inlined here per
-/// the existing `sdRoundedBox` inlining convention. See the common-library
-/// version for full prose.
-fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    // (top, bottom) radii for the active side — see sdRoundedBox.
-    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
-    let r3 = select(r2.x, r2.y, p.y > 0.0);
-
-    let q = abs(p) - b + vec2<f32>(r3);
-
-    if (q.x < 0.0 && q.y < 0.0) {
-        return max(q.x, q.y) - r3;
-    }
-
-    if (r3 <= 0.0) {
-        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0)));
-    }
-
-    let ax = max(q.x, 0.0) / r3;
-    let ay = max(q.y, 0.0) / r3;
-    let n_norm = sqrt(sqrt(ax * ax * ax * ax + ay * ay * ay * ay));
-    return (n_norm - 1.0) * r3;
-}
-
-/// Convert SDF distance to alpha with adaptive antialiasing.
-/// Uses the L2 (Euclidean) gradient magnitude so a diagonal/rotated edge
-/// receives ~1-device-px AA exactly, not ~1.41× as with L1/fwidth.
-fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
-    return 1.0 - smoothstep(-edge_width, edge_width, dist);
-}
 
 // =============================================================================
 // Vertex Shader

--- a/crates/flui-engine/src/wgpu/shaders/common/clip.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/common/clip.wgsl
@@ -1,0 +1,64 @@
+// Shared SDF helpers for the per-instance clip.
+//
+// This file is not a standalone shader: it is prepended to every shader that
+// evaluates a clip (see `shaders/mod.rs`), because WGSL has no include
+// directive and module-scope declarations are order-independent.
+//
+// It exists because these three functions were inlined byte-for-byte into
+// `rect_instanced`, `circle_instanced`, and `texture_instanced`, and each new
+// clip-carrying shader added another copy. Copies of a distance function drift
+// silently: the same `ClipRRect` would round a rect and a gradient by
+// different amounts, with nothing failing.
+//
+// `common/sdf.wgsl` is a broader reference library with no `include_str!`
+// consumer — do not confuse the two. This file is the one that ships.
+
+/// Rounded box SDF with per-corner radii.
+///
+/// `p` — point to test, centred at the origin.
+/// `b` — half-extents (half width, half height).
+/// `r` — corner radii [top-left, top-right, bottom-right, bottom-left].
+fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
+    // Select radius based on quadrant (branchless).
+    // r2 = (top, bottom) radii for the active horizontal side:
+    //   right (p.x>0) → (tr=r.y, br=r.z); left → (tl=r.x, bl=r.w).
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    // r3 = bottom (p.y>0) → r2.y; top → r2.x.
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
+
+    let q = abs(p) - b + vec2<f32>(r3);
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
+}
+
+/// Rounded superellipse SDF (iOS-squircle, n=4) with per-corner radii.
+fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
+    // (top, bottom) radii for the active side — see sdRoundedBox.
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
+
+    let q = abs(p) - b + vec2<f32>(r3);
+
+    // Inner rect: both components negative — the curve choice does not apply.
+    if (q.x < 0.0 && q.y < 0.0) {
+        return max(q.x, q.y) - r3;
+    }
+
+    // Degenerate corner: fall back to the sharp-rect SDF.
+    if (r3 <= 0.0) {
+        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0)));
+    }
+
+    let ax = max(q.x, 0.0) / r3;
+    let ay = max(q.y, 0.0) / r3;
+    let n_norm = sqrt(sqrt(ax * ax * ax * ax + ay * ay * ay * ay));
+    return (n_norm - 1.0) * r3;
+}
+
+/// Convert an SDF distance to coverage with adaptive antialiasing.
+///
+/// Uses the L2 (Euclidean) gradient magnitude so a diagonal or rotated edge
+/// receives ~1 device pixel of AA exactly, not ~1.41× as with L1/fwidth.
+fn sdfToAlpha(dist: f32) -> f32 {
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
+    return 1.0 - smoothstep(-edge_width, edge_width, dist);
+}

--- a/crates/flui-engine/src/wgpu/shaders/common/sdf.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/common/sdf.wgsl
@@ -1,5 +1,11 @@
 // Signed Distance Field (SDF) Utility Library for FLUI
 //
+// REFERENCE ONLY — no `include_str!` consumer. Nothing in this file reaches a
+// GPU. The SDF helpers that ship are in `common/clip.wgsl`, which every
+// clip-evaluating shader is prepended with. Shader comments used to say they
+// "mirror common/sdf.wgsl", which read as though this file were authoritative;
+// it is not. Editing it changes no rendering.
+//
 // This library provides reusable SDF functions for rendering 2D primitives
 // with perfect antialiasing and efficient GPU execution.
 //

--- a/crates/flui-engine/src/wgpu/shaders/mod.rs
+++ b/crates/flui-engine/src/wgpu/shaders/mod.rs
@@ -20,11 +20,35 @@
 pub const SHAPE: &str = include_str!("shape.wgsl");
 
 // Instanced rendering
+//
+// Every shader that evaluates a per-instance SDF clip is prepended with
+// `common/clip.wgsl`. WGSL has no include directive, but module-scope
+// declarations are order-independent, so plain concatenation is the whole
+// mechanism. These three shaders each carried a byte-for-byte copy of the
+// clip helpers; a distance function copied per shader drifts silently, and
+// the same `ClipRRect` would then round different primitives by different
+// amounts with nothing failing.
+//
+// `arc_instanced` is NOT prepended: `ArcInstance` carries no clip slot, and
+// adding unused functions to a shader is noise, not symmetry.
+//
+// `concat!` takes the `include_str!` calls directly rather than a named
+// `CLIP_SDF` const: it concatenates literals, and a `const` is not one.
+
 /// Instanced rectangle rendering shader.
-pub const RECT_INSTANCED: &str = include_str!("rect_instanced.wgsl");
+pub const RECT_INSTANCED: &str = concat!(
+    include_str!("common/clip.wgsl"),
+    include_str!("rect_instanced.wgsl")
+);
 /// Instanced circle rendering shader.
-pub const CIRCLE_INSTANCED: &str = include_str!("circle_instanced.wgsl");
+pub const CIRCLE_INSTANCED: &str = concat!(
+    include_str!("common/clip.wgsl"),
+    include_str!("circle_instanced.wgsl")
+);
 /// Instanced arc rendering shader.
 pub const ARC_INSTANCED: &str = include_str!("arc_instanced.wgsl");
 /// Instanced texture rendering shader.
-pub const TEXTURE_INSTANCED: &str = include_str!("texture_instanced.wgsl");
+pub const TEXTURE_INSTANCED: &str = concat!(
+    include_str!("common/clip.wgsl"),
+    include_str!("texture_instanced.wgsl")
+);

--- a/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
@@ -73,56 +73,6 @@ var<uniform> viewport: Viewport;
 // SDF Functions (inline for this shader, can be extracted to common library)
 // =============================================================================
 
-/// Rounded box SDF with per-corner radii
-/// p: point to test (centered at origin)
-/// b: half-extents (half width, half height)
-/// r: corner radii [top-left, top-right, bottom-right, bottom-left]
-fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    // Select radius based on quadrant (branchless!)
-    // r2 = (top, bottom) radii for the active horizontal side:
-    //   right (p.x>0) → (tr=r.y, br=r.z); left → (tl=r.x, bl=r.w).
-    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
-    // r3 = bottom (p.y>0) → r2.y; top → r2.x.
-    let r3 = select(r2.x, r2.y, p.y > 0.0);
-
-    let q = abs(p) - b + vec2<f32>(r3);
-    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
-}
-
-/// Rounded superellipse SDF (iOS-squircle, n=4) with per-corner radii.
-///
-/// Mirrors `sdRoundedSuperellipse` from `common/sdf.wgsl`; inlined here per
-/// the existing `sdRoundedBox` inlining convention. See the common-library
-/// version for full prose.
-fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    // (top, bottom) radii for the active side — see sdRoundedBox.
-    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
-    let r3 = select(r2.x, r2.y, p.y > 0.0);
-
-    let q = abs(p) - b + vec2<f32>(r3);
-
-    if (q.x < 0.0 && q.y < 0.0) {
-        return max(q.x, q.y) - r3;
-    }
-
-    if (r3 <= 0.0) {
-        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0)));
-    }
-
-    let ax = max(q.x, 0.0) / r3;
-    let ay = max(q.y, 0.0) / r3;
-    let n_norm = sqrt(sqrt(ax * ax * ax * ax + ay * ay * ay * ay));
-    return (n_norm - 1.0) * r3;
-}
-
-/// Convert SDF distance to alpha with adaptive antialiasing.
-/// Uses the L2 (Euclidean) gradient magnitude so a diagonal/rotated edge
-/// receives ~1-device-px AA exactly, not ~1.41× as with L1/fwidth.
-fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
-    return 1.0 - smoothstep(-edge_width, edge_width, dist);
-}
-
 // =============================================================================
 // Vertex Shader
 // =============================================================================

--- a/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
@@ -42,44 +42,6 @@ struct VertexOutput {
 // must stay identical — a clip that rounds differently per primitive is worse
 // than no clip at all, because the seam only shows where two primitives meet.
 
-/// Rounded box SDF with per-corner radii. See `rect_instanced.wgsl` for the
-/// branchless quadrant-selection prose.
-fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
-    let r3 = select(r2.x, r2.y, p.y > 0.0);
-
-    let q = abs(p) - b + vec2<f32>(r3);
-    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
-}
-
-/// Rounded superellipse SDF (iOS-squircle, n=4) with per-corner radii.
-fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
-    let r3 = select(r2.x, r2.y, p.y > 0.0);
-
-    let q = abs(p) - b + vec2<f32>(r3);
-
-    if (q.x < 0.0 && q.y < 0.0) {
-        return max(q.x, q.y) - r3;
-    }
-
-    if (r3 <= 0.0) {
-        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0)));
-    }
-
-    let ax = max(q.x, 0.0) / r3;
-    let ay = max(q.y, 0.0) / r3;
-    let n_norm = sqrt(sqrt(ax * ax * ax * ax + ay * ay * ay * ay));
-    return (n_norm - 1.0) * r3;
-}
-
-/// Convert SDF distance to alpha with adaptive antialiasing (L2 gradient, so a
-/// rotated edge gets ~1 device pixel of AA rather than ~1.41).
-fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
-    return 1.0 - smoothstep(-edge_width, edge_width, dist);
-}
-
 // Viewport uniform (for screen-space to clip-space conversion)
 struct Viewport {
     size: vec2<f32>,      // Viewport size in pixels


### PR DESCRIPTION
## What

`sdRoundedBox`, `sdRoundedSuperellipse`, and `sdfToAlpha` were inlined byte-for-byte into `rect_instanced.wgsl`, `circle_instanced.wgsl`, and `texture_instanced.wgsl`. They now live once in `shaders/common/clip.wgsl`, prepended with `concat!` to each shader that evaluates a clip.

## Why now

I was about to write the fourth, fifth, and sixth copy — gradients need the same block to honour a rounded clip. Copies of a distance function drift silently: the same `ClipRRect` would round a rect and a gradient by different amounts, and nothing would fail. The three existing copies had already drifted in their comments, which is the harmless version of the same process.

WGSL has no include directive, but module-scope declarations are order-independent, so concatenation is the entire mechanism. `arc_instanced` is deliberately not prepended — `ArcInstance` carries no clip slot, and unused functions in a shader are noise, not symmetry.

## Evidence

A green suite after a no-behavior-change refactor proves little on its own, so the wiring was checked positively. Dropping the concat from `circle_instanced` fails at pipeline creation:

```
Shader 'Instanced Circle Shader' parsing error:
  no definition in scope for identifier: `sdRoundedSuperellipse`
```

`cargo nextest run -p flui-engine --features enable-wgpu-tests` → 563 passed. Clippy clean in both invocations.

## Two doc corrections the change forced

- **`sdf_smoke_test.rs` promised something it cannot deliver.** It said "future edits to either side that change behavior trigger the divergence test failure, surfacing the desync". Both sides of every comparison in that file are its own Rust transliterations — editing the WGSL changes nothing that runs there, so a desync passes silently. The tests still earn their place (they pin the squircle-vs-rrect math relationship without needing a GPU), so the fix is the claim, not the tests. They now point at the readback oracles that do pin the shader.
- **`common/sdf.wgsl` has no `include_str!` consumer** and never reaches a GPU, yet two shaders described themselves as mirroring it — which reads as though it were authoritative. Marked REFERENCE ONLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo