### PR TITLE
feat(engine): the remaining primitives honour the active SDF clip

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3470,6 +3470,85 @@ mod gpu_tests {
         );
     }
 
+    /// A rounded clip actually rounds tessellated geometry.
+    ///
+    /// Strokes and path fills never reach the instanced SDF path — they are
+    /// tessellated by lyon and drawn through `shape.wgsl`, which receives only
+    /// the clip's axis-aligned bounding scissor. A stroked border inside a
+    /// `ClipRRect` therefore keeps square corners while the rrect fill beside
+    /// it is correctly rounded.
+    ///
+    /// Geometry: a stroke wide enough to cover the whole surface, so a corner
+    /// pixel is inside the stroked band and outside the clip. The stroke is
+    /// centred on the surface so it cannot coincide with the clip's own
+    /// boundary — a stroke that merely traced the clip would leave the corner
+    /// unpainted with no clip support at all.
+    ///
+    /// Reverted (drop the clip uniform from the tessellated draw, or the
+    /// `clipAlpha` call in `shape.wgsl`): the corner is painted and this fails.
+    #[test]
+    fn a_rounded_clip_rounds_tessellated_geometry() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        const R: f32 = 40.0;
+        let full = flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            full,
+            Pixels(R),
+        ));
+        // A stroke this wide covers the surface, corners included. `Paint`
+        // with a Stroke style routes through the tessellator, not the
+        // instanced rect path.
+        painter.rect(
+            flui_types::Rect::from_xywh(
+                Pixels(SURFACE_WIDTH as f32 / 2.0),
+                Pixels(SURFACE_HEIGHT as f32 / 2.0),
+                Pixels(1.0),
+                Pixels(1.0),
+            ),
+            &Paint::stroke(Color::rgb(0, 0, 255), SURFACE_WIDTH as f32 * 2.0),
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Tess Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        let centre = at(w / 2, SURFACE_HEIGHT as usize / 2);
+        assert!(
+            centre[2] > 200,
+            "precondition: the stroke must paint inside the clip; got {centre:?}"
+        );
+
+        let corner = at(3, 3);
+        assert!(
+            corner[3] < 32,
+            "a rounded clip must round tessellated geometry inside it; corner \
+             rgba={corner:?} — the stroke received only the clip's bounding scissor"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3549,6 +3549,95 @@ mod gpu_tests {
         );
     }
 
+    /// A tessellated draw that routes through the SSAA tile still honours its
+    /// clip.
+    ///
+    /// `render_ssaa_path` rebases vertex positions into tile-local 2x space, so
+    /// the `world_pos` the fragment stage sees is tile-local while the batch's
+    /// SDF clip is in full-frame device space. Left unremapped the shader
+    /// compares the two and the clip lands somewhere else entirely. Same shape
+    /// as the grown-offscreen bug on circles, a different rebasing seam.
+    ///
+    /// `BlendMode::Plus` is tile-safe and not SrcOver, so a draw above the
+    /// 256 px² area threshold takes the SSAA route rather than the direct one.
+    ///
+    /// The geometry sits AWAY from the origin on purpose: a tile whose origin
+    /// is (0, 0) at scale 1 makes the remap an identity and the test would pass
+    /// with no remap at all.
+    #[test]
+    fn an_ssaa_tiled_draw_honours_its_clip() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Bottom-right region of a 128x128 surface, heavily rounded.
+        let region =
+            flui_types::Rect::from_xywh(Pixels(48.0), Pixels(48.0), Pixels(80.0), Pixels(80.0));
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            region,
+            Pixels(40.0),
+        ));
+        // A FILL, and a large one: the SSAA gate reads the rect's own area
+        // (80x80 = 6400 px², over the 256 px² threshold), not the painted
+        // area — a hairline rect with a huge stroke width stays under it and
+        // silently takes the direct path instead.
+        painter.rect(
+            region,
+            &Paint::fill(Color::rgb(0, 0, 255))
+                .with_blend_mode(flui_types::painting::BlendMode::Plus),
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("SSAA Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        let centre = at(88, 88);
+        assert!(
+            centre[2] > 200,
+            "precondition: the fill must paint inside the clip; got {centre:?}"
+        );
+
+        // Top-left of the region, inside the rounded clip: cut away.
+        let corner = at(52, 52);
+        assert!(
+            corner[3] < 32,
+            "the clip's rounded corner must still cut; got rgba={corner:?}"
+        );
+
+        // THE discriminating sample. The tile is `origin=(48, 48)`,
+        // `scale=1.6`, so this pixel is tile-local (20, 64):
+        //
+        //   remapped clip   → bounds (0, 0, 128, 128), radii 64  → inside
+        //   full-frame clip → bounds (48, 48, 80, 80), radii 40  → outside
+        //
+        // Most sample points agree between the two — the corner above is
+        // clipped either way — so an assertion placed anywhere else passes
+        // with the remap deleted.
+        let discriminating = at(60, 88);
+        assert!(
+            discriminating[2] > 200,
+            "an SSAA-tiled draw's clip must be remapped into tile space; \
+             rgba={discriminating:?} at a pixel the correctly-remapped clip \
+             keeps — its clip was left in full-frame coordinates while its \
+             vertices were rebased to the tile"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3392,6 +3392,84 @@ mod gpu_tests {
         );
     }
 
+    /// A rounded clip actually rounds a gradient fill.
+    ///
+    /// The same gap circles had, one primitive over: the gradient instances did
+    /// not implement `ClippableInstance`, so a gradient received only the
+    /// clip's axis-aligned bounding scissor and a `ClipRRect` around a gradient
+    /// card left square corners.
+    ///
+    /// The geometry avoids the coincide-with-the-clip trap: the gradient is
+    /// drawn with SQUARE corners over the whole surface, so a sampled corner
+    /// pixel is inside the drawn shape and outside the clip. A gradient whose
+    /// own `corner_radius` matched the clip would pass with no clip support at
+    /// all.
+    ///
+    /// Reverted (drop `apply_active_clip` at the gradient record sites, or the
+    /// `clipAlpha` call in the gradient shaders): the corner is painted and
+    /// this fails.
+    #[test]
+    fn a_rounded_clip_rounds_a_gradient() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        const R: f32 = 40.0;
+        let full = flui_types::Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            full,
+            Pixels(R),
+        ));
+        painter.gradient_rect(
+            full,
+            glam::Vec2::new(0.0, 0.0),
+            glam::Vec2::new(0.0, SURFACE_HEIGHT as f32),
+            &[
+                crate::wgpu::effects::GradientStop::start(Color::rgb(0, 0, 255)),
+                crate::wgpu::effects::GradientStop::end(Color::rgb(0, 0, 255)),
+            ],
+            // Square corners: the clip, not the shape, is what must round this.
+            0.0,
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Gradient Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        let centre = at(w / 2, SURFACE_HEIGHT as usize / 2);
+        assert!(
+            centre[2] > 200,
+            "precondition: the gradient must paint inside the clip; got {centre:?}"
+        );
+
+        let corner = at(3, 3);
+        assert!(
+            corner[3] < 32,
+            "a rounded clip must round the gradient inside it; corner rgba={corner:?} \
+             — the gradient received only the clip's bounding scissor"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/batches/gradients.rs
+++ b/crates/flui-engine/src/wgpu/batches/gradients.rs
@@ -106,6 +106,7 @@ impl DrawBatcher {
             stop_count as u32,
         )
         .with_stop_offset(stop_offset);
+        let instance = state.apply_active_clip(instance);
 
         let _ = segment.linear_gradient_batch.add(instance);
         DrawSegment::push_scissor_region(
@@ -198,6 +199,7 @@ impl DrawBatcher {
             stop_count as u32,
         )
         .with_stop_offset(stop_offset);
+        let instance = state.apply_active_clip(instance);
 
         let _ = segment.radial_gradient_batch.add(instance);
         DrawSegment::push_scissor_region(
@@ -293,6 +295,7 @@ impl DrawBatcher {
             stop_count as u32,
         )
         .with_stop_offset(stop_offset);
+        let instance = state.apply_active_clip(instance);
 
         let _ = segment.sweep_gradient_batch.add(instance);
         DrawSegment::push_scissor_region(&mut segment.sweep_grad_scissors, state.current_scissor());
@@ -421,6 +424,7 @@ impl DrawBatcher {
                         stop_count as u32,
                     )
                     .with_stop_offset(0);
+                    let instance = state.apply_active_clip(instance);
                     let _ = shape_segment.linear_gradient_batch.add(instance);
                     DrawSegment::push_scissor_region(
                         &mut shape_segment.linear_grad_scissors,
@@ -446,6 +450,7 @@ impl DrawBatcher {
                         stop_count as u32,
                     )
                     .with_stop_offset(0);
+                    let instance = state.apply_active_clip(instance);
                     let _ = shape_segment.radial_gradient_batch.add(instance);
                     DrawSegment::push_scissor_region(
                         &mut shape_segment.radial_grad_scissors,
@@ -477,6 +482,7 @@ impl DrawBatcher {
                         stop_count as u32,
                     )
                     .with_stop_offset(0);
+                    let instance = state.apply_active_clip(instance);
                     let _ = shape_segment.sweep_gradient_batch.add(instance);
                     DrawSegment::push_scissor_region(
                         &mut shape_segment.sweep_grad_scissors,

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -234,6 +234,7 @@ impl DrawBatcher {
             let device_bounds = vertices_aabb(&vertices);
 
             // Step 3: build an isolated DrawSegment containing only this shape.
+            let clip_for_isolated = state.active_clip();
             let mut shape_segment = DrawSegment::new();
             // Indices reference vertices[0..], so base_index = 0.
             shape_segment.vertices.extend_from_slice(&vertices);
@@ -249,6 +250,11 @@ impl DrawBatcher {
                 scissor: state.current_scissor(),
                 index_start: 0,
                 index_count: indices.len() as u32,
+                // The isolated shape carries the clip that was active when it
+                // was recorded — it renders into an offscreen at full-frame
+                // device coordinates, so the device-space clip still applies.
+                clip_rrect: clip_for_isolated.0,
+                clip_kind: clip_for_isolated.1,
             });
 
             draw_order.push(DrawItem::AdvancedShape(AdvancedShapeOp {
@@ -278,10 +284,21 @@ impl DrawBatcher {
 
         let index_count = indices.len() as u32;
 
-        if let Some(last) = segment.tess_batches.last_mut()
-            && last.pipeline_key == key
-            && last.scissor == state.current_scissor()
-        {
+        let (clip_rrect, clip_kind) = state.active_clip();
+        // Merging also requires the SAME clip: two different rounded clips can
+        // share one bounding scissor (same rect, different radii), and the
+        // batch's clip is what its draw binds.
+        #[expect(
+            clippy::float_cmp,
+            reason = "both sides are assigned bit-exact from the same state slot"
+        )]
+        let mergeable = segment.tess_batches.last().is_some_and(|last| {
+            last.pipeline_key == key
+                && last.scissor == state.current_scissor()
+                && last.clip_rrect == clip_rrect
+                && last.clip_kind == clip_kind
+        });
+        if mergeable && let Some(last) = segment.tess_batches.last_mut() {
             last.index_count += index_count;
         } else {
             segment.current_pipeline_key = Some(key);
@@ -290,6 +307,8 @@ impl DrawBatcher {
                 scissor: state.current_scissor(),
                 index_start,
                 index_count,
+                clip_rrect,
+                clip_kind,
             });
         }
 
@@ -348,6 +367,7 @@ impl DrawBatcher {
         // The internal pipeline is always SrcOver (alpha-blend): the geometry is
         // rendered into a transparent offscreen tile.  The SSAA blend mode is stored
         // in `SsaaPathOp::blend` and applied at composite time, not at raster time.
+        let clip_for_isolated = state.active_clip();
         let mut path_segment = DrawSegment::new();
         path_segment.vertices.extend_from_slice(vertices);
         path_segment.indices.extend(indices.iter().copied());
@@ -357,6 +377,8 @@ impl DrawBatcher {
             scissor: state.current_scissor(),
             index_start: 0,
             index_count: indices.len() as u32,
+            clip_rrect: clip_for_isolated.0,
+            clip_kind: clip_for_isolated.1,
         });
 
         draw_order.push(DrawItem::SsaaPath(SsaaPathOp {

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -368,6 +368,21 @@ pub(crate) struct ScissorRegion {
     pub(crate) count: u32,
 }
 
+/// The per-batch SDF clip, in the layout `shape.wgsl`'s `ClipUniform` expects.
+///
+/// `vec4` members because WGSL uniform layout aligns them to 16 bytes; the
+/// three arrays are the same values `TessellatedBatch` stores, regrouped.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub(crate) struct ClipUniform {
+    /// Device-space `[x, y, w, h]`.
+    pub(crate) bounds: [f32; 4],
+    /// `[tl, tr, br, bl]`.
+    pub(crate) radii: [f32; 4],
+    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
+    pub(crate) kind: [u32; 4],
+}
+
 /// A recorded batch of tessellated geometry sharing the same pipeline key.
 ///
 /// During a frame, each call to
@@ -385,6 +400,17 @@ pub(crate) struct TessellatedBatch {
     pub(crate) index_start: u32,
     /// Number of indices in this batch
     pub(crate) index_count: u32,
+    /// Device-space rounded-rect clip active when this batch was recorded:
+    /// `[x, y, w, h, tl, tr, br, bl]`, all-zero meaning "no clip".
+    ///
+    /// Tessellated geometry carries no per-instance slot — there are no
+    /// instances, only vertices — so the clip lives on the batch and is bound
+    /// as a uniform for its draw. The batch is the right granularity because
+    /// `add_tessellated_with_key` only merges into the previous batch when the
+    /// pipeline key AND the clip both match.
+    pub(crate) clip_rrect: [f32; 8],
+    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
+    pub(crate) clip_kind: [u32; 4],
 }
 
 // ─── Offscreen / layer snapshots ─────────────────────────────────────────────

--- a/crates/flui-engine/src/wgpu/effects.rs
+++ b/crates/flui-engine/src/wgpu/effects.rs
@@ -70,6 +70,20 @@ pub struct LinearGradientInstance {
     pub stop_count: u32,
     /// Offset into the shared gradient stops buffer
     pub stop_offset: u32,
+    /// Device-space rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
+    ///
+    /// All-zero means "no clip". Attached by `apply_active_clip`, evaluated per
+    /// pixel by the shader against `world_pos`. The scissor alone can only
+    /// express the clip's axis-aligned bounding box, which leaves square
+    /// corners on a `ClipRRect`.
+    ///
+    /// Placed BEFORE the trailing padding field on purpose: `desc()` builds its
+    /// attribute offsets with `vertex_attr_array!`, which lays attributes out
+    /// contiguously and knows nothing about padding fields. A clip slot after
+    /// the padding would be read 8 bytes early.
+    pub clip_rrect: [f32; 8],
+    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
+    pub clip_kind: [u32; 4],
     /// Padding for GPU alignment
     pub padding: [u32; 2],
 }
@@ -91,6 +105,8 @@ impl LinearGradientInstance {
             stop_count: stop_count.min(8),
             stop_offset: 0,
             padding: [0; 2],
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -156,6 +172,20 @@ pub struct RadialGradientInstance {
     pub stop_count: u32,
     /// Offset into the shared gradient stops buffer
     pub stop_offset: u32,
+    /// Device-space rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
+    ///
+    /// All-zero means "no clip". Attached by `apply_active_clip`, evaluated per
+    /// pixel by the shader against `world_pos`. The scissor alone can only
+    /// express the clip's axis-aligned bounding box, which leaves square
+    /// corners on a `ClipRRect`.
+    ///
+    /// Placed BEFORE the trailing padding field on purpose: `desc()` builds its
+    /// attribute offsets with `vertex_attr_array!`, which lays attributes out
+    /// contiguously and knows nothing about padding fields. A clip slot after
+    /// the padding would be read 8 bytes early.
+    pub clip_rrect: [f32; 8],
+    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
+    pub clip_kind: [u32; 4],
     /// Padding for GPU alignment
     pub padding2: [u32; 2],
 }
@@ -178,6 +208,8 @@ impl RadialGradientInstance {
             stop_count: stop_count.min(8),
             stop_offset: 0,
             padding2: [0; 2],
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -220,6 +252,20 @@ pub struct SweepGradientInstance {
     pub stop_count: u32,
     /// Offset into the shared gradient stops buffer
     pub stop_offset: u32,
+    /// Device-space rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
+    ///
+    /// All-zero means "no clip". Attached by `apply_active_clip`, evaluated per
+    /// pixel by the shader against `world_pos`. The scissor alone can only
+    /// express the clip's axis-aligned bounding box, which leaves square
+    /// corners on a `ClipRRect`.
+    ///
+    /// Placed BEFORE the trailing padding field on purpose: `desc()` builds its
+    /// attribute offsets with `vertex_attr_array!`, which lays attributes out
+    /// contiguously and knows nothing about padding fields. A clip slot after
+    /// the padding would be read 8 bytes early.
+    pub clip_rrect: [f32; 8],
+    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
+    pub clip_kind: [u32; 4],
     /// Padding for GPU alignment
     pub padding: [u32; 2],
 }
@@ -242,6 +288,8 @@ impl SweepGradientInstance {
             stop_count: stop_count.min(8),
             stop_offset: 0,
             padding: [0; 2],
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -218,32 +218,13 @@ impl RectInstance {
     /// avg(bl_x,bl_y)]`.
     #[must_use]
     pub fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        // Exact equality against the bit-exact `[0.0; 12]` "no clip" sentinel.
+        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
         #[expect(
             clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
         )]
-        let is_empty = superellipse_clip == [0.0; 12];
-        if is_empty {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-            return self;
-        }
-        let tl = 0.5 * (superellipse_clip[4] + superellipse_clip[5]);
-        let tr = 0.5 * (superellipse_clip[6] + superellipse_clip[7]);
-        let br = 0.5 * (superellipse_clip[8] + superellipse_clip[9]);
-        let bl = 0.5 * (superellipse_clip[10] + superellipse_clip[11]);
-        self.clip_rrect = [
-            superellipse_clip[0],
-            superellipse_clip[1],
-            superellipse_clip[2],
-            superellipse_clip[3],
-            tl,
-            tr,
-            br,
-            bl,
-        ];
-        self.clip_kind = [2, 0, 0, 0];
+        let cleared = self.clip_rrect == [0.0; 8];
+        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
         self
     }
 
@@ -761,6 +742,35 @@ impl TextureInstance {
 /// of each batch re-deriving that branch order and drifting from the others.
 ///
 /// [`GpuStateStack::apply_active_clip`]: super::state_stack::GpuStateStack::apply_active_clip
+/// Reduce the 12-slot rounded-superellipse clip to the 8-slot form every
+/// clip-capable instance stores.
+///
+/// The 12-slot form carries `(rx, ry)` per corner; an instance slot holds one
+/// radius per corner, so each pair is averaged. This lived as six identical
+/// copies — one per `ClippableInstance` impl — before it was a function.
+///
+/// Returns the all-zero "no clip" sentinel unchanged.
+pub(crate) fn reduce_superellipse_clip(c: [f32; 12]) -> [f32; 8] {
+    #[expect(
+        clippy::float_cmp,
+        reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+    )]
+    let is_empty = c == [0.0; 12];
+    if is_empty {
+        return [0.0; 8];
+    }
+    [
+        c[0],
+        c[1],
+        c[2],
+        c[3],
+        0.5 * (c[4] + c[5]),
+        0.5 * (c[6] + c[7]),
+        0.5 * (c[8] + c[9]),
+        0.5 * (c[10] + c[11]),
+    ]
+}
+
 pub trait ClippableInstance {
     /// Attach a rounded-rect SDF clip (`clip_kind = 1`), or clear the clip
     /// when the slot is the all-zero "no clip" sentinel.
@@ -799,36 +809,13 @@ impl ClippableInstance for CircleInstance {
     }
 
     fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
         #[expect(
             clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
         )]
-        let is_empty = superellipse_clip == [0.0; 12];
-        if is_empty {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-            return self;
-        }
-        // Per-corner rx/ry averaged into one scalar, exactly as `RectInstance`
-        // does: the shared 8-float slot has room for one radius per corner, and
-        // `sdRoundedSuperellipse` takes one too. Elliptical corners therefore
-        // round to a circular approximation — a pre-existing divergence, kept
-        // identical here rather than given a second behaviour.
-        let tl = 0.5 * (superellipse_clip[4] + superellipse_clip[5]);
-        let tr = 0.5 * (superellipse_clip[6] + superellipse_clip[7]);
-        let br = 0.5 * (superellipse_clip[8] + superellipse_clip[9]);
-        let bl = 0.5 * (superellipse_clip[10] + superellipse_clip[11]);
-        self.clip_rrect = [
-            superellipse_clip[0],
-            superellipse_clip[1],
-            superellipse_clip[2],
-            superellipse_clip[3],
-            tl,
-            tr,
-            br,
-            bl,
-        ];
-        self.clip_kind = [2, 0, 0, 0];
+        let cleared = self.clip_rrect == [0.0; 8];
+        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
         self
     }
 }
@@ -853,30 +840,13 @@ impl ClippableInstance for LinearGradientInstance {
     }
 
     fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
         #[expect(
             clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
         )]
-        let no_clip = superellipse_clip == [0.0; 12];
-        if no_clip {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-            return self;
-        }
-        // The 12-slot form carries (rx, ry) per corner; this instance's slot
-        // holds one radius per corner, so average the pair — the same
-        // reduction `CircleInstance` applies.
-        self.clip_rrect = [
-            superellipse_clip[0],
-            superellipse_clip[1],
-            superellipse_clip[2],
-            superellipse_clip[3],
-            (superellipse_clip[4] + superellipse_clip[5]) * 0.5,
-            (superellipse_clip[6] + superellipse_clip[7]) * 0.5,
-            (superellipse_clip[8] + superellipse_clip[9]) * 0.5,
-            (superellipse_clip[10] + superellipse_clip[11]) * 0.5,
-        ];
-        self.clip_kind = [2, 0, 0, 0];
+        let cleared = self.clip_rrect == [0.0; 8];
+        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
         self
     }
 }
@@ -901,30 +871,13 @@ impl ClippableInstance for RadialGradientInstance {
     }
 
     fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
         #[expect(
             clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
         )]
-        let no_clip = superellipse_clip == [0.0; 12];
-        if no_clip {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-            return self;
-        }
-        // The 12-slot form carries (rx, ry) per corner; this instance's slot
-        // holds one radius per corner, so average the pair — the same
-        // reduction `CircleInstance` applies.
-        self.clip_rrect = [
-            superellipse_clip[0],
-            superellipse_clip[1],
-            superellipse_clip[2],
-            superellipse_clip[3],
-            (superellipse_clip[4] + superellipse_clip[5]) * 0.5,
-            (superellipse_clip[6] + superellipse_clip[7]) * 0.5,
-            (superellipse_clip[8] + superellipse_clip[9]) * 0.5,
-            (superellipse_clip[10] + superellipse_clip[11]) * 0.5,
-        ];
-        self.clip_kind = [2, 0, 0, 0];
+        let cleared = self.clip_rrect == [0.0; 8];
+        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
         self
     }
 }
@@ -949,30 +902,13 @@ impl ClippableInstance for SweepGradientInstance {
     }
 
     fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
         #[expect(
             clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
         )]
-        let no_clip = superellipse_clip == [0.0; 12];
-        if no_clip {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-            return self;
-        }
-        // The 12-slot form carries (rx, ry) per corner; this instance's slot
-        // holds one radius per corner, so average the pair — the same
-        // reduction `CircleInstance` applies.
-        self.clip_rrect = [
-            superellipse_clip[0],
-            superellipse_clip[1],
-            superellipse_clip[2],
-            superellipse_clip[3],
-            (superellipse_clip[4] + superellipse_clip[5]) * 0.5,
-            (superellipse_clip[6] + superellipse_clip[7]) * 0.5,
-            (superellipse_clip[8] + superellipse_clip[9]) * 0.5,
-            (superellipse_clip[10] + superellipse_clip[11]) * 0.5,
-        ];
-        self.clip_kind = [2, 0, 0, 0];
+        let cleared = self.clip_rrect == [0.0; 8];
+        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
         self
     }
 }
@@ -992,29 +928,13 @@ impl ClippableInstance for TextureInstance {
     }
 
     fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
         #[expect(
             clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
         )]
-        let is_empty = superellipse_clip == [0.0; 12];
-        if is_empty {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-            return self;
-        }
-        // Same per-corner rx/ry averaging as `RectInstance`, so both instance
-        // kinds approximate the squircle identically rather than in two ways.
-        self.clip_rrect = [
-            superellipse_clip[0],
-            superellipse_clip[1],
-            superellipse_clip[2],
-            superellipse_clip[3],
-            0.5 * (superellipse_clip[4] + superellipse_clip[5]),
-            0.5 * (superellipse_clip[6] + superellipse_clip[7]),
-            0.5 * (superellipse_clip[8] + superellipse_clip[9]),
-            0.5 * (superellipse_clip[10] + superellipse_clip[11]),
-        ];
-        self.clip_kind = [2, 0, 0, 0];
+        let cleared = self.clip_rrect == [0.0; 8];
+        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
         self
     }
 }

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -833,6 +833,150 @@ impl ClippableInstance for CircleInstance {
     }
 }
 
+impl ClippableInstance for LinearGradientInstance {
+    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
+        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
+        // `RectInstance` — the slot is assigned, never computed.
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
+        )]
+        let no_clip = clip == [0.0; 8];
+        if no_clip {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+        } else {
+            self.clip_rrect = clip;
+            self.clip_kind = [1, 0, 0, 0];
+        }
+        self
+    }
+
+    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+        )]
+        let no_clip = superellipse_clip == [0.0; 12];
+        if no_clip {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+            return self;
+        }
+        // The 12-slot form carries (rx, ry) per corner; this instance's slot
+        // holds one radius per corner, so average the pair — the same
+        // reduction `CircleInstance` applies.
+        self.clip_rrect = [
+            superellipse_clip[0],
+            superellipse_clip[1],
+            superellipse_clip[2],
+            superellipse_clip[3],
+            (superellipse_clip[4] + superellipse_clip[5]) * 0.5,
+            (superellipse_clip[6] + superellipse_clip[7]) * 0.5,
+            (superellipse_clip[8] + superellipse_clip[9]) * 0.5,
+            (superellipse_clip[10] + superellipse_clip[11]) * 0.5,
+        ];
+        self.clip_kind = [2, 0, 0, 0];
+        self
+    }
+}
+
+impl ClippableInstance for RadialGradientInstance {
+    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
+        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
+        // `RectInstance` — the slot is assigned, never computed.
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
+        )]
+        let no_clip = clip == [0.0; 8];
+        if no_clip {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+        } else {
+            self.clip_rrect = clip;
+            self.clip_kind = [1, 0, 0, 0];
+        }
+        self
+    }
+
+    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+        )]
+        let no_clip = superellipse_clip == [0.0; 12];
+        if no_clip {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+            return self;
+        }
+        // The 12-slot form carries (rx, ry) per corner; this instance's slot
+        // holds one radius per corner, so average the pair — the same
+        // reduction `CircleInstance` applies.
+        self.clip_rrect = [
+            superellipse_clip[0],
+            superellipse_clip[1],
+            superellipse_clip[2],
+            superellipse_clip[3],
+            (superellipse_clip[4] + superellipse_clip[5]) * 0.5,
+            (superellipse_clip[6] + superellipse_clip[7]) * 0.5,
+            (superellipse_clip[8] + superellipse_clip[9]) * 0.5,
+            (superellipse_clip[10] + superellipse_clip[11]) * 0.5,
+        ];
+        self.clip_kind = [2, 0, 0, 0];
+        self
+    }
+}
+
+impl ClippableInstance for SweepGradientInstance {
+    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
+        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
+        // `RectInstance` — the slot is assigned, never computed.
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
+        )]
+        let no_clip = clip == [0.0; 8];
+        if no_clip {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+        } else {
+            self.clip_rrect = clip;
+            self.clip_kind = [1, 0, 0, 0];
+        }
+        self
+    }
+
+    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+        )]
+        let no_clip = superellipse_clip == [0.0; 12];
+        if no_clip {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+            return self;
+        }
+        // The 12-slot form carries (rx, ry) per corner; this instance's slot
+        // holds one radius per corner, so average the pair — the same
+        // reduction `CircleInstance` applies.
+        self.clip_rrect = [
+            superellipse_clip[0],
+            superellipse_clip[1],
+            superellipse_clip[2],
+            superellipse_clip[3],
+            (superellipse_clip[4] + superellipse_clip[5]) * 0.5,
+            (superellipse_clip[6] + superellipse_clip[7]) * 0.5,
+            (superellipse_clip[8] + superellipse_clip[9]) * 0.5,
+            (superellipse_clip[10] + superellipse_clip[11]) * 0.5,
+        ];
+        self.clip_kind = [2, 0, 0, 0];
+        self
+    }
+}
+
 impl ClippableInstance for TextureInstance {
     fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
         self.clip_rrect = clip;
@@ -902,6 +1046,12 @@ impl LinearGradientInstance {
             6 => Uint32,
             // Stop offset (location 7)
             7 => Uint32,
+            // Clip bounds [x, y, w, h] (location 8)
+            8 => Float32x4,
+            // Clip corner radii [tl, tr, br, bl] (location 9)
+            9 => Float32x4,
+            // Clip kind (location 10)
+            10 => Uint32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -932,6 +1082,12 @@ impl RadialGradientInstance {
             6 => Uint32,
             // Stop offset (location 7)
             7 => Uint32,
+            // Clip bounds [x, y, w, h] (location 8)
+            8 => Float32x4,
+            // Clip corner radii [tl, tr, br, bl] (location 9)
+            9 => Float32x4,
+            // Clip kind (location 10)
+            10 => Uint32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -966,6 +1122,12 @@ impl SweepGradientInstance {
             6 => Uint32,
             // Stop offset (location 7)
             7 => Uint32,
+            // Clip bounds [x, y, w, h] (location 8)
+            8 => Float32x4,
+            // Clip corner radii [tl, tr, br, bl] (location 9)
+            9 => Float32x4,
+            // Clip kind (location 10)
+            10 => Uint32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -1327,25 +1489,73 @@ mod tests {
         assert_eq!(instance.clip_rrect[7], 9.0);
     }
 
+    /// The instance stride the vertex layout advertises must be the struct's
+    /// real size.
+    ///
+    /// `desc()` writes `array_stride: size_of::<Self>()` while
+    /// `vertex_attr_array!` computes each attribute's offset by summing the
+    /// declared attribute sizes — two independent numbers that agree only
+    /// while the clip slots sit before the trailing padding. Reordering them
+    /// after it makes the GPU read every clip 8 bytes early with no
+    /// compile error; these totals are what makes that reordering fail here.
     #[test]
     fn test_gradient_instance_sizes() {
+        // Shared by all three: clip_rrect[8]=32  clip_kind[4u32]=16 → 48 bytes
+        // of clip, placed before the trailing padding.
+
         // LinearGradientInstance:
         //   bounds[4]=16  gradient_start[2]=8  gradient_end[2]=8
-        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4  padding[2u32]=8
-        //   Total: 64 bytes
-        assert_eq!(std::mem::size_of::<LinearGradientInstance>(), 64);
+        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4
+        //   clip=48  padding[2u32]=8
+        //   Total: 112 bytes
+        assert_eq!(std::mem::size_of::<LinearGradientInstance>(), 112);
 
         // RadialGradientInstance:
         //   bounds[4]=16  center[2]=8  radius(f32)=4  padding1(f32)=4
-        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4  padding2[2u32]=8
-        //   Total: 64 bytes
-        assert_eq!(std::mem::size_of::<RadialGradientInstance>(), 64);
+        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4
+        //   clip=48  padding2[2u32]=8
+        //   Total: 112 bytes
+        assert_eq!(std::mem::size_of::<RadialGradientInstance>(), 112);
 
         // SweepGradientInstance:
         //   bounds[4]=16  center[2]=8  angles[2]=8
-        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4  padding[2u32]=8
-        //   Total: 64 bytes
-        assert_eq!(std::mem::size_of::<SweepGradientInstance>(), 64);
+        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4
+        //   clip=48  padding[2u32]=8
+        //   Total: 112 bytes
+        assert_eq!(std::mem::size_of::<SweepGradientInstance>(), 112);
+    }
+
+    /// The clip attributes must be reachable within the advertised stride.
+    ///
+    /// `vertex_attr_array!` lays attributes out contiguously from offset 0, so
+    /// the last clip attribute ends at 56 + 48 = 104. A struct whose clip
+    /// slots drifted after the padding would still be 112 bytes — the size
+    /// assertions above would pass — but the shader would read the padding as
+    /// clip bounds. Pinning the layout's own numbers is what distinguishes the
+    /// two.
+    #[test]
+    fn gradient_clip_attributes_fit_before_the_padding() {
+        for (name, layout) in [
+            ("linear", LinearGradientInstance::desc()),
+            ("radial", RadialGradientInstance::desc()),
+            ("sweep", SweepGradientInstance::desc()),
+        ] {
+            let clip_kind = layout
+                .attributes
+                .iter()
+                .find(|a| a.shader_location == 10)
+                .unwrap_or_else(|| panic!("{name}: no clip_kind attribute at location 10"));
+            assert_eq!(
+                clip_kind.offset, 88,
+                "{name}: clip_kind must start right after clip_rrect (56 + 32)"
+            );
+            assert!(
+                clip_kind.offset + 16 <= layout.array_stride,
+                "{name}: clip_kind ends at {} but the stride is {}",
+                clip_kind.offset + 16,
+                layout.array_stride
+            );
+        }
     }
 
     #[test]

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -201,7 +201,7 @@ impl GpuReplay {
     /// `fb_dim == viewport` and this remap would be the identity anyway. If that
     /// fallback gate ever admits images, their clips must be added here in the
     /// same change.
-    fn remap_segment_clips(
+    pub(super) fn remap_segment_clips(
         segment: &mut super::command_ir::DrawSegment,
         origin: (f32, f32),
         scale: (f32, f32),
@@ -211,6 +211,13 @@ impl GpuReplay {
         }
         for inst in &mut segment.circle_batch.instances {
             Self::remap_clip_rrect(&mut inst.clip_rrect, inst.clip_kind, origin, scale);
+        }
+        // Tessellated geometry carries its clip on the BATCH, not on instances
+        // — and unlike shadows/gradients/images it IS repositioned into a
+        // shrunken intermediate (`content_aabb` returns `Some` for a
+        // vertices-only segment), so it needs the remap just as much.
+        for batch in &mut segment.tess_batches {
+            Self::remap_clip_rrect(&mut batch.clip_rrect, batch.clip_kind, origin, scale);
         }
     }
 
@@ -1315,8 +1322,7 @@ mod grown_offscreen_clip_tests {
     use super::super::instancing::{CircleInstance, ClippableInstance, RectInstance};
     use flui_types::{Color, Point, Rect, geometry::Pixels};
 
-    /// A device-space clip attached to a circle is remapped into a grown
-    /// offscreen exactly as the same clip on a rect is.
+    /// Every clip carrier is remapped into a grown offscreen the same way.
     ///
     /// `render_segment_to_grown_offscreen` rebases and scales instances into a
     /// filter intermediate that is smaller than the viewport. `clip_rrect` is in
@@ -1325,13 +1331,14 @@ mod grown_offscreen_clip_tests {
     /// rounded clip is displaced far enough to erase the filtered shape.
     ///
     /// The rect loop always did this inline; the circle loop did not, because
-    /// circles had no clip slot until they gained one. Asserting the two AGREE,
-    /// rather than asserting a literal, is what stops them drifting again.
+    /// circles had no clip slot until they gained one, and tessellated batches
+    /// arrived later still. Asserting they all AGREE, rather than asserting a
+    /// literal, is what stops the next carrier being forgotten.
     ///
-    /// Reverted (drop the `remap_segment_clips` circle loop): the circle keeps
-    /// full-frame bounds and this fails on the final `assert_eq!`.
+    /// Reverted (drop any one loop in `remap_segment_clips`): that carrier
+    /// keeps full-frame bounds and this fails on its `assert_eq!`.
     #[test]
-    fn a_circles_clip_is_remapped_like_a_rects() {
+    fn every_clip_carrier_is_remapped_the_same_way() {
         const ORIGIN: (f32, f32) = (40.0, 24.0);
         const SCALE: (f32, f32) = (0.5, 0.25);
         // [x, y, w, h, tl, tr, br, bl] in device space.
@@ -1360,6 +1367,16 @@ mod grown_offscreen_clip_tests {
         // `add` returns "batch is now full", not "succeeded".
         assert!(!segment.rect_batch.add(rect), "rect batch not full");
         assert!(!segment.circle_batch.add(circle), "circle batch not full");
+        segment
+            .tess_batches
+            .push(super::super::command_ir::TessellatedBatch {
+                pipeline_key: super::super::pipeline::PipelineKey::alpha_blend(),
+                scissor: None,
+                index_start: 0,
+                index_count: 3,
+                clip_rrect: CLIP,
+                clip_kind: [1, 0, 0, 0],
+            });
 
         super::GpuReplay::remap_segment_clips(&mut segment, ORIGIN, SCALE);
 
@@ -1368,6 +1385,12 @@ mod grown_offscreen_clip_tests {
         assert_ne!(
             remapped_rect, CLIP,
             "precondition: the remap actually changed the rect's clip"
+        );
+        assert_eq!(
+            segment.tess_batches[0].clip_rrect, remapped_rect,
+            "a tessellated batch's clip must be remapped like a rect's; it IS \
+             repositioned into the shrunken intermediate, unlike gradients and \
+             images, which `content_aabb` keeps out of that path"
         );
         assert_eq!(
             remapped_circle, remapped_rect,

--- a/crates/flui-engine/src/wgpu/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/pipeline.rs
@@ -273,6 +273,12 @@ pub struct PipelineCache {
 
     /// Viewport bind group layout (for coordinate transformation)
     viewport_bind_group_layout: wgpu::BindGroupLayout,
+
+    /// Per-batch SDF clip bind group layout (group 1).
+    ///
+    /// Owned here rather than passed in, because every pipeline this cache
+    /// builds uses it and there is exactly one shader module behind them all.
+    clip_bind_group_layout: wgpu::BindGroupLayout,
 }
 
 impl PipelineCache {
@@ -294,11 +300,27 @@ impl PipelineCache {
             source: wgpu::ShaderSource::Wgsl(shader_source.into()),
         });
 
+        let clip_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Tessellated Clip Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
         Self {
             cache: HashMap::new(),
             shader,
             format,
             viewport_bind_group_layout,
+            clip_bind_group_layout,
         }
     }
 
@@ -339,7 +361,10 @@ impl PipelineCache {
         // Create layout with viewport bind group
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Shape Pipeline Layout"),
-            bind_group_layouts: &[Some(&self.viewport_bind_group_layout)],
+            bind_group_layouts: &[
+                Some(&self.viewport_bind_group_layout),
+                Some(&self.clip_bind_group_layout),
+            ],
             immediate_size: 0,
         });
 
@@ -404,6 +429,12 @@ impl PipelineCache {
     /// exact same layout object that the pipeline expects.
     pub fn viewport_bind_group_layout(&self) -> &wgpu::BindGroupLayout {
         &self.viewport_bind_group_layout
+    }
+
+    /// The per-batch SDF clip bind-group layout (group 1) every tessellated
+    /// draw binds against.
+    pub fn clip_bind_group_layout(&self) -> &wgpu::BindGroupLayout {
+        &self.clip_bind_group_layout
     }
 }
 

--- a/crates/flui-engine/src/wgpu/replay/flush.rs
+++ b/crates/flui-engine/src/wgpu/replay/flush.rs
@@ -589,6 +589,47 @@ impl GpuReplay {
             return;
         }
 
+        // Build every batch's clip bind group BEFORE the vertex/index buffers.
+        //
+        // Two reasons it cannot happen inside the loop: `alloc` needs the
+        // resources borrow that the vertex/index buffers below hold for the
+        // rest of this function, and the pool hands out a buffer that must
+        // stay distinct for the whole submit — every tessellated batch lands
+        // in ONE submit, so a reused buffer would give them all the last clip
+        // written.
+        let clip_bind_groups: Vec<wgpu::BindGroup> = segment
+            .tess_batches
+            .iter()
+            .map(|batch| {
+                let uniform = super::super::command_ir::ClipUniform {
+                    bounds: [
+                        batch.clip_rrect[0],
+                        batch.clip_rrect[1],
+                        batch.clip_rrect[2],
+                        batch.clip_rrect[3],
+                    ],
+                    radii: [
+                        batch.clip_rrect[4],
+                        batch.clip_rrect[5],
+                        batch.clip_rrect[6],
+                        batch.clip_rrect[7],
+                    ],
+                    kind: batch.clip_kind,
+                };
+                let buffer = resources
+                    .uniform_pool_mut()
+                    .alloc(bytemuck::bytes_of(&uniform));
+                device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("Tessellated Clip Bind Group"),
+                    layout: pipelines.shape_cache_mut().clip_bind_group_layout(),
+                    entries: &[wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: buffer.as_entire_binding(),
+                    }],
+                })
+            })
+            .collect();
+
         let (vertex_buffer, index_buffer) =
             resources.buffer_pool_mut().get_vertex_and_index_buffers(
                 device,
@@ -636,7 +677,7 @@ impl GpuReplay {
         render_pass.set_viewport(0.0, 0.0, full_w as f32, full_h as f32, 0.0, 1.0);
 
         let mut active_key: Option<PipelineKey> = None;
-        for batch in &segment.tess_batches {
+        for (batch, clip_bind_group) in segment.tess_batches.iter().zip(&clip_bind_groups) {
             if active_key != Some(batch.pipeline_key) {
                 // `pipelines` and `device` are disjoint from the encoder/render_pass
                 // borrows — no borrow conflict.
@@ -652,6 +693,8 @@ impl GpuReplay {
                 // remap's off-target sentinel) — nothing to draw for this batch.
                 continue;
             }
+
+            render_pass.set_bind_group(1, clip_bind_group, &[]);
 
             let start = batch.index_start;
             let end = start + batch.index_count;

--- a/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
@@ -220,28 +220,8 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let aa = length(vec2<f32>(dpdx(d), dpdy(d))) * 0.5;
     let alpha = 1.0 - smoothstep(-aa, aa, d);
 
-    // --- SDF Clip Test ---
-    // Identical to `rect_instanced.wgsl`: the clip_bounds + clip_radii slot is
-    // shared between clip kinds and the flat `clip_kind` selects the SDF. Kept
-    // byte-for-byte the same shape as the rect path so the two cannot drift —
-    // circles previously received only the clip's bounding scissor, leaving an
-    // avatar inside a `ClipRRect` with square corners.
-    var clip_alpha = 1.0;
-    if (in.clip_kind != 0u && in.clip_bounds.z > 0.0 && in.clip_bounds.w > 0.0) {
-        let clip_center = in.clip_bounds.xy + in.clip_bounds.zw * 0.5;
-        let clip_p = in.world_pos - clip_center;
-        let clip_half = in.clip_bounds.zw * 0.5;
-
-        var clip_dist = 0.0;
-        if (in.clip_kind == 2u) {
-            clip_dist = sdRoundedSuperellipse(clip_p, clip_half, in.clip_radii);
-        } else {
-            // clip_kind == 1u (rrect), and the safe default for any kind this
-            // shader has not learned about.
-            clip_dist = sdRoundedBox(clip_p, clip_half, in.clip_radii);
-        }
-        clip_alpha = sdfToAlpha(clip_dist);
-    }
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
 
     let final_alpha = alpha * clip_alpha;
 

--- a/crates/flui-engine/src/wgpu/shaders/common/clip.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/common/clip.wgsl
@@ -62,3 +62,39 @@ fn sdfToAlpha(dist: f32) -> f32 {
     let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
     return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
+
+/// Coverage from the per-instance SDF clip; 1.0 when no clip is attached.
+///
+/// `clip_bounds` is `[x, y, w, h]` in DEVICE space and `clip_radii` is
+/// `[tl, tr, br, bl]`, matching the instance slot the Rust side fills via
+/// `ClippableInstance`. `clip_kind` selects the distance function: 0 = none,
+/// 2 = rounded superellipse, anything else = rounded rect (the safe default
+/// for a kind this shader has not learned about yet).
+///
+/// The whole evaluation lives here rather than being pasted into each
+/// fragment shader for the same reason the distance functions do: every
+/// clip-capable primitive must agree on what a clip means, and a pasted copy
+/// is free to disagree silently.
+fn clipAlpha(
+    world_pos: vec2<f32>,
+    clip_bounds: vec4<f32>,
+    clip_radii: vec4<f32>,
+    clip_kind: u32,
+) -> f32 {
+    var alpha = 1.0;
+    if (clip_kind != 0u && clip_bounds.z > 0.0 && clip_bounds.w > 0.0) {
+        let clip_center = clip_bounds.xy + clip_bounds.zw * 0.5;
+        let clip_p = world_pos - clip_center;
+        let clip_half = clip_bounds.zw * 0.5;
+
+        var clip_dist = 0.0;
+        if (clip_kind == 2u) {
+            clip_dist = sdRoundedSuperellipse(clip_p, clip_half, clip_radii);
+        } else {
+            clip_dist = sdRoundedBox(clip_p, clip_half, clip_radii);
+        }
+
+        alpha = sdfToAlpha(clip_dist);
+    }
+    return alpha;
+}

--- a/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
@@ -22,6 +22,9 @@ struct InstanceInput {
     @location(5) corner_radii: vec4<f32>,   // [tl, tr, br, bl] for clipping
     @location(6) stop_count: u32,           // Number of gradient stops (1-8)
     @location(7) stop_offset: u32,          // Offset into gradient stops buffer
+    @location(8) clip_bounds: vec4<f32>,    // Device-space [x, y, w, h]
+    @location(9) clip_radii: vec4<f32>,     // [tl, tr, br, bl]
+    @location(10) clip_kind: vec4<u32>,     // [kind, _, _, _]
 }
 
 // Gradient stop definition
@@ -44,6 +47,9 @@ struct VertexOutput {
     @location(5) corner_radii: vec4<f32>,
     @location(6) @interpolate(flat) stop_count: u32,
     @location(7) @interpolate(flat) stop_offset: u32,
+    @location(8) clip_bounds: vec4<f32>,
+    @location(9) clip_radii: vec4<f32>,
+    @location(10) @interpolate(flat) clip_kind: u32,
 }
 
 // Uniforms
@@ -134,6 +140,9 @@ fn vs_main(
     out.corner_radii = instance.corner_radii;
     out.stop_count = instance.stop_count;
     out.stop_offset = instance.stop_offset;
+    out.clip_bounds = instance.clip_bounds;
+    out.clip_radii = instance.clip_radii;
+    out.clip_kind = instance.clip_kind.x;
 
     return out;
 }
@@ -171,7 +180,9 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     // Apply rounded corner alpha (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
-    color = vec4<f32>(color.rgb, color.a * alpha);
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    color = vec4<f32>(color.rgb, color.a * alpha * clip_alpha);
 
     return color;
 }

--- a/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
@@ -22,6 +22,9 @@ struct InstanceInput {
     @location(5) corner_radii: vec4<f32>,   // [tl, tr, br, bl]
     @location(6) stop_count: u32,
     @location(7) stop_offset: u32,          // Offset into gradient stops buffer
+    @location(8) clip_bounds: vec4<f32>,    // Device-space [x, y, w, h]
+    @location(9) clip_radii: vec4<f32>,     // [tl, tr, br, bl]
+    @location(10) clip_kind: vec4<u32>,     // [kind, _, _, _]
 }
 
 // Gradient stop (same as linear)
@@ -43,6 +46,12 @@ struct VertexOutput {
     @location(4) corner_radii: vec4<f32>,
     @location(5) @interpolate(flat) stop_count: u32,
     @location(6) @interpolate(flat) stop_offset: u32,
+    // Device-space position, carried only for the clip SDF. Linear
+    // already had one at location 0; these two did not.
+    @location(7) world_pos: vec2<f32>,
+    @location(8) clip_bounds: vec4<f32>,
+    @location(9) clip_radii: vec4<f32>,
+    @location(10) @interpolate(flat) clip_kind: u32,
 }
 
 // Uniforms
@@ -126,6 +135,10 @@ fn vs_main(
     out.corner_radii = instance.corner_radii;
     out.stop_count = instance.stop_count;
     out.stop_offset = instance.stop_offset;
+    out.world_pos = world_pos;
+    out.clip_bounds = instance.clip_bounds;
+    out.clip_radii = instance.clip_radii;
+    out.clip_kind = instance.clip_kind.x;
 
     return out;
 }
@@ -160,7 +173,9 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     // Apply corner clipping (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
-    color = vec4<f32>(color.rgb, color.a * alpha);
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    color = vec4<f32>(color.rgb, color.a * alpha * clip_alpha);
 
     return color;
 }

--- a/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
@@ -22,6 +22,9 @@ struct InstanceInput {
     @location(5) corner_radii: vec4<f32>,   // [tl, tr, br, bl]
     @location(6) stop_count: u32,
     @location(7) stop_offset: u32,          // Offset into gradient stops buffer
+    @location(8) clip_bounds: vec4<f32>,    // Device-space [x, y, w, h]
+    @location(9) clip_radii: vec4<f32>,     // [tl, tr, br, bl]
+    @location(10) clip_kind: vec4<u32>,     // [kind, _, _, _]
 }
 
 // Gradient stop (same layout as linear/radial)
@@ -43,6 +46,12 @@ struct VertexOutput {
     @location(4) corner_radii: vec4<f32>,
     @location(5) @interpolate(flat) stop_count: u32,
     @location(6) @interpolate(flat) stop_offset: u32,
+    // Device-space position, carried only for the clip SDF. Linear
+    // already had one at location 0; these two did not.
+    @location(7) world_pos: vec2<f32>,
+    @location(8) clip_bounds: vec4<f32>,
+    @location(9) clip_radii: vec4<f32>,
+    @location(10) @interpolate(flat) clip_kind: u32,
 }
 
 // Uniforms
@@ -126,6 +135,10 @@ fn vs_main(
     out.corner_radii = instance.corner_radii;
     out.stop_count = instance.stop_count;
     out.stop_offset = instance.stop_offset;
+    out.world_pos = world_pos;
+    out.clip_bounds = instance.clip_bounds;
+    out.clip_radii = instance.clip_radii;
+    out.clip_kind = instance.clip_kind.x;
 
     return out;
 }
@@ -178,7 +191,9 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     // Apply corner clipping (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
-    color = vec4<f32>(color.rgb, color.a * alpha);
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    color = vec4<f32>(color.rgb, color.a * alpha * clip_alpha);
 
     return color;
 }

--- a/crates/flui-engine/src/wgpu/shaders/mod.rs
+++ b/crates/flui-engine/src/wgpu/shaders/mod.rs
@@ -17,7 +17,10 @@
 
 // Basic shapes
 /// Basic shape rendering shader.
-pub const SHAPE: &str = include_str!("shape.wgsl");
+///
+/// Prepended with the shared clip block: tessellated geometry evaluates the
+/// same SDF clip the instanced primitives do, from a per-batch uniform.
+pub const SHAPE: &str = concat!(include_str!("common/clip.wgsl"), include_str!("shape.wgsl"));
 
 // Instanced rendering
 //

--- a/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
@@ -169,28 +169,8 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // The L2 screen-space gradient automatically adjusts AA based on zoom level and pixel density
     let alpha = sdfToAlpha(dist);
 
-    // --- SDF Clip Test ---
-    // Branch on clip_kind: 0 = no clip, 1 = sdRoundedBox, 2 = sdRoundedSuperellipse.
-    // The clip_bounds + clip_radii slot is shared between clip kinds; the
-    // kind flag selects the SDF function. Per-instance flat interpolation
-    // keeps the branch divergence-free within a draw call.
-    var clip_alpha = 1.0;
-    if (in.clip_kind != 0u && in.clip_bounds.z > 0.0 && in.clip_bounds.w > 0.0) {
-        let clip_center = in.clip_bounds.xy + in.clip_bounds.zw * 0.5;
-        let clip_p = in.world_pos - clip_center;
-        let clip_half = in.clip_bounds.zw * 0.5;
-
-        var clip_dist = 0.0;
-        if (in.clip_kind == 2u) {
-            clip_dist = sdRoundedSuperellipse(clip_p, clip_half, in.clip_radii);
-        } else {
-            // clip_kind == 1u (rrect) — also the safe default for any
-            // future kind we haven't yet learned about.
-            clip_dist = sdRoundedBox(clip_p, clip_half, in.clip_radii);
-        }
-
-        clip_alpha = sdfToAlpha(clip_dist);
-    }
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
 
     // Return color with antialiased alpha, modulated by clip alpha
     return vec4<f32>(in.color.rgb, in.color.a * alpha * clip_alpha);

--- a/crates/flui-engine/src/wgpu/shaders/shape.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/shape.wgsl
@@ -12,6 +12,18 @@ struct Viewport {
 @group(0) @binding(0)
 var<uniform> viewport: Viewport;
 
+// Per-batch SDF clip. Tessellated geometry has no instances to hang a clip
+// slot on, so the clip is bound once per `TessellatedBatch` — the granularity
+// the batcher already splits at, since it refuses to merge across a clip change.
+struct ClipUniform {
+    bounds: vec4<f32>,  // Device-space [x, y, w, h]
+    radii: vec4<f32>,   // [tl, tr, br, bl]
+    kind: vec4<u32>,    // [kind, _, _, _]: 0 = none, 1 = rrect, 2 = rsuperellipse
+}
+
+@group(1) @binding(0)
+var<uniform> clip: ClipUniform;
+
 struct VertexInput {
     @location(0) position: vec2<f32>,  // Position in pixel coordinates
     @location(1) color: vec4<f32>,     // RGBA color [0-1]
@@ -21,6 +33,9 @@ struct VertexInput {
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) color: vec4<f32>,
+    // Device-space position, carried for the clip SDF. `clip_position` is in
+    // NDC by the time the fragment stage sees it, so it cannot serve here.
+    @location(1) world_pos: vec2<f32>,
 }
 
 @vertex
@@ -33,6 +48,7 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
     output.clip_position = vec4<f32>(clip_x, clip_y, 0.0, 1.0);
     output.color = input.color;
+    output.world_pos = input.position;
 
     return output;
 }
@@ -44,11 +60,13 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 // tessellated pipeline selects per `PipelineKey::blend_mode`. The default
 // SrcOver case pairs this with `BlendState::PREMULTIPLIED_ALPHA_BLENDING`
 // (src factor One), making it visually identical to the previous straight
-// `input.color` + `ALPHA_BLENDING` output. No clip/opacity factor is applied
-// to alpha in this shader, so premultiplying by `c.a` is the full final alpha.
+// `input.color` + `ALPHA_BLENDING` output. The batch clip is folded into alpha
+// BEFORE premultiplying, so `a` below is the full final alpha.
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let c = input.color;
-    return vec4<f32>(c.rgb * c.a, c.a);
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let a = c.a * clipAlpha(input.world_pos, clip.bounds, clip.radii, clip.kind.x);
+    return vec4<f32>(c.rgb * a, a);
 }

--- a/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
@@ -133,32 +133,8 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Apply tint (multiply)
     tex_color = tex_color * in.tint;
 
-    // --- SDF Clip Test ---
-    // Same branch order and kind encoding as `rect_instanced.wgsl`: the kind
-    // flag selects the SDF, the bounds+radii slot is shared between kinds, and
-    // flat interpolation keeps the branch uniform across the draw call.
-    //
-    // A circle is expressed here as radii of half the shorter side. Because
-    // this is a distance field rather than tessellated geometry, that is an
-    // exact circle at any scale — the ~6% diagonal bulge that rules out
-    // drrect for circular *geometry* does not apply to a clip.
-    var clip_alpha = 1.0;
-    if (in.clip_kind != 0u && in.clip_bounds.z > 0.0 && in.clip_bounds.w > 0.0) {
-        let clip_center = in.clip_bounds.xy + in.clip_bounds.zw * 0.5;
-        let clip_p = in.world_pos - clip_center;
-        let clip_half = in.clip_bounds.zw * 0.5;
-
-        var clip_dist = 0.0;
-        if (in.clip_kind == 2u) {
-            clip_dist = sdRoundedSuperellipse(clip_p, clip_half, in.clip_radii);
-        } else {
-            // clip_kind == 1u (rrect), and the safe default for a kind this
-            // shader has not learned about yet.
-            clip_dist = sdRoundedBox(clip_p, clip_half, in.clip_radii);
-        }
-
-        clip_alpha = sdfToAlpha(clip_dist);
-    }
+    // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
+    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
 
     tex_color.a = tex_color.a * clip_alpha;
 

--- a/crates/flui-engine/src/wgpu/ssaa.rs
+++ b/crates/flui-engine/src/wgpu/ssaa.rs
@@ -460,6 +460,17 @@ impl GpuReplay {
             v.position[1] = (v.position[1] - tile_origin_y) * scale_y;
         }
 
+        // The vertices above just became tile-local, so `world_pos` in the
+        // fragment stage is tile-local too — and a tessellated batch's SDF clip
+        // is in FULL-FRAME device space. Left alone it would be compared
+        // against the wrong coordinates and displace or erase the path. Same
+        // remap, same helper as the grown-offscreen path.
+        Self::remap_segment_clips(
+            &mut remapped_segment,
+            (tile_origin_x, tile_origin_y),
+            (scale_x, scale_y),
+        );
+
         // ── Scissor remap: full-frame → tile-local 2× space ─────────────────
         //
         // The `tess_batches` scissor was captured at record time in full-frame

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -643,29 +643,53 @@ impl GpuStateStack {
     // SDF clip application
     // =========================================================================
 
-    /// Apply the currently-active SDF clip (rrect or rsuperellipse) to a
-    /// `RectInstance`.
+    /// The currently-active SDF clip, resolved to the single form every
+    /// consumer stores: `([x, y, w, h, tl, tr, br, bl], [kind, _, _, _])`.
     ///
-    /// Branch order: if `current_rsuperellipse_clip` is non-trivial the
-    /// superellipse clip wins (`clip_kind = 2`). Otherwise the rrect slot is
-    /// used (`clip_kind = 1` when non-zero, `clip_kind = 0` when both are zero).
+    /// Branch order: a non-trivial `current_rsuperellipse_clip` wins
+    /// (`kind = 2`), otherwise the rrect slot is used (`kind = 1` when
+    /// non-zero, `kind = 0` when both are zero).
     ///
-    /// Centralises the per-instance clip-kind selection so the two
-    /// `rect`/`rrect` batch-build sites do not drift apart.
+    /// This is the ONE place that selection happens. Instanced primitives
+    /// reach it through `apply_active_clip`; tessellated geometry, which has
+    /// no instance to hang a slot on, reads it directly for its batch uniform.
+    pub(super) fn active_clip(&self) -> ([f32; 8], [u32; 4]) {
+        // Exact equality against the all-zero "no clip active" sentinel is
+        // intentional: the field is set bit-exact to `[0.0; 12]` whenever the
+        // clip is cleared, never via arithmetic that would introduce ULP noise.
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact 'no clip' sentinels"
+        )]
+        let superellipse_active = self.current_rsuperellipse_clip != [0.0; 12];
+        if superellipse_active {
+            return (
+                super::instancing::reduce_superellipse_clip(self.current_rsuperellipse_clip),
+                [2, 0, 0, 0],
+            );
+        }
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact 'no clip' sentinels"
+        )]
+        let rrect_active = self.current_rrect_clip != [0.0; 8];
+        if rrect_active {
+            (self.current_rrect_clip, [1, 0, 0, 0])
+        } else {
+            ([0.0; 8], [0; 4])
+        }
+    }
+
+    /// Apply the currently-active SDF clip to an instance.
+    ///
+    /// Delegates the selection to [`Self::active_clip`] so the instanced and
+    /// tessellated paths cannot disagree about which clip is in force.
     pub(super) fn apply_active_clip<I: super::instancing::ClippableInstance>(
         &self,
         instance: I,
     ) -> I {
-        // Exact equality against the all-zero "no clip active" sentinel is
-        // intentional: the field is set bit-exact to `[0.0; 12]` whenever
-        // the clip is cleared, never via arithmetic that would introduce
-        // ULP noise.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
-        )]
-        let superellipse_active = self.current_rsuperellipse_clip != [0.0; 12];
-        if superellipse_active {
+        let (_, kind) = self.active_clip();
+        if kind[0] == 2 {
             instance.with_clip_rsuperellipse(self.current_rsuperellipse_clip)
         } else {
             instance.with_clip_rrect(self.current_rrect_clip)


### PR DESCRIPTION
Finishes clip coverage. After #746 (circles/ovals) and #747 (the shared block), two carriers were still clipped only by their bounding scissor: gradients and tessellated geometry. A `ClipRRect` around a gradient card or a stroked border left square corners while the rrect fill beside it was correctly rounded.

Three commits.

## 1. Gradients honour the active SDF clip

All three gradient instances gain the clip slot, their shaders read it, and the six record sites attach the active clip.

The slot sits **before** each struct's trailing padding on purpose: `desc()` advertises `size_of::<Self>()` as the stride while `vertex_attr_array!` computes attribute offsets by summing the declared attributes, and the two agree only in that order. A slot after the padding is read 8 bytes early with no compile error — so a second test pins the layout's own offsets rather than just the struct size.

`radial.wgsl` and `sweep.wgsl` had no `world_pos` in their `VertexOutput` (only `linear.wgsl` did) and now carry one.

## 2. Tessellated geometry honours the active SDF clip

Strokes and path fills never reach the instanced path — lyon tessellates them and `shape.wgsl` draws them — so there are no instances to hang a clip slot on. The clip lives on `TessellatedBatch` and is bound as a uniform per draw. That is the right granularity because the batcher already refuses to merge across a pipeline or scissor change; the merge predicate now also compares the clip, since two different rounded clips can share one bounding scissor (same rect, different radii).

Bind groups are built before the vertex/index buffers rather than inside the draw loop: `alloc` needs the resources borrow those buffers hold, and every tessellated batch lands in ONE submit, so a reused uniform buffer would give them all the last clip written.

**Two coordinate-space seams had to follow**, both the shape of the bug Codex caught on circles in #746 — geometry rebased, device-space clip not:

- the grown filter offscreen, where `content_aabb` returns `Some` for a vertices-only segment, so tessellated geometry *is* repositioned (unlike gradients, shadows, and images, which that gate keeps out);
- the SSAA tile, which rebases vertex positions into tile-local 2× space.

The drift test is renamed and widened to assert every clip carrier is remapped identically, so the next carrier added cannot be silently forgotten. Reverting any one loop fails it.

Along the way two rules that were duplicated became functions: the 12-slot→8-slot superellipse reduction had six identical copies (one per `ClippableInstance` impl) and tessellation would have been a seventh; clip *selection* is now `GpuStateStack::active_clip`, which the instanced and tessellated paths both read, so they cannot disagree about which clip is in force.

## 3. Pinning the SSAA remap

The SSAA remap in commit 2 had no test — deleting the call failed nothing, which is exactly the defect class this series is about. Two things had to be right before a test could see it, and both were wrong on my first attempt:

- The SSAA gate reads the **rect's** area, not the painted area. A 1×1 rect with a 160-wide stroke stays under the 256 px² threshold and silently takes the direct path.
- Almost every sample point agrees between the remapped and full-frame clips. With `tile_origin=(48, 48)`, `scale=1.6`, the region's own corner is cut either way — an assertion there passes with the remap deleted. The pinned pixel is tile-local (20, 64), which the remapped clip keeps and the full-frame clip rejects, and the comment records why that point so a later edit does not casually move it.

Reverted, it reads `rgba=[0, 0, 0, 0]` where the fill should be.

## Evidence

Every new oracle was confirmed red before the fix and re-confirmed by reverting the specific line:

| Oracle | Reverted |
|---|---|
| `a_rounded_clip_rounds_a_gradient` | `apply_active_clip` at the gradient record sites → corner `rgba=[0,0,255,255]` |
| `a_rounded_clip_rounds_tessellated_geometry` | clip uniform → corner painted |
| `every_clip_carrier_is_remapped_the_same_way` | any one loop → `[60,44,200,120,…]` vs `[10,5,100,30,…]` |
| `an_ssaa_tiled_draw_honours_its_clip` | SSAA remap → `rgba=[0,0,0,0]` |

`cargo nextest run -p flui-engine --features enable-wgpu-tests` → 568 passed. Clippy clean in both invocations.

## Still not clipped

`clip_path` remains a documented no-op with a `tracing::warn!` — arbitrary path clipping needs a stencil pass, which is its own project, not a line in this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo