### PR TITLE
fix(engine): gradient fills round the corners they were given

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3292,6 +3292,106 @@ mod gpu_tests {
         );
     }
 
+    /// A gradient-filled rrect rounds the corner the caller asked for.
+    ///
+    /// The gradient shaders carried their own `sdRoundedBox` whose quadrant
+    /// selection was a permutation of the canonical one:
+    ///
+    /// ```text
+    /// canonical: r2 = select(vec2(r.x, r.w), vec2(r.y, r.z), p.x > 0.0)
+    ///            r3 = select(r2.x, r2.y, p.y > 0.0)
+    /// gradients: r2 = select(r.zw, r.xy, p.x > 0.0)
+    ///            r3 = select(r2.y, r2.x, p.y > 0.0)
+    /// ```
+    ///
+    /// With `r = [tl, tr, br, bl]` the gradient form resolves top-left to `bl`,
+    /// bottom-left to `br`, and bottom-right to `tl` — only top-right is right.
+    /// Four equal radii hide it completely, which is why it survived: the
+    /// single-`f32` `gradient_rect` entry point passes `[r; 4]`. It becomes
+    /// visible through `dispatch_shader_rect`, which carries genuinely
+    /// per-corner radii from `RRect` (`batches/shapes.rs`) — a card rounded on
+    /// top only, filled with a gradient.
+    ///
+    /// Geometry: only the BOTTOM-LEFT corner is rounded, and hugely (56 px on a
+    /// 128 px surface). Sampling the bottom-left corner pixel distinguishes the
+    /// two: correct → cut away; permuted → bottom-left resolves to `br` = 0,
+    /// square, painted.
+    #[test]
+    fn a_gradient_rrect_rounds_the_corner_it_was_given() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        const R: f32 = 56.0;
+        let full = flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // [tl, tr, br, bl] = [0, 0, 0, R] — bottom-left only.
+        use flui_types::geometry::{RRect, Radius};
+        let zero = Radius::circular(Pixels(0.0));
+        let rrect = RRect::new(full, zero, zero, zero, Radius::circular(Pixels(R)));
+
+        // The base colour is RED and the gradient is BLUE on purpose: a blue
+        // centre pixel proves the gradient pipeline ran at all, so a failure
+        // here cannot be the tessellated fallback quietly standing in.
+        let mut paint = Paint::fill(Color::rgb(255, 0, 0));
+        paint.shader = Some(flui_types::painting::Shader::LinearGradient {
+            from: flui_types::Offset::new(Pixels(0.0), Pixels(0.0)),
+            to: flui_types::Offset::new(Pixels(0.0), Pixels(SURFACE_HEIGHT as f32)),
+            colors: vec![Color::rgb(0, 0, 255), Color::rgb(0, 0, 255)],
+            stops: Some(vec![0.0, 1.0]),
+            tile_mode: flui_types::painting::TileMode::Clamp,
+        });
+        painter.rrect(rrect, &paint);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Gradient RRect Corner Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let h = SURFACE_HEIGHT as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        let centre = at(w / 2, h / 2);
+        assert!(
+            centre[2] > 200 && centre[0] < 64,
+            "precondition: the centre must be the gradient's BLUE, not the base \
+             RED — a red centre means the gradient pipeline never ran and this \
+             test is measuring the tessellated fallback; got {centre:?}"
+        );
+
+        // Top-left: radius 0, so this corner stays square and painted. Without
+        // it the test would pass on a shader that rounded every corner.
+        let top_left = at(2, 2);
+        assert!(
+            top_left[3] > 200,
+            "precondition: the top-left corner has radius 0 and must stay \
+             square; got {top_left:?}"
+        );
+
+        // Bottom-left: radius R, so this pixel is outside the shape.
+        let bottom_left = at(2, h - 3);
+        assert!(
+            bottom_left[3] < 32,
+            "the bottom-left corner was given radius {R} and must be cut away; \
+             got rgba={bottom_left:?} — the gradient shader resolved this \
+             corner to a different entry of [tl, tr, br, bl]"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/batches/gradients.rs
+++ b/crates/flui-engine/src/wgpu/batches/gradients.rs
@@ -31,7 +31,7 @@ impl DrawBatcher {
     /// * `gradient_start`  — gradient start point (local to `bounds`)
     /// * `gradient_end`    — gradient end point (local to `bounds`)
     /// * `stops`           — gradient color stops (max 8)
-    /// * `corner_radius`   — uniform corner radius (0.0 = sharp)
+    /// * `corner_radii`    — per-corner radii `[tl, tr, br, bl]` (0.0 = sharp)
     #[allow(
         clippy::too_many_arguments,
         reason = "borrow-seam design: segment/state are disjoint WgpuPainter fields; \
@@ -44,7 +44,7 @@ impl DrawBatcher {
         gradient_start: glam::Vec2,
         gradient_end: glam::Vec2,
         stops: &[effects::GradientStop],
-        corner_radius: f32,
+        corner_radii: [f32; 4],
     ) {
         use super::super::instancing::LinearGradientInstance;
 
@@ -102,7 +102,7 @@ impl DrawBatcher {
             ],
             gradient_start,
             gradient_end,
-            [corner_radius; 4],
+            corner_radii,
             stop_count as u32,
         )
         .with_stop_offset(stop_offset);
@@ -126,7 +126,7 @@ impl DrawBatcher {
     /// * `center`         — gradient center (local to `bounds`)
     /// * `radius`         — gradient radius
     /// * `stops`          — gradient color stops (max 8)
-    /// * `corner_radius`  — uniform corner radius (0.0 = sharp)
+    /// * `corner_radii`   — per-corner radii `[tl, tr, br, bl]` (0.0 = sharp)
     #[allow(
         clippy::too_many_arguments,
         reason = "borrow-seam design: segment/state are disjoint WgpuPainter fields; \
@@ -139,7 +139,7 @@ impl DrawBatcher {
         center: glam::Vec2,
         radius: f32,
         stops: &[effects::GradientStop],
-        corner_radius: f32,
+        corner_radii: [f32; 4],
     ) {
         use super::super::instancing::RadialGradientInstance;
 
@@ -194,7 +194,7 @@ impl DrawBatcher {
             ],
             center,
             radius,
-            [corner_radius; 4],
+            corner_radii,
             stop_count as u32,
         )
         .with_stop_offset(stop_offset);
@@ -219,7 +219,7 @@ impl DrawBatcher {
     /// * `start_angle`  — start angle in radians
     /// * `end_angle`    — end angle in radians
     /// * `stops`        — gradient color stops (max 8)
-    /// * `corner_radius`— uniform corner radius (0.0 = sharp)
+    /// * `corner_radii` — per-corner radii `[tl, tr, br, bl]` (0.0 = sharp)
     #[allow(
         clippy::too_many_arguments,
         reason = "borrow-seam design: segment/state are disjoint WgpuPainter fields; \
@@ -233,7 +233,7 @@ impl DrawBatcher {
         start_angle: f32,
         end_angle: f32,
         stops: &[effects::GradientStop],
-        corner_radius: f32,
+        corner_radii: [f32; 4],
     ) {
         use super::super::instancing::SweepGradientInstance;
 
@@ -289,7 +289,7 @@ impl DrawBatcher {
             center,
             start_angle,
             end_angle,
-            [corner_radius; 4],
+            corner_radii,
             stop_count as u32,
         )
         .with_stop_offset(stop_offset);
@@ -512,7 +512,7 @@ impl DrawBatcher {
                     start,
                     end,
                     &stops,
-                    corner_radii[0],
+                    corner_radii,
                 );
             }
             Shader::RadialGradient { center, radius, .. } => {
@@ -525,7 +525,7 @@ impl DrawBatcher {
                     c,
                     *radius,
                     &stops,
-                    corner_radii[0],
+                    corner_radii,
                 );
             }
             Shader::SweepGradient {
@@ -544,7 +544,7 @@ impl DrawBatcher {
                     *start_angle,
                     *end_angle,
                     &stops,
-                    corner_radii[0],
+                    corner_radii,
                 );
             }
             Shader::Solid { .. } | _ => return false,

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -642,7 +642,7 @@ mod unit_tests {
             glam::Vec2::new(0.0, 0.0),
             glam::Vec2::new(10.0, 0.0),
             &stops,
-            0.0,
+            [0.0; 4],
         );
         assert!(
             !segment.current_gradient_stops.is_empty(),

--- a/crates/flui-engine/src/wgpu/effects_pipeline.rs
+++ b/crates/flui-engine/src/wgpu/effects_pipeline.rs
@@ -73,7 +73,13 @@ pub fn create_linear_gradient_pipeline(
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Linear Gradient Shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("shaders/gradients/linear.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(
+            concat!(
+                include_str!("shaders/common/clip.wgsl"),
+                include_str!("shaders/gradients/linear.wgsl")
+            )
+            .into(),
+        ),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -132,7 +138,13 @@ pub fn create_radial_gradient_pipeline(
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Radial Gradient Shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("shaders/gradients/radial.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(
+            concat!(
+                include_str!("shaders/common/clip.wgsl"),
+                include_str!("shaders/gradients/radial.wgsl")
+            )
+            .into(),
+        ),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -191,7 +203,13 @@ pub fn create_sweep_gradient_pipeline(
 ) -> wgpu::RenderPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("Sweep Gradient Shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("shaders/gradients/sweep.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(
+            concat!(
+                include_str!("shaders/common/clip.wgsl"),
+                include_str!("shaders/gradients/sweep.wgsl")
+            )
+            .into(),
+        ),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/crates/flui-engine/src/wgpu/painter/gradient.rs
+++ b/crates/flui-engine/src/wgpu/painter/gradient.rs
@@ -51,7 +51,10 @@ impl WgpuPainter {
             gradient_start,
             gradient_end,
             stops,
-            corner_radius,
+            // This entry point is the uniform-radius convenience form; the
+            // per-corner path is `rrect` with a shader paint, which reaches
+            // the same batcher with genuine `[tl, tr, br, bl]`.
+            [corner_radius; 4],
         );
     }
 
@@ -93,7 +96,10 @@ impl WgpuPainter {
             center,
             radius,
             stops,
-            corner_radius,
+            // This entry point is the uniform-radius convenience form; the
+            // per-corner path is `rrect` with a shader paint, which reaches
+            // the same batcher with genuine `[tl, tr, br, bl]`.
+            [corner_radius; 4],
         );
     }
 
@@ -123,7 +129,10 @@ impl WgpuPainter {
             start_angle,
             end_angle,
             stops,
-            corner_radius,
+            // This entry point is the uniform-radius convenience form; the
+            // per-corner path is `rrect` with a shader paint, which reaches
+            // the same batcher with genuine `[tl, tr, br, bl]`.
+            [corner_radius; 4],
         );
     }
 

--- a/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
@@ -63,19 +63,6 @@ var<storage, read> gradient_stops: array<GradientStop>;
 // SDF Functions (for rounded corners clipping)
 // =============================================================================
 
-fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    let r2 = select(r.zw, r.xy, p.x > 0.0);
-    let r3 = select(r2.y, r2.x, p.y > 0.0);
-    let q = abs(p) - b + vec2<f32>(r3);
-    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
-}
-
-/// L2 gradient magnitude for ~1-device-px AA on diagonal/rotated clip edges.
-fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
-    return 1.0 - smoothstep(-edge_width, edge_width, dist);
-}
-
 // =============================================================================
 // Gradient Interpolation
 // =============================================================================

--- a/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
@@ -61,19 +61,6 @@ var<storage, read> gradient_stops: array<GradientStop>;
 // SDF Functions
 // =============================================================================
 
-fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    let r2 = select(r.zw, r.xy, p.x > 0.0);
-    let r3 = select(r2.y, r2.x, p.y > 0.0);
-    let q = abs(p) - b + vec2<f32>(r3);
-    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
-}
-
-/// L2 gradient magnitude for ~1-device-px AA on diagonal/rotated clip edges.
-fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
-    return 1.0 - smoothstep(-edge_width, edge_width, dist);
-}
-
 // =============================================================================
 // Gradient Interpolation (same as linear)
 // =============================================================================

--- a/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
@@ -61,19 +61,6 @@ var<storage, read> gradient_stops: array<GradientStop>;
 // SDF Functions
 // =============================================================================
 
-fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    let r2 = select(r.zw, r.xy, p.x > 0.0);
-    let r3 = select(r2.y, r2.x, p.y > 0.0);
-    let q = abs(p) - b + vec2<f32>(r3);
-    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
-}
-
-/// L2 gradient magnitude for ~1-device-px AA on diagonal/rotated clip edges.
-fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
-    return 1.0 - smoothstep(-edge_width, edge_width, dist);
-}
-
 // =============================================================================
 // Gradient Interpolation (same as linear/radial)
 // =============================================================================


### PR DESCRIPTION
Stacked on #747 (the shared clip block), which the shader half of this fix uses.

## The bug

A gradient-filled `RRect` ignores three of its four corner radii. Two independent defects, both of which have to go for the corner to render:

**1. The radii never leave the CPU.** `dispatch_shader_rect` receives genuine per-corner `[tl, tr, br, bl]` from `batches/shapes.rs:213`, then passes `corner_radii[0]` — the top-left one — as a single uniform radius to all three gradient record methods (`batches/gradients.rs:515/528/547`). A card rounded only at the bottom renders fully square; a card rounded only at the top renders rounded on all four corners.

**2. The advanced-blend path does pass the full array, and the shader permutes it.** The gradient shaders carried their own `sdRoundedBox`:

```wgsl
// canonical                                        // gradients
r2 = select(vec2(r.x, r.w), vec2(r.y, r.z), p.x>0)  r2 = select(r.zw, r.xy, p.x>0)
r3 = select(r2.x, r2.y, p.y>0)                      r3 = select(r2.y, r2.x, p.y>0)
```

With `r = [tl, tr, br, bl]` the gradient form resolves top-left to `bl`, bottom-left to `br`, and bottom-right to `tl`. Only top-right was correct.

Four equal radii hide both defects exactly — every entry point except the RRect one passes `[r; 4]`, which is why this survived.

## The fix

The three record methods take `[f32; 4]`. The public `gradient_rect`/`radial_gradient_rect`/`sweep_gradient_rect` painter entry points keep their scalar parameter: they are the uniform-radius convenience form, and the per-corner path is `rrect` with a shader paint, which reaches the same batcher. The gradient shaders drop their local copy and use the shared `common/clip.wgsl`.

## Evidence

The oracle draws a gradient rrect rounded on the bottom-left only and checks three pixels:

- the centre is the gradient's BLUE rather than the base RED — so a failure cannot be the tessellated fallback quietly standing in;
- the zero-radius top-left corner stays square — so a shader that rounded everything would not pass;
- the bottom-left corner is cut away.

Reverting either fix alone fails it. Both were confirmed that way before this was written up — collapsing back to `corner_radii[0]` gives `rgba=[0,0,255,255]` at the corner, and restoring the permuted selection fails the same assertion.

`cargo nextest run -p flui-engine --features enable-wgpu-tests` → 564 passed. Clippy clean.

## Not fixed here

`effects/shadow.wgsl` has its own `sdRoundedBox` taking a scalar radius — a different signature, and shadows take a uniform radius throughout. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo