### PR TITLE
feat(engine): clips carry their own transform instead of device-space bounds

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3638,6 +3638,180 @@ mod gpu_tests {
         );
     }
 
+    /// A rotated `ClipRRect` clips to the rotated rounded rect, not to its
+    /// bounding box.
+    ///
+    /// The clip slot used to hold device-space bounds, which cannot express a
+    /// rotation: `clip_rrect` detected a non-axis-aligned CTM and fell back to
+    /// the coarse scissor. At 45° the scissor is the AABB of the rotated rect,
+    /// 41% larger per axis, so content leaked well outside the intended shape.
+    ///
+    /// The drawn rrect had already solved this — `RectInstance::with_affine_transform`
+    /// passes local bounds plus the affine and lets the shader do the work
+    /// (see `o4_rotated_rrect_correct_size_orientation_and_aa`). The clip now
+    /// carries the same information, inverted, so the fragment stage maps
+    /// `world_pos` back into clip-local space.
+    ///
+    /// Sample points, for a 80x80 clip at (24, 24) rotated 45° about the
+    /// surface centre (64, 64):
+    ///
+    /// - (64, 64) — the centre, inside under any interpretation. Paints, or
+    ///   the test would pass by drawing nothing.
+    /// - (14, 14) — inside the AABB of the rotated rect, OUTSIDE the rect
+    ///   itself. This is the discriminating sample: the scissor fallback
+    ///   paints it, a correct rotated clip does not.
+    ///
+    /// The point has to be near an AABB CORNER. The clip is rotated about its
+    /// own centre, so the AABB grows along the diagonals and a point pushed
+    /// straight out along an axis — (18, 64), say — is still inside the
+    /// rotated square and correctly painted either way.
+    #[test]
+    fn a_rotated_clip_follows_the_rotation() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.translate(flui_types::Offset::new(Pixels(64.0), Pixels(64.0)));
+        painter.rotate(std::f32::consts::FRAC_PI_4);
+        painter.translate(flui_types::Offset::new(Pixels(-64.0), Pixels(-64.0)));
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            flui_types::Rect::from_xywh(Pixels(24.0), Pixels(24.0), Pixels(80.0), Pixels(80.0)),
+            Pixels(12.0),
+        ));
+        // Far larger than the surface, so every sample point is inside the
+        // drawn shape and only the clip can remove it.
+        painter.rect(
+            flui_types::Rect::from_xywh(
+                Pixels(-200.0),
+                Pixels(-200.0),
+                Pixels(600.0),
+                Pixels(600.0),
+            ),
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Rotated Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        let centre = at(64, 64);
+        assert!(
+            centre[2] > 200,
+            "precondition: the fill must paint inside the clip; got {centre:?}"
+        );
+
+        let outside = at(14, 14);
+        assert!(
+            outside[3] < 32,
+            "a rotated clip must follow its rotation; rgba={outside:?} at a \
+             pixel inside the rotated rect's BOUNDING BOX but outside the rect \
+             — the clip fell back to the coarse scissor"
+        );
+    }
+
+    /// A non-uniformly scaled circular clip produces elliptical corners, not a
+    /// clamped scalar radius.
+    ///
+    /// The clip slot holds ONE radius per corner, so a device-space form had
+    /// to collapse a scaled circular corner — an ellipse — to a scalar, then
+    /// clamp it to the box's half-height or the rounded-box SDF went
+    /// degenerate and clipped inward. Keeping the radius in the caller's own
+    /// space and letting the mapping stretch it removes the collapse entirely.
+    ///
+    /// `scale(1, 3)` on a 96x32 clip with radius 16: device bounds 96x96,
+    /// corners 16 wide and 48 tall. The old form collapsed those to
+    /// `max(16, 48) = 48`, clamped to `min(96, 96)/2 = 48`, and rounded every
+    /// corner by 48 — a stadium, not the intended shape.
+    ///
+    /// Sample (20, 48) is on the left edge at mid-height: outside a 48-radius
+    /// corner sweep, inside the true ellipse.
+    ///
+    /// What this test can and cannot show. Its counterfactual is the ENTIRE
+    /// previous representation — device-space bounds with pre-scaled radii —
+    /// which no longer exists as a line to revert; in local space the
+    /// anisotropy problem cannot be expressed at all, which is the point. The
+    /// old form's arithmetic is pinned instead by the `state_stack` unit tests
+    /// that replaced its device-space ones. What this test does prove is that
+    /// the mapping is live: making `clipAlpha` use `world_pos` directly fails
+    /// the first precondition with `[0, 0, 0, 0]`.
+    #[test]
+    fn a_non_uniformly_scaled_clip_keeps_elliptical_corners() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.scale(1.0, 3.0);
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            flui_types::Rect::from_xywh(Pixels(16.0), Pixels(0.0), Pixels(96.0), Pixels(32.0)),
+            Pixels(16.0),
+        ));
+        painter.rect(
+            flui_types::Rect::from_xywh(
+                Pixels(-200.0),
+                Pixels(-200.0),
+                Pixels(600.0),
+                Pixels(600.0),
+            ),
+            &Paint::fill(Color::rgb(0, 0, 255)),
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Anisotropic Clip Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        let w = SURFACE_WIDTH as usize;
+        let at = |x: usize, y: usize| pixels[y * w + x];
+
+        let centre = at(64, 48);
+        assert!(
+            centre[2] > 200,
+            "precondition: the fill must paint inside the clip; got {centre:?}"
+        );
+
+        // Just outside the device-space bounds: clipped under any reading, so
+        // a shader that ignored the clip entirely would not pass.
+        let beyond = at(120, 48);
+        assert!(
+            beyond[3] < 32,
+            "precondition: outside the clip's own bounds; got {beyond:?}"
+        );
+
+        // Left edge at mid-height. A 48-radius corner sweep would have eaten
+        // this pixel; the true ellipse (16 wide, 48 tall) does not.
+        let edge = at(20, 48);
+        assert!(
+            edge[2] > 200,
+            "a non-uniformly scaled clip must keep elliptical corners; \
+             rgba={edge:?} — the radius collapsed to a clamped scalar and \
+             rounded the shape into a stadium"
+        );
+    }
+
     /// Text that is the ONLY content of an opacity layer must still belong
     /// to the layer: composited with the layer (subject to its opacity) and
     /// buried by top-level geometry drawn AFTER the layer — not dropped as

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -252,7 +252,8 @@ impl DrawBatcher {
                 index_count: indices.len() as u32,
                 // The isolated shape carries the clip that was active when it
                 // was recorded — it renders into an offscreen at full-frame
-                // device coordinates, so the device-space clip still applies.
+                // device coordinates, so the clip's mapping still applies
+                // unchanged — there is no rebase to compose in.
                 clip: clip_for_isolated,
             });
 

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -253,8 +253,7 @@ impl DrawBatcher {
                 // The isolated shape carries the clip that was active when it
                 // was recorded — it renders into an offscreen at full-frame
                 // device coordinates, so the device-space clip still applies.
-                clip_rrect: clip_for_isolated.0,
-                clip_kind: clip_for_isolated.1,
+                clip: clip_for_isolated,
             });
 
             draw_order.push(DrawItem::AdvancedShape(AdvancedShapeOp {
@@ -284,19 +283,12 @@ impl DrawBatcher {
 
         let index_count = indices.len() as u32;
 
-        let (clip_rrect, clip_kind) = state.active_clip();
+        let clip = state.active_clip();
         // Merging also requires the SAME clip: two different rounded clips can
         // share one bounding scissor (same rect, different radii), and the
         // batch's clip is what its draw binds.
-        #[expect(
-            clippy::float_cmp,
-            reason = "both sides are assigned bit-exact from the same state slot"
-        )]
         let mergeable = segment.tess_batches.last().is_some_and(|last| {
-            last.pipeline_key == key
-                && last.scissor == state.current_scissor()
-                && last.clip_rrect == clip_rrect
-                && last.clip_kind == clip_kind
+            last.pipeline_key == key && last.scissor == state.current_scissor() && last.clip == clip
         });
         if mergeable && let Some(last) = segment.tess_batches.last_mut() {
             last.index_count += index_count;
@@ -307,8 +299,7 @@ impl DrawBatcher {
                 scissor: state.current_scissor(),
                 index_start,
                 index_count,
-                clip_rrect,
-                clip_kind,
+                clip,
             });
         }
 
@@ -377,8 +368,7 @@ impl DrawBatcher {
             scissor: state.current_scissor(),
             index_start: 0,
             index_count: indices.len() as u32,
-            clip_rrect: clip_for_isolated.0,
-            clip_kind: clip_for_isolated.1,
+            clip: clip_for_isolated,
         });
 
         draw_order.push(DrawItem::SsaaPath(SsaaPathOp {

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -375,12 +375,31 @@ pub(crate) struct ScissorRegion {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub(crate) struct ClipUniform {
-    /// Device-space `[x, y, w, h]`.
+    /// Clip-local `[x, y, w, h]`.
     pub(crate) bounds: [f32; 4],
-    /// `[tl, tr, br, bl]`.
+    /// `[tl, tr, br, bl]`, in the same space as `bounds`.
     pub(crate) radii: [f32; 4],
     /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
     pub(crate) kind: [u32; 4],
+    /// Device-to-clip-local linear part `[a, b, c, d]`, columns first.
+    pub(crate) device_to_local: [f32; 4],
+    /// Device-to-clip-local translation `[tx, ty, 0, 0]`.
+    pub(crate) local_origin: [f32; 4],
+}
+
+impl ClipUniform {
+    /// Regroup a [`ResolvedClip`](super::state_stack::ResolvedClip) into the
+    /// `vec4` members WGSL uniform layout wants.
+    pub(crate) fn from_resolved(clip: super::state_stack::ResolvedClip) -> Self {
+        let m = clip.device_to_local;
+        Self {
+            bounds: [clip.rrect[0], clip.rrect[1], clip.rrect[2], clip.rrect[3]],
+            radii: [clip.rrect[4], clip.rrect[5], clip.rrect[6], clip.rrect[7]],
+            kind: clip.kind,
+            device_to_local: [m[0], m[1], m[2], m[3]],
+            local_origin: [m[4], m[5], 0.0, 0.0],
+        }
+    }
 }
 
 /// A recorded batch of tessellated geometry sharing the same pipeline key.
@@ -400,17 +419,14 @@ pub(crate) struct TessellatedBatch {
     pub(crate) index_start: u32,
     /// Number of indices in this batch
     pub(crate) index_count: u32,
-    /// Device-space rounded-rect clip active when this batch was recorded:
-    /// `[x, y, w, h, tl, tr, br, bl]`, all-zero meaning "no clip".
+    /// The SDF clip active when this batch was recorded.
     ///
     /// Tessellated geometry carries no per-instance slot — there are no
     /// instances, only vertices — so the clip lives on the batch and is bound
     /// as a uniform for its draw. The batch is the right granularity because
     /// `add_tessellated_with_key` only merges into the previous batch when the
     /// pipeline key AND the clip both match.
-    pub(crate) clip_rrect: [f32; 8],
-    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
-    pub(crate) clip_kind: [u32; 4],
+    pub(crate) clip: super::state_stack::ResolvedClip,
 }
 
 // ─── Offscreen / layer snapshots ─────────────────────────────────────────────

--- a/crates/flui-engine/src/wgpu/effects.rs
+++ b/crates/flui-engine/src/wgpu/effects.rs
@@ -70,10 +70,11 @@ pub struct LinearGradientInstance {
     pub stop_count: u32,
     /// Offset into the shared gradient stops buffer
     pub stop_offset: u32,
-    /// Device-space rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
+    /// Clip-local rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
     ///
-    /// All-zero means "no clip". Attached by `apply_active_clip`, evaluated per
-    /// pixel by the shader against `world_pos`. The scissor alone can only
+    /// All-zero means "no clip". Attached by `apply_active_clip`; the shader
+    /// maps a fragment's device position into this space with
+    /// `clip_device_to_local` before evaluating it. The scissor alone can only
     /// express the clip's axis-aligned bounding box, which leaves square
     /// corners on a `ClipRRect`.
     ///
@@ -183,10 +184,11 @@ pub struct RadialGradientInstance {
     pub stop_count: u32,
     /// Offset into the shared gradient stops buffer
     pub stop_offset: u32,
-    /// Device-space rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
+    /// Clip-local rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
     ///
-    /// All-zero means "no clip". Attached by `apply_active_clip`, evaluated per
-    /// pixel by the shader against `world_pos`. The scissor alone can only
+    /// All-zero means "no clip". Attached by `apply_active_clip`; the shader
+    /// maps a fragment's device position into this space with
+    /// `clip_device_to_local` before evaluating it. The scissor alone can only
     /// express the clip's axis-aligned bounding box, which leaves square
     /// corners on a `ClipRRect`.
     ///
@@ -274,10 +276,11 @@ pub struct SweepGradientInstance {
     pub stop_count: u32,
     /// Offset into the shared gradient stops buffer
     pub stop_offset: u32,
-    /// Device-space rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
+    /// Clip-local rounded-rect clip: `[x, y, w, h, tl, tr, br, bl]`.
     ///
-    /// All-zero means "no clip". Attached by `apply_active_clip`, evaluated per
-    /// pixel by the shader against `world_pos`. The scissor alone can only
+    /// All-zero means "no clip". Attached by `apply_active_clip`; the shader
+    /// maps a fragment's device position into this space with
+    /// `clip_device_to_local` before evaluating it. The scissor alone can only
     /// express the clip's axis-aligned bounding box, which leaves square
     /// corners on a `ClipRRect`.
     ///

--- a/crates/flui-engine/src/wgpu/effects.rs
+++ b/crates/flui-engine/src/wgpu/effects.rs
@@ -84,6 +84,15 @@ pub struct LinearGradientInstance {
     pub clip_rrect: [f32; 8],
     /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
     pub clip_kind: [u32; 4],
+    /// Device-to-clip-local linear part: `[a, b, c, d]`, columns first.
+    ///
+    /// The clip's bounds and radii are in the space the caller set them in;
+    /// this maps a device-space fragment position back there. Identity is
+    /// `[1, 0, 0, 1]`.
+    pub clip_device_to_local: [f32; 4],
+    /// Device-to-clip-local translation, padded to a `vec4` attribute:
+    /// `[tx, ty, 0, 0]`.
+    pub clip_local_origin: [f32; 4],
     /// Padding for GPU alignment
     pub padding: [u32; 2],
 }
@@ -107,6 +116,8 @@ impl LinearGradientInstance {
             padding: [0; 2],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -186,6 +197,15 @@ pub struct RadialGradientInstance {
     pub clip_rrect: [f32; 8],
     /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
     pub clip_kind: [u32; 4],
+    /// Device-to-clip-local linear part: `[a, b, c, d]`, columns first.
+    ///
+    /// The clip's bounds and radii are in the space the caller set them in;
+    /// this maps a device-space fragment position back there. Identity is
+    /// `[1, 0, 0, 1]`.
+    pub clip_device_to_local: [f32; 4],
+    /// Device-to-clip-local translation, padded to a `vec4` attribute:
+    /// `[tx, ty, 0, 0]`.
+    pub clip_local_origin: [f32; 4],
     /// Padding for GPU alignment
     pub padding2: [u32; 2],
 }
@@ -210,6 +230,8 @@ impl RadialGradientInstance {
             padding2: [0; 2],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -266,6 +288,15 @@ pub struct SweepGradientInstance {
     pub clip_rrect: [f32; 8],
     /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
     pub clip_kind: [u32; 4],
+    /// Device-to-clip-local linear part: `[a, b, c, d]`, columns first.
+    ///
+    /// The clip's bounds and radii are in the space the caller set them in;
+    /// this maps a device-space fragment position back there. Identity is
+    /// `[1, 0, 0, 1]`.
+    pub clip_device_to_local: [f32; 4],
+    /// Device-to-clip-local translation, padded to a `vec4` attribute:
+    /// `[tx, ty, 0, 0]`.
+    pub clip_local_origin: [f32; 4],
     /// Padding for GPU alignment
     pub padding: [u32; 2],
 }
@@ -290,6 +321,8 @@ impl SweepGradientInstance {
             padding: [0; 2],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -91,6 +91,15 @@ pub struct RectInstance {
     /// instance attributes. Only the `.x` lane carries the kind; the other
     /// three lanes are padding.
     pub clip_kind: [u32; 4],
+    /// Device-to-clip-local linear part: `[a, b, c, d]`, columns first.
+    ///
+    /// The clip's bounds and radii are in the space the caller set them in;
+    /// this maps a device-space fragment position back there. Identity is
+    /// `[1, 0, 0, 1]`.
+    pub clip_device_to_local: [f32; 4],
+    /// Device-to-clip-local translation, padded to a `vec4` attribute:
+    /// `[tx, ty, 0, 0]`.
+    pub clip_local_origin: [f32; 4],
 
     /// Translation part of the affine transform: `[tx, ty, 0, 0]`.
     ///
@@ -116,6 +125,8 @@ impl RectInstance {
             transform: [1.0, 0.0, 0.0, 1.0],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
             transform_translate: [0.0; 4],
         }
     }
@@ -145,6 +156,8 @@ impl RectInstance {
             transform: [1.0, 0.0, 0.0, 1.0],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
             transform_translate: [0.0; 4],
         }
     }
@@ -178,54 +191,10 @@ impl RectInstance {
             transform: linear_cols,
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
             transform_translate: [translation[0], translation[1], 0.0, 0.0],
         }
-    }
-
-    /// Set the SDF clip rounded rectangle on this instance.
-    ///
-    /// The clip is specified as `[x, y, width, height, radius_tl, radius_tr, radius_br, radius_bl]`.
-    /// All zeros means no clip. When non-zero, the fragment shader discards
-    /// pixels that fall outside the rounded rectangle using an SDF test.
-    /// Sets `clip_kind = 1` (rrect) when the clip is non-trivial; leaves
-    /// `clip_kind = 0` when all-zero (no clip).
-    #[must_use]
-    pub fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
-        self.clip_rrect = clip;
-        // Exact equality against the bit-exact `[0.0; 8]` "no clip" sentinel —
-        // never set via arithmetic, so ULP slop is not a concern.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let is_empty = clip == [0.0; 8];
-        self.clip_kind = if is_empty { [0; 4] } else { [1, 0, 0, 0] };
-        self
-    }
-
-    /// Set an SDF clip rounded-superellipse (iOS-squircle) on this instance.
-    ///
-    /// The 12-float superellipse uniform produced by
-    /// `Painter::clip_rsuperellipse` carries separate-axis radii per corner.
-    /// At the per-instance level we average each corner's `rx`/`ry` into a
-    /// single radius to fit the existing `clip_rrect` slot — this is the
-    /// "single-radius-per-corner" first-pass interpretation called out in
-    /// the plan's Outstanding Questions Q9. Sets `clip_kind = 2`.
-    ///
-    /// Layout of `superellipse_clip`: `[x, y, w, h, tl_x, tl_y, tr_x, tr_y,
-    /// br_x, br_y, bl_x, bl_y]`. Layout in the resulting `clip_rrect` slot:
-    /// `[x, y, w, h, avg(tl_x,tl_y), avg(tr_x,tr_y), avg(br_x,br_y),
-    /// avg(bl_x,bl_y)]`.
-    #[must_use]
-    pub fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let cleared = self.clip_rrect == [0.0; 8];
-        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
-        self
     }
 
     // `RectInstance::with_transform(scale_x, scale_y, translate_x,
@@ -260,8 +229,12 @@ impl RectInstance {
             7 => Float32x4,
             // Clip kind: [kind, _pad, _pad, _pad] (location 8) — 0=none, 1=rrect, 2=rsuperellipse
             8 => Uint32x4,
-            // Affine translation [tx, ty, 0, 0] (location 9)
+            // Device-to-clip-local linear part (location 9)
             9 => Float32x4,
+            // Device-to-clip-local translation, padded (location 10)
+            10 => Float32x4,
+            // Affine translation [tx, ty, 0, 0] (location 9)
+            11 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -344,6 +317,15 @@ pub struct CircleInstance {
     /// `[0, _, _, _]` none, `[1, _, _, _]` rounded rect, `[2, _, _, _]`
     /// rounded superellipse. Only `.x` is read; the rest is padding.
     pub clip_kind: [u32; 4],
+    /// Device-to-clip-local linear part: `[a, b, c, d]`, columns first.
+    ///
+    /// The clip's bounds and radii are in the space the caller set them in;
+    /// this maps a device-space fragment position back there. Identity is
+    /// `[1, 0, 0, 1]`.
+    pub clip_device_to_local: [f32; 4],
+    /// Device-to-clip-local translation, padded to a `vec4` attribute:
+    /// `[tx, ty, 0, 0]`.
+    pub clip_local_origin: [f32; 4],
 }
 
 impl CircleInstance {
@@ -374,6 +356,8 @@ impl CircleInstance {
             // No clip until `ClippableInstance::with_clip_*` attaches one.
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -408,6 +392,8 @@ impl CircleInstance {
             // No clip until `ClippableInstance::with_clip_*` attaches one.
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -438,6 +424,10 @@ impl CircleInstance {
             7 => Float32x4,
             // Clip kind [kind, _, _, _] (location 8)
             8 => Uint32x4,
+            // Device-to-clip-local linear part (location 9)
+            9 => Float32x4,
+            // Device-to-clip-local translation, padded (location 10)
+            10 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -619,6 +609,15 @@ pub struct TextureInstance {
     /// encoding to [`RectInstance::clip_kind`], including the `[u32; 4]`
     /// padding for 16-byte vec4 alignment.
     pub clip_kind: [u32; 4],
+    /// Device-to-clip-local linear part: `[a, b, c, d]`, columns first.
+    ///
+    /// The clip's bounds and radii are in the space the caller set them in;
+    /// this maps a device-space fragment position back there. Identity is
+    /// `[1, 0, 0, 1]`.
+    pub clip_device_to_local: [f32; 4],
+    /// Device-to-clip-local translation, padded to a `vec4` attribute:
+    /// `[tx, ty, 0, 0]`.
+    pub clip_local_origin: [f32; 4],
 }
 
 impl TextureInstance {
@@ -641,6 +640,8 @@ impl TextureInstance {
             transform: [1.0, 0.0, 0.0, 0.0], // No rotation
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -668,6 +669,8 @@ impl TextureInstance {
             transform: [1.0, 0.0, 0.0, 0.0],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -704,6 +707,8 @@ impl TextureInstance {
             transform: [1.0, 0.0, 0.0, 0.0],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            clip_device_to_local: [1.0, 0.0, 0.0, 1.0],
+            clip_local_origin: [0.0; 4],
         }
     }
 
@@ -725,6 +730,10 @@ impl TextureInstance {
             7 => Float32x4,
             // Clip kind: [kind, _pad, _pad, _pad] (location 8) — 0=none, 1=rrect, 2=rsuperellipse
             8 => Uint32x4,
+            // Device-to-clip-local linear part (location 9)
+            9 => Float32x4,
+            // Device-to-clip-local translation, padded (location 10)
+            10 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -772,169 +781,102 @@ pub(crate) fn reduce_superellipse_clip(c: [f32; 12]) -> [f32; 8] {
 }
 
 pub trait ClippableInstance {
-    /// Attach a rounded-rect SDF clip (`clip_kind = 1`), or clear the clip
-    /// when the slot is the all-zero "no clip" sentinel.
+    /// Store the active clip, or clear the slot when no clip is active.
+    ///
+    /// One method rather than a per-kind pair: every implementor has the same
+    /// body, and a two-method form made each of them re-derive the kind flag
+    /// and the superellipse reduction — six copies of arithmetic that has one
+    /// right answer.
     #[must_use]
-    fn with_clip_rrect(self, clip: [f32; 8]) -> Self;
-
-    /// Attach a rounded-superellipse SDF clip (`clip_kind = 2`), or clear the
-    /// clip when the slot is the all-zero sentinel.
-    #[must_use]
-    fn with_clip_rsuperellipse(self, superellipse_clip: [f32; 12]) -> Self;
+    fn with_clip(self, clip: super::state_stack::ResolvedClip) -> Self;
 }
 
 impl ClippableInstance for RectInstance {
-    fn with_clip_rrect(self, clip: [f32; 8]) -> Self {
-        RectInstance::with_clip_rrect(self, clip)
-    }
-
-    fn with_clip_rsuperellipse(self, superellipse_clip: [f32; 12]) -> Self {
-        RectInstance::with_clip_rsuperellipse(self, superellipse_clip)
+    fn with_clip(mut self, clip: super::state_stack::ResolvedClip) -> Self {
+        self.clip_rrect = clip.rrect;
+        self.clip_kind = clip.kind;
+        self.clip_device_to_local = [
+            clip.device_to_local[0],
+            clip.device_to_local[1],
+            clip.device_to_local[2],
+            clip.device_to_local[3],
+        ];
+        self.clip_local_origin = [clip.device_to_local[4], clip.device_to_local[5], 0.0, 0.0];
+        self
     }
 }
 
 impl ClippableInstance for CircleInstance {
-    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
-        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
-        // `RectInstance`/`TextureInstance` — the slot is assigned, never
-        // computed, so there is no ULP slop to tolerate.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let is_empty = clip == [0.0; 8];
-        self.clip_rrect = clip;
-        self.clip_kind = if is_empty { [0; 4] } else { [1, 0, 0, 0] };
-        self
-    }
-
-    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let cleared = self.clip_rrect == [0.0; 8];
-        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
+    fn with_clip(mut self, clip: super::state_stack::ResolvedClip) -> Self {
+        self.clip_rrect = clip.rrect;
+        self.clip_kind = clip.kind;
+        self.clip_device_to_local = [
+            clip.device_to_local[0],
+            clip.device_to_local[1],
+            clip.device_to_local[2],
+            clip.device_to_local[3],
+        ];
+        self.clip_local_origin = [clip.device_to_local[4], clip.device_to_local[5], 0.0, 0.0];
         self
     }
 }
 
 impl ClippableInstance for LinearGradientInstance {
-    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
-        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
-        // `RectInstance` — the slot is assigned, never computed.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let no_clip = clip == [0.0; 8];
-        if no_clip {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-        } else {
-            self.clip_rrect = clip;
-            self.clip_kind = [1, 0, 0, 0];
-        }
-        self
-    }
-
-    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let cleared = self.clip_rrect == [0.0; 8];
-        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
+    fn with_clip(mut self, clip: super::state_stack::ResolvedClip) -> Self {
+        self.clip_rrect = clip.rrect;
+        self.clip_kind = clip.kind;
+        self.clip_device_to_local = [
+            clip.device_to_local[0],
+            clip.device_to_local[1],
+            clip.device_to_local[2],
+            clip.device_to_local[3],
+        ];
+        self.clip_local_origin = [clip.device_to_local[4], clip.device_to_local[5], 0.0, 0.0];
         self
     }
 }
 
 impl ClippableInstance for RadialGradientInstance {
-    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
-        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
-        // `RectInstance` — the slot is assigned, never computed.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let no_clip = clip == [0.0; 8];
-        if no_clip {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-        } else {
-            self.clip_rrect = clip;
-            self.clip_kind = [1, 0, 0, 0];
-        }
-        self
-    }
-
-    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let cleared = self.clip_rrect == [0.0; 8];
-        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
+    fn with_clip(mut self, clip: super::state_stack::ResolvedClip) -> Self {
+        self.clip_rrect = clip.rrect;
+        self.clip_kind = clip.kind;
+        self.clip_device_to_local = [
+            clip.device_to_local[0],
+            clip.device_to_local[1],
+            clip.device_to_local[2],
+            clip.device_to_local[3],
+        ];
+        self.clip_local_origin = [clip.device_to_local[4], clip.device_to_local[5], 0.0, 0.0];
         self
     }
 }
 
 impl ClippableInstance for SweepGradientInstance {
-    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
-        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
-        // `RectInstance` — the slot is assigned, never computed.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let no_clip = clip == [0.0; 8];
-        if no_clip {
-            self.clip_rrect = [0.0; 8];
-            self.clip_kind = [0; 4];
-        } else {
-            self.clip_rrect = clip;
-            self.clip_kind = [1, 0, 0, 0];
-        }
-        self
-    }
-
-    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let cleared = self.clip_rrect == [0.0; 8];
-        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
+    fn with_clip(mut self, clip: super::state_stack::ResolvedClip) -> Self {
+        self.clip_rrect = clip.rrect;
+        self.clip_kind = clip.kind;
+        self.clip_device_to_local = [
+            clip.device_to_local[0],
+            clip.device_to_local[1],
+            clip.device_to_local[2],
+            clip.device_to_local[3],
+        ];
+        self.clip_local_origin = [clip.device_to_local[4], clip.device_to_local[5], 0.0, 0.0];
         self
     }
 }
 
 impl ClippableInstance for TextureInstance {
-    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
-        self.clip_rrect = clip;
-        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
-        // `RectInstance` — the slot is assigned, never computed, so no ULP slop.
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let is_empty = clip == [0.0; 8];
-        self.clip_kind = if is_empty { [0; 4] } else { [1, 0, 0, 0] };
-        self
-    }
-
-    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
-        self.clip_rrect = reduce_superellipse_clip(superellipse_clip);
-        #[expect(
-            clippy::float_cmp,
-            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
-        )]
-        let cleared = self.clip_rrect == [0.0; 8];
-        self.clip_kind = if cleared { [0; 4] } else { [2, 0, 0, 0] };
+    fn with_clip(mut self, clip: super::state_stack::ResolvedClip) -> Self {
+        self.clip_rrect = clip.rrect;
+        self.clip_kind = clip.kind;
+        self.clip_device_to_local = [
+            clip.device_to_local[0],
+            clip.device_to_local[1],
+            clip.device_to_local[2],
+            clip.device_to_local[3],
+        ];
+        self.clip_local_origin = [clip.device_to_local[4], clip.device_to_local[5], 0.0, 0.0];
         self
     }
 }
@@ -972,6 +914,10 @@ impl LinearGradientInstance {
             9 => Float32x4,
             // Clip kind (location 10)
             10 => Uint32x4,
+            // Device-to-clip-local linear part (location 11)
+            11 => Float32x4,
+            // Device-to-clip-local translation, padded (location 12)
+            12 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -1008,6 +954,10 @@ impl RadialGradientInstance {
             9 => Float32x4,
             // Clip kind (location 10)
             10 => Uint32x4,
+            // Device-to-clip-local linear part (location 11)
+            11 => Float32x4,
+            // Device-to-clip-local translation, padded (location 12)
+            12 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -1048,6 +998,10 @@ impl SweepGradientInstance {
             9 => Float32x4,
             // Clip kind (location 10)
             10 => Uint32x4,
+            // Device-to-clip-local linear part (location 11)
+            11 => Float32x4,
+            // Device-to-clip-local translation, padded (location 12)
+            12 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -1186,7 +1140,7 @@ mod tests {
         //   clip_kind:           [u32; 4]  = 16 bytes
         //   transform_translate: [f32; 4]  = 16 bytes  ← appended for affine path
         //   Total: 128 bytes
-        assert_eq!(std::mem::size_of::<RectInstance>(), 128);
+        assert_eq!(std::mem::size_of::<RectInstance>(), 160);
     }
 
     #[test]
@@ -1203,7 +1157,7 @@ mod tests {
         // The clip pair is APPENDED, so every pre-existing field offset is
         // byte-identical and the `vertex_attr_array!` offsets for locations
         // 2–5 are unchanged; locations 6–8 are new at the end.
-        assert_eq!(std::mem::size_of::<CircleInstance>(), 112);
+        assert_eq!(std::mem::size_of::<CircleInstance>(), 144);
     }
 
     #[test]
@@ -1222,11 +1176,11 @@ mod tests {
     fn test_texture_instance_size() {
         // Tightly packed for the GPU, and the count must match `desc()`:
         // dst_rect + src_uv + tint + transform (4 vec4s) + the clip slot
-        // (clip_rrect is 2 vec4s, clip_kind 1 uvec4) = 7 * 16 bytes. A
-        // mismatch here means an attribute in the vertex layout has no
-        // storage behind it, which reads as garbage clip bounds on the GPU
-        // rather than as a compile error.
-        assert_eq!(std::mem::size_of::<TextureInstance>(), 7 * 16);
+        // (clip_rrect is 2 vec4s, clip_kind 1 uvec4) + the device-to-clip-local
+        // mapping (2 vec4s) = 9 * 16 bytes. A mismatch here means an attribute
+        // in the vertex layout has no storage behind it, which reads as garbage
+        // clip bounds on the GPU rather than as a compile error.
+        assert_eq!(std::mem::size_of::<TextureInstance>(), 9 * 16);
     }
 
     #[test]
@@ -1363,50 +1317,62 @@ mod tests {
     }
 
     #[test]
-    fn test_with_clip_rrect_sets_kind_one() {
-        // Non-zero clip_rrect must set clip_kind[0] = 1 (sdRoundedBox).
-        let clip: [f32; 8] = [5.0, 5.0, 90.0, 40.0, 4.0, 4.0, 4.0, 4.0];
+    fn with_clip_stores_the_resolved_clip_verbatim() {
+        let clip = super::super::state_stack::ResolvedClip {
+            rrect: [5.0, 5.0, 90.0, 40.0, 4.0, 4.0, 4.0, 4.0],
+            kind: [1, 0, 0, 0],
+            device_to_local: [0.5, 0.0, 0.0, 2.0, -3.0, 7.0],
+        };
         let instance = RectInstance::rect(
             Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
             Color::RED,
         )
-        .with_clip_rrect(clip);
-        assert_eq!(instance.clip_rrect, clip);
-        assert_eq!(instance.clip_kind[0], 1u32);
-        // Padding lanes must be zero.
-        assert_eq!(instance.clip_kind[1], 0u32);
-        assert_eq!(instance.clip_kind[2], 0u32);
-        assert_eq!(instance.clip_kind[3], 0u32);
+        .with_clip(clip);
+
+        assert_eq!(instance.clip_rrect, clip.rrect);
+        assert_eq!(instance.clip_kind, clip.kind);
+        assert_eq!(
+            instance.clip_device_to_local,
+            [0.5, 0.0, 0.0, 2.0],
+            "the linear part goes in first"
+        );
+        assert_eq!(
+            instance.clip_local_origin,
+            [-3.0, 7.0, 0.0, 0.0],
+            "and the translation is padded to a vec4"
+        );
     }
 
     #[test]
-    fn test_with_clip_rrect_all_zeros_keeps_no_clip() {
-        // Passing the all-zeros sentinel must leave clip_kind == 0.
+    fn with_clip_none_leaves_the_slot_empty() {
         let instance = RectInstance::rect(
             Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
             Color::RED,
         )
-        .with_clip_rrect([0.0; 8]);
+        .with_clip(super::super::state_stack::ResolvedClip::NONE);
         assert_eq!(instance.clip_kind, [0u32; 4]);
+        assert_eq!(instance.clip_rrect, [0.0; 8]);
     }
 
+    /// The 12-slot superellipse clip averages each corner's `(rx, ry)` into
+    /// the one radius the instance slot holds.
     #[test]
-    fn test_with_clip_rsuperellipse_sets_kind_two() {
-        // Non-zero squircle clip must set clip_kind[0] = 2.
+    fn reduce_superellipse_clip_averages_each_corner() {
         let se: [f32; 12] = [
             0.0, 0.0, 100.0, 50.0, 8.0, 10.0, 8.0, 10.0, 8.0, 10.0, 8.0, 10.0,
         ];
-        let instance = RectInstance::rect(
-            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
-            Color::RED,
-        )
-        .with_clip_rsuperellipse(se);
-        assert_eq!(instance.clip_kind[0], 2u32);
-        // Averaged corner radii: avg(8,10) = 9.0 for each corner.
-        assert_eq!(instance.clip_rrect[4], 9.0);
-        assert_eq!(instance.clip_rrect[5], 9.0);
-        assert_eq!(instance.clip_rrect[6], 9.0);
-        assert_eq!(instance.clip_rrect[7], 9.0);
+        let reduced = reduce_superellipse_clip(se);
+        assert_eq!(
+            &reduced[0..4],
+            &[0.0, 0.0, 100.0, 50.0],
+            "bounds pass through"
+        );
+        assert_eq!(&reduced[4..8], &[9.0; 4], "avg(8, 10) per corner");
+        assert_eq!(
+            reduce_superellipse_clip([0.0; 12]),
+            [0.0; 8],
+            "the sentinel survives unchanged"
+        );
     }
 
     /// The instance stride the vertex layout advertises must be the struct's
@@ -1421,28 +1387,30 @@ mod tests {
     #[test]
     fn test_gradient_instance_sizes() {
         // Shared by all three: clip_rrect[8]=32  clip_kind[4u32]=16 → 48 bytes
-        // of clip, placed before the trailing padding.
+        // of clip, plus clip_device_to_local[4]=16 + clip_local_origin[4]=16 →
+        // 32 bytes of device-to-clip-local mapping. All of it placed before
+        // the trailing padding.
 
         // LinearGradientInstance:
         //   bounds[4]=16  gradient_start[2]=8  gradient_end[2]=8
         //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4
-        //   clip=48  padding[2u32]=8
-        //   Total: 112 bytes
-        assert_eq!(std::mem::size_of::<LinearGradientInstance>(), 112);
+        //   clip=48  mapping=32  padding[2u32]=8
+        //   Total: 144 bytes
+        assert_eq!(std::mem::size_of::<LinearGradientInstance>(), 144);
 
         // RadialGradientInstance:
         //   bounds[4]=16  center[2]=8  radius(f32)=4  padding1(f32)=4
         //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4
         //   clip=48  padding2[2u32]=8
         //   Total: 112 bytes
-        assert_eq!(std::mem::size_of::<RadialGradientInstance>(), 112);
+        assert_eq!(std::mem::size_of::<RadialGradientInstance>(), 144);
 
         // SweepGradientInstance:
         //   bounds[4]=16  center[2]=8  angles[2]=8
         //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4
-        //   clip=48  padding[2u32]=8
-        //   Total: 112 bytes
-        assert_eq!(std::mem::size_of::<SweepGradientInstance>(), 112);
+        //   clip=48  mapping=32  padding[2u32]=8
+        //   Total: 144 bytes
+        assert_eq!(std::mem::size_of::<SweepGradientInstance>(), 144);
     }
 
     /// The clip attributes must be reachable within the advertised stride.

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -233,7 +233,8 @@ impl RectInstance {
             9 => Float32x4,
             // Device-to-clip-local translation, padded (location 10)
             10 => Float32x4,
-            // Affine translation [tx, ty, 0, 0] (location 9)
+            // Affine translation [tx, ty, 0, 0] (location 11 — it moved off 9
+            // when the clip mapping took 9 and 10)
             11 => Float32x4,
         ];
 

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -431,9 +431,10 @@ impl GpuReplay {
             inst.transform[3] *= scale_y;
         }
 
-        // The SDF clip each instance carries is in DEVICE space, so it moves
-        // with them. One call covering every clip-carrying batch, rather than a
-        // line per transform loop above — see `remap_segment_clips`.
+        // Each clip's device-to-local mapping consumes a device-space
+        // position, so the rebase above has to be composed into it. One call
+        // covering every clip carrier, rather than a line per transform loop
+        // above — see `remap_segment_clips`.
         Self::remap_segment_clips(
             &mut remapped_segment,
             (origin_x, origin_y),

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -184,45 +184,82 @@ impl GpuReplay {
     ///
     /// A cleared slot (`clip_kind[0] == 0`) is left untouched: the all-zero sentinel
     /// must stay bit-exact, and scaling zeros could introduce signed zeros.
-    /// Remap EVERY device-space SDF clip in `segment` into a grown offscreen's
-    /// local space.
+    /// Rebase EVERY SDF clip in `segment` into a shrunken intermediate's local
+    /// space.
     ///
-    /// One call covering every clip-carrying batch, rather than a line inside each
-    /// batch's transform loop. That shape is deliberate: the rect loop carried this
-    /// inline and the circle loop did not, and a clip left in full-frame
-    /// coordinates is invisible until something is drawn inside a blur or filter
-    /// layer. A batch that gains a clip slot later is remapped by adding it here,
-    /// in the one place that already reads them all.
+    /// One call covering every clip carrier, rather than a line inside each
+    /// batch's transform loop. That shape is deliberate: the rect loop carried
+    /// this inline and the circle loop did not, and a clip left in the wrong
+    /// space is invisible until something is drawn inside a blur or filter
+    /// layer. A carrier added later is covered by editing the one place that
+    /// already reads them all.
     ///
     /// Two kinds are deliberately absent, neither by oversight. `ArcInstance`
-    /// carries no clip slot at all. `TextureInstance` carries one, but a segment
-    /// holding `cached_images`/`external_images` never reaches a shrunken
-    /// intermediate: `content_aabb` (`painter/layer.rs`) returns `None` for it, so
-    /// `fb_dim == viewport` and this remap would be the identity anyway. If that
-    /// fallback gate ever admits images, their clips must be added here in the
-    /// same change.
+    /// carries no clip slot at all. Gradients carry one but, like shadows and
+    /// images, are excluded from the shrunken path by `content_aabb`; if that
+    /// gate ever admits them, their clips must be added here in the same
+    /// change.
     pub(super) fn remap_segment_clips(
         segment: &mut super::command_ir::DrawSegment,
         origin: (f32, f32),
         scale: (f32, f32),
     ) {
         for inst in &mut segment.rect_batch.instances {
-            Self::remap_clip_rrect(&mut inst.clip_rrect, inst.clip_kind, origin, scale);
+            Self::rebase_clip(
+                &mut inst.clip_device_to_local,
+                &mut inst.clip_local_origin,
+                inst.clip_kind,
+                origin,
+                scale,
+            );
         }
         for inst in &mut segment.circle_batch.instances {
-            Self::remap_clip_rrect(&mut inst.clip_rrect, inst.clip_kind, origin, scale);
+            Self::rebase_clip(
+                &mut inst.clip_device_to_local,
+                &mut inst.clip_local_origin,
+                inst.clip_kind,
+                origin,
+                scale,
+            );
         }
         // Tessellated geometry carries its clip on the BATCH, not on instances
         // — and unlike shadows/gradients/images it IS repositioned into a
         // shrunken intermediate (`content_aabb` returns `Some` for a
-        // vertices-only segment), so it needs the remap just as much.
+        // vertices-only segment), so it needs the rebase just as much.
         for batch in &mut segment.tess_batches {
-            Self::remap_clip_rrect(&mut batch.clip_rrect, batch.clip_kind, origin, scale);
+            let mut m = [
+                batch.clip.device_to_local[0],
+                batch.clip.device_to_local[1],
+                batch.clip.device_to_local[2],
+                batch.clip.device_to_local[3],
+            ];
+            let mut t = [
+                batch.clip.device_to_local[4],
+                batch.clip.device_to_local[5],
+                0.0,
+                0.0,
+            ];
+            Self::rebase_clip(&mut m, &mut t, batch.clip.kind, origin, scale);
+            batch.clip.device_to_local = [m[0], m[1], m[2], m[3], t[0], t[1]];
         }
     }
 
-    fn remap_clip_rrect(
-        clip_rrect: &mut [f32; 8],
+    /// Compose a framebuffer rebase into a clip's device-to-local mapping.
+    ///
+    /// The intermediate's fragments arrive at `p' = (p − origin) · scale`, so
+    /// the mapping that used to consume `p` must now consume `p'`:
+    ///
+    /// ```text
+    /// p     = p' / scale + origin
+    /// local = M · p + t
+    ///       = (M · diag(1/scale)) · p' + (M · origin + t)
+    /// ```
+    ///
+    /// Composing rather than moving the bounds is what makes this exact under
+    /// rotation: there is no AABB step to lose the orientation in.
+    fn rebase_clip(
+        device_to_local: &mut [f32; 4],
+        local_origin: &mut [f32; 4],
         clip_kind: [u32; 4],
         origin: (f32, f32),
         scale: (f32, f32),
@@ -232,13 +269,20 @@ impl GpuReplay {
         }
         let (origin_x, origin_y) = origin;
         let (scale_x, scale_y) = scale;
-        clip_rrect[0] = (clip_rrect[0] - origin_x) * scale_x;
-        clip_rrect[1] = (clip_rrect[1] - origin_y) * scale_y;
-        clip_rrect[2] *= scale_x;
-        clip_rrect[3] *= scale_y;
-        let avg_scale = (scale_x + scale_y) * 0.5;
-        for r in &mut clip_rrect[4..8] {
-            *r *= avg_scale;
+        let [a, b, c, d] = *device_to_local;
+
+        // t' = M · origin + t, using the PRE-scale columns.
+        local_origin[0] += a * origin_x + c * origin_y;
+        local_origin[1] += b * origin_x + d * origin_y;
+
+        // M' = M · diag(1/sx, 1/sy) — scale each column by its own axis.
+        if scale_x != 0.0 {
+            device_to_local[0] = a / scale_x;
+            device_to_local[1] = b / scale_x;
+        }
+        if scale_y != 0.0 {
+            device_to_local[2] = c / scale_y;
+            device_to_local[3] = d / scale_y;
         }
     }
 
@@ -1318,17 +1362,20 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
 
 #[cfg(test)]
 mod grown_offscreen_clip_tests {
-    use super::super::command_ir::DrawSegment;
+    use super::super::command_ir::{DrawSegment, TessellatedBatch};
     use super::super::instancing::{CircleInstance, ClippableInstance, RectInstance};
+    use super::super::pipeline::PipelineKey;
+    use super::super::state_stack::ResolvedClip;
     use flui_types::{Color, Point, Rect, geometry::Pixels};
 
-    /// Every clip carrier is remapped into a grown offscreen the same way.
+    /// Every clip carrier is rebased into a shrunken intermediate the same way.
     ///
-    /// `render_segment_to_grown_offscreen` rebases and scales instances into a
-    /// filter intermediate that is smaller than the viewport. `clip_rrect` is in
-    /// DEVICE space, so it has to move with them — otherwise the shader compares
-    /// a framebuffer-local `world_pos` against full-frame clip bounds, and the
-    /// rounded clip is displaced far enough to erase the filtered shape.
+    /// `render_segment_to_grown_offscreen` rebases and scales geometry into a
+    /// filter intermediate smaller than the viewport, so the mapping that takes
+    /// a fragment position into clip-local space has to absorb that rebase —
+    /// otherwise the shader feeds it a framebuffer-local position while the
+    /// mapping still expects a full-frame one, and the clip lands somewhere
+    /// else entirely.
     ///
     /// The rect loop always did this inline; the circle loop did not, because
     /// circles had no clip slot until they gained one, and tessellated batches
@@ -1336,30 +1383,35 @@ mod grown_offscreen_clip_tests {
     /// literal, is what stops the next carrier being forgotten.
     ///
     /// Reverted (drop any one loop in `remap_segment_clips`): that carrier
-    /// keeps full-frame bounds and this fails on its `assert_eq!`.
+    /// keeps its full-frame mapping and this fails on its `assert_eq!`.
     #[test]
     fn every_clip_carrier_is_remapped_the_same_way() {
         const ORIGIN: (f32, f32) = (40.0, 24.0);
         const SCALE: (f32, f32) = (0.5, 0.25);
-        // [x, y, w, h, tl, tr, br, bl] in device space.
-        const CLIP: [f32; 8] = [60.0, 44.0, 200.0, 120.0, 8.0, 8.0, 8.0, 8.0];
+        // A rotated, translated clip: the case device-space bounds could not
+        // express at all, and the one a per-component remap would mangle.
+        const CLIP: ResolvedClip = ResolvedClip {
+            rrect: [0.0, 0.0, 200.0, 120.0, 8.0, 8.0, 8.0, 8.0],
+            kind: [1, 0, 0, 0],
+            device_to_local: [0.7, 0.7, -0.7, 0.7, 12.0, -5.0],
+        };
 
         let rect = RectInstance::rect(
             Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(10.0), Pixels(10.0)),
             Color::rgb(255, 0, 0),
         )
-        .with_clip_rrect(CLIP);
+        .with_clip(CLIP);
         let circle = CircleInstance::new(
             Point::new(Pixels(5.0), Pixels(5.0)),
             5.0,
             Color::rgb(255, 0, 0),
             [1.0, 1.0],
         )
-        .with_clip_rrect(CLIP);
+        .with_clip(CLIP);
 
         assert_eq!(
-            rect.clip_rrect, circle.clip_rrect,
-            "precondition: both kinds start from the same device-space clip"
+            rect.clip_device_to_local, circle.clip_device_to_local,
+            "precondition: both kinds start from the same mapping"
         );
         assert_ne!(rect.clip_kind[0], 0, "precondition: the clip is active");
 
@@ -1367,36 +1419,88 @@ mod grown_offscreen_clip_tests {
         // `add` returns "batch is now full", not "succeeded".
         assert!(!segment.rect_batch.add(rect), "rect batch not full");
         assert!(!segment.circle_batch.add(circle), "circle batch not full");
-        segment
-            .tess_batches
-            .push(super::super::command_ir::TessellatedBatch {
-                pipeline_key: super::super::pipeline::PipelineKey::alpha_blend(),
-                scissor: None,
-                index_start: 0,
-                index_count: 3,
-                clip_rrect: CLIP,
-                clip_kind: [1, 0, 0, 0],
-            });
+        segment.tess_batches.push(TessellatedBatch {
+            pipeline_key: PipelineKey::alpha_blend(),
+            scissor: None,
+            index_start: 0,
+            index_count: 3,
+            clip: CLIP,
+        });
 
         super::GpuReplay::remap_segment_clips(&mut segment, ORIGIN, SCALE);
 
-        let remapped_rect = segment.rect_batch.instances[0].clip_rrect;
-        let remapped_circle = segment.circle_batch.instances[0].clip_rrect;
+        let rect_m = segment.rect_batch.instances[0].clip_device_to_local;
+        let rect_t = segment.rect_batch.instances[0].clip_local_origin;
         assert_ne!(
-            remapped_rect, CLIP,
-            "precondition: the remap actually changed the rect's clip"
+            rect_m,
+            [
+                CLIP.device_to_local[0],
+                CLIP.device_to_local[1],
+                CLIP.device_to_local[2],
+                CLIP.device_to_local[3]
+            ],
+            "precondition: the rebase actually changed the rect's mapping"
+        );
+
+        assert_eq!(
+            segment.circle_batch.instances[0].clip_device_to_local, rect_m,
+            "a circle's clip must be rebased exactly as a rect's is"
         );
         assert_eq!(
-            segment.tess_batches[0].clip_rrect, remapped_rect,
-            "a tessellated batch's clip must be remapped like a rect's; it IS \
+            segment.circle_batch.instances[0].clip_local_origin, rect_t,
+            "a circle's clip origin must be rebased exactly as a rect's is"
+        );
+
+        let tess = segment.tess_batches[0].clip.device_to_local;
+        assert_eq!(
+            [tess[0], tess[1], tess[2], tess[3]],
+            rect_m,
+            "a tessellated batch's clip must be rebased like a rect's; it IS \
              repositioned into the shrunken intermediate, unlike gradients and \
              images, which `content_aabb` keeps out of that path"
         );
         assert_eq!(
-            remapped_circle, remapped_rect,
-            "a circle's clip must be remapped into the grown offscreen exactly as \
-             a rect's is; leaving it in full-frame device space displaces the \
-             rounded clip inside every blur/filter layer"
+            [tess[4], tess[5]],
+            [rect_t[0], rect_t[1]],
+            "and so must its origin"
+        );
+    }
+
+    /// The rebase is a composition, so applying it must equal mapping through
+    /// the original clip after undoing the framebuffer transform.
+    ///
+    /// A per-component remap of device-space bounds cannot satisfy this under
+    /// rotation — there is no axis-aligned box to move — which is why the old
+    /// representation had to refuse rotated clips outright.
+    #[test]
+    fn the_rebase_composes_with_the_framebuffer_transform() {
+        const ORIGIN: (f32, f32) = (40.0, 24.0);
+        const SCALE: (f32, f32) = (0.5, 0.25);
+        // A 45°-ish rotation with a translation.
+        let m0 = [0.7_f32, 0.7, -0.7, 0.7];
+        let t0 = [12.0_f32, -5.0, 0.0, 0.0];
+
+        let mut m = m0;
+        let mut t = t0;
+        super::GpuReplay::rebase_clip(&mut m, &mut t, [1, 0, 0, 0], ORIGIN, SCALE);
+
+        // A device-space point, and the framebuffer-local point it becomes.
+        let p = (137.0_f32, 91.0_f32);
+        let p_fb = ((p.0 - ORIGIN.0) * SCALE.0, (p.1 - ORIGIN.1) * SCALE.1);
+
+        let apply = |m: [f32; 4], t: [f32; 4], q: (f32, f32)| {
+            (
+                m[0] * q.0 + m[2] * q.1 + t[0],
+                m[1] * q.0 + m[3] * q.1 + t[1],
+            )
+        };
+        let want = apply(m0, t0, p);
+        let got = apply(m, t, p_fb);
+
+        assert!(
+            (want.0 - got.0).abs() < 1e-3 && (want.1 - got.1).abs() < 1e-3,
+            "rebased mapping applied to the framebuffer-local point must land \
+             where the original lands for the device point: want {want:?}, got {got:?}"
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/replay/flush.rs
+++ b/crates/flui-engine/src/wgpu/replay/flush.rs
@@ -601,21 +601,7 @@ impl GpuReplay {
             .tess_batches
             .iter()
             .map(|batch| {
-                let uniform = super::super::command_ir::ClipUniform {
-                    bounds: [
-                        batch.clip_rrect[0],
-                        batch.clip_rrect[1],
-                        batch.clip_rrect[2],
-                        batch.clip_rrect[3],
-                    ],
-                    radii: [
-                        batch.clip_rrect[4],
-                        batch.clip_rrect[5],
-                        batch.clip_rrect[6],
-                        batch.clip_rrect[7],
-                    ],
-                    kind: batch.clip_kind,
-                };
+                let uniform = super::super::command_ir::ClipUniform::from_resolved(batch.clip);
                 let buffer = resources
                     .uniform_pool_mut()
                     .alloc(bytemuck::bytes_of(&uniform));

--- a/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
@@ -61,7 +61,9 @@ struct InstanceInput {
     @location(5) transform_translate: vec4<f32>,// [tx, ty, 0, 0] — translation part
     @location(6) clip_bounds: vec4<f32>,        // [x, y, width, height] of the SDF clip
     @location(7) clip_radii: vec4<f32>,         // [tl, tr, br, bl] of the SDF clip
-    @location(8) clip_kind: vec4<u32>,          // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
+    @location(8) clip_kind: vec4<u32>,           // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
+    @location(9) clip_device_to_local: vec4<f32>,  // [a, b, c, d], columns first
+    @location(10) clip_local_origin: vec4<f32>,    // [tx, ty, 0, 0]
 }
 
 // Vertex output / Fragment input
@@ -82,6 +84,8 @@ struct VertexOutput {
     // Flat: the clip is per-instance, so interpolating it would be both wrong
     // and a source of branch divergence within a draw call.
     @location(5) @interpolate(flat) clip_kind: u32,
+    @location(6) clip_device_to_local: vec4<f32>,
+    @location(7) clip_local_origin: vec4<f32>,
 }
 
 // Viewport uniform (for screen-space to clip-space conversion)
@@ -187,6 +191,8 @@ fn vs_main(
     out.world_pos = device_pos;
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
+    out.clip_device_to_local = instance.clip_device_to_local;
+    out.clip_local_origin = instance.clip_local_origin;
     out.clip_kind = instance.clip_kind.x;
 
     return out;
@@ -221,7 +227,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let alpha = 1.0 - smoothstep(-aa, aa, d);
 
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    let clip_alpha = clipAlpha(
+        in.world_pos,
+        in.clip_bounds,
+        in.clip_radii,
+        in.clip_kind,
+        in.clip_device_to_local,
+        in.clip_local_origin,
+    );
 
     let final_alpha = alpha * clip_alpha;
 

--- a/crates/flui-engine/src/wgpu/shaders/common/clip.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/common/clip.wgsl
@@ -63,28 +63,47 @@ fn sdfToAlpha(dist: f32) -> f32 {
     return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
 
-/// Coverage from the per-instance SDF clip; 1.0 when no clip is attached.
+/// Coverage from the SDF clip; 1.0 when no clip is attached.
 ///
-/// `clip_bounds` is `[x, y, w, h]` in DEVICE space and `clip_radii` is
-/// `[tl, tr, br, bl]`, matching the instance slot the Rust side fills via
-/// `ClippableInstance`. `clip_kind` selects the distance function: 0 = none,
-/// 2 = rounded superellipse, anything else = rounded rect (the safe default
-/// for a kind this shader has not learned about yet).
+/// `clip_bounds` is `[x, y, w, h]` and `clip_radii` is `[tl, tr, br, bl]`, both
+/// in CLIP-LOCAL space — the shape the caller asked for, untransformed.
+/// `device_to_local` maps a device-space fragment position into that space:
+/// `[a, b, c, d]` columns first, `local_origin.xy` the translation.
 ///
-/// The whole evaluation lives here rather than being pasted into each
-/// fragment shader for the same reason the distance functions do: every
-/// clip-capable primitive must agree on what a clip means, and a pasted copy
-/// is free to disagree silently.
+/// Evaluating in local space is what lets a rotated or non-uniformly scaled
+/// clip be exact. Device-space bounds cannot express a rotation at all, and a
+/// scaled circular corner is an ellipse that one radius per corner cannot
+/// hold — so the old form refused rotations and clamped scaled radii.
+///
+/// AA survives the change: `sdfToAlpha` measures the distance field's rate of
+/// change per SCREEN pixel via `dpdx`/`dpdy`, so it picks up the mapping's
+/// Jacobian automatically and the band stays ~1 device pixel wide.
+///
+/// `clip_kind` selects the distance function: 0 = none, 2 = rounded
+/// superellipse, anything else = rounded rect (the safe default for a kind
+/// this shader has not learned about yet).
+///
+/// The whole evaluation lives here rather than being pasted into each fragment
+/// shader for the same reason the distance functions do: every clip-capable
+/// primitive must agree on what a clip means, and a pasted copy is free to
+/// disagree silently.
 fn clipAlpha(
     world_pos: vec2<f32>,
     clip_bounds: vec4<f32>,
     clip_radii: vec4<f32>,
     clip_kind: u32,
+    device_to_local: vec4<f32>,
+    local_origin: vec4<f32>,
 ) -> f32 {
     var alpha = 1.0;
     if (clip_kind != 0u && clip_bounds.z > 0.0 && clip_bounds.w > 0.0) {
+        let local = vec2<f32>(
+            device_to_local.x * world_pos.x + device_to_local.z * world_pos.y + local_origin.x,
+            device_to_local.y * world_pos.x + device_to_local.w * world_pos.y + local_origin.y,
+        );
+
         let clip_center = clip_bounds.xy + clip_bounds.zw * 0.5;
-        let clip_p = world_pos - clip_center;
+        let clip_p = local - clip_center;
         let clip_half = clip_bounds.zw * 0.5;
 
         var clip_dist = 0.0;

--- a/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
@@ -25,6 +25,8 @@ struct InstanceInput {
     @location(8) clip_bounds: vec4<f32>,    // Device-space [x, y, w, h]
     @location(9) clip_radii: vec4<f32>,     // [tl, tr, br, bl]
     @location(10) clip_kind: vec4<u32>,     // [kind, _, _, _]
+    @location(11) clip_device_to_local: vec4<f32>, // [a, b, c, d], columns first
+    @location(12) clip_local_origin: vec4<f32>,    // [tx, ty, 0, 0]
 }
 
 // Gradient stop definition
@@ -50,6 +52,8 @@ struct VertexOutput {
     @location(8) clip_bounds: vec4<f32>,
     @location(9) clip_radii: vec4<f32>,
     @location(10) @interpolate(flat) clip_kind: u32,
+    @location(11) clip_device_to_local: vec4<f32>,
+    @location(12) clip_local_origin: vec4<f32>,
 }
 
 // Uniforms
@@ -143,6 +147,8 @@ fn vs_main(
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
     out.clip_kind = instance.clip_kind.x;
+    out.clip_device_to_local = instance.clip_device_to_local;
+    out.clip_local_origin = instance.clip_local_origin;
 
     return out;
 }
@@ -181,7 +187,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Apply rounded corner alpha (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    let clip_alpha = clipAlpha(
+        in.world_pos,
+        in.clip_bounds,
+        in.clip_radii,
+        in.clip_kind,
+        in.clip_device_to_local,
+        in.clip_local_origin,
+    );
     color = vec4<f32>(color.rgb, color.a * alpha * clip_alpha);
 
     return color;

--- a/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
@@ -25,6 +25,8 @@ struct InstanceInput {
     @location(8) clip_bounds: vec4<f32>,    // Device-space [x, y, w, h]
     @location(9) clip_radii: vec4<f32>,     // [tl, tr, br, bl]
     @location(10) clip_kind: vec4<u32>,     // [kind, _, _, _]
+    @location(11) clip_device_to_local: vec4<f32>, // [a, b, c, d], columns first
+    @location(12) clip_local_origin: vec4<f32>,    // [tx, ty, 0, 0]
 }
 
 // Gradient stop (same as linear)
@@ -52,6 +54,8 @@ struct VertexOutput {
     @location(8) clip_bounds: vec4<f32>,
     @location(9) clip_radii: vec4<f32>,
     @location(10) @interpolate(flat) clip_kind: u32,
+    @location(11) clip_device_to_local: vec4<f32>,
+    @location(12) clip_local_origin: vec4<f32>,
 }
 
 // Uniforms
@@ -139,6 +143,8 @@ fn vs_main(
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
     out.clip_kind = instance.clip_kind.x;
+    out.clip_device_to_local = instance.clip_device_to_local;
+    out.clip_local_origin = instance.clip_local_origin;
 
     return out;
 }
@@ -174,7 +180,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Apply corner clipping (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    let clip_alpha = clipAlpha(
+        in.world_pos,
+        in.clip_bounds,
+        in.clip_radii,
+        in.clip_kind,
+        in.clip_device_to_local,
+        in.clip_local_origin,
+    );
     color = vec4<f32>(color.rgb, color.a * alpha * clip_alpha);
 
     return color;

--- a/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
@@ -25,6 +25,8 @@ struct InstanceInput {
     @location(8) clip_bounds: vec4<f32>,    // Device-space [x, y, w, h]
     @location(9) clip_radii: vec4<f32>,     // [tl, tr, br, bl]
     @location(10) clip_kind: vec4<u32>,     // [kind, _, _, _]
+    @location(11) clip_device_to_local: vec4<f32>, // [a, b, c, d], columns first
+    @location(12) clip_local_origin: vec4<f32>,    // [tx, ty, 0, 0]
 }
 
 // Gradient stop (same layout as linear/radial)
@@ -52,6 +54,8 @@ struct VertexOutput {
     @location(8) clip_bounds: vec4<f32>,
     @location(9) clip_radii: vec4<f32>,
     @location(10) @interpolate(flat) clip_kind: u32,
+    @location(11) clip_device_to_local: vec4<f32>,
+    @location(12) clip_local_origin: vec4<f32>,
 }
 
 // Uniforms
@@ -139,6 +143,8 @@ fn vs_main(
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
     out.clip_kind = instance.clip_kind.x;
+    out.clip_device_to_local = instance.clip_device_to_local;
+    out.clip_local_origin = instance.clip_local_origin;
 
     return out;
 }
@@ -192,7 +198,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Apply corner clipping (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    let clip_alpha = clipAlpha(
+        in.world_pos,
+        in.clip_bounds,
+        in.clip_radii,
+        in.clip_kind,
+        in.clip_device_to_local,
+        in.clip_local_origin,
+    );
     color = vec4<f32>(color.rgb, color.a * alpha * clip_alpha);
 
     return color;

--- a/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
@@ -44,7 +44,9 @@ struct InstanceInput {
     @location(6) clip_bounds: vec4<f32>,         // [x, y, width, height] of clip
     @location(7) clip_radii: vec4<f32>,          // [tl, tr, br, bl] of clip
     @location(8) clip_kind: vec4<u32>,           // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
-    @location(9) transform_translate: vec4<f32>, // [tx, ty, 0, 0] — translation part of affine
+    @location(9) clip_device_to_local: vec4<f32>,  // [a, b, c, d], columns first
+    @location(10) clip_local_origin: vec4<f32>,    // [tx, ty, 0, 0]
+    @location(11) transform_translate: vec4<f32>, // [tx, ty, 0, 0] — translation part of affine
 }
 
 // Vertex output / Fragment input
@@ -58,6 +60,8 @@ struct VertexOutput {
     @location(5) clip_bounds: vec4<f32>,     // Clip rect bounds
     @location(6) clip_radii: vec4<f32>,      // Clip corner radii (single-radius-per-corner)
     @location(7) @interpolate(flat) clip_kind: u32, // 0=none, 1=rrect, 2=rsuperellipse
+    @location(8) clip_device_to_local: vec4<f32>,
+    @location(9) clip_local_origin: vec4<f32>,
 }
 
 // Viewport uniform (for screen-space to clip-space conversion)
@@ -147,6 +151,8 @@ fn vs_main(
     out.world_pos = device_pos;
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
+    out.clip_device_to_local = instance.clip_device_to_local;
+    out.clip_local_origin = instance.clip_local_origin;
     out.clip_kind = instance.clip_kind.x;
 
     return out;
@@ -170,7 +176,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let alpha = sdfToAlpha(dist);
 
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    let clip_alpha = clipAlpha(
+        in.world_pos,
+        in.clip_bounds,
+        in.clip_radii,
+        in.clip_kind,
+        in.clip_device_to_local,
+        in.clip_local_origin,
+    );
 
     // Return color with antialiased alpha, modulated by clip alpha
     return vec4<f32>(in.color.rgb, in.color.a * alpha * clip_alpha);

--- a/crates/flui-engine/src/wgpu/shaders/shape.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/shape.wgsl
@@ -19,6 +19,8 @@ struct ClipUniform {
     bounds: vec4<f32>,  // Device-space [x, y, w, h]
     radii: vec4<f32>,   // [tl, tr, br, bl]
     kind: vec4<u32>,    // [kind, _, _, _]: 0 = none, 1 = rrect, 2 = rsuperellipse
+    device_to_local: vec4<f32>, // [a, b, c, d], columns first
+    local_origin: vec4<f32>,    // [tx, ty, 0, 0]
 }
 
 @group(1) @binding(0)
@@ -33,7 +35,8 @@ struct VertexInput {
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) color: vec4<f32>,
-    // Device-space position, carried for the clip SDF. `clip_position` is in
+    // Device-space position, carried for the clip SDF, which maps it
+    // into clip-local space itself. `clip_position` is in
     // NDC by the time the fragment stage sees it, so it cannot serve here.
     @location(1) world_pos: vec2<f32>,
 }
@@ -67,6 +70,14 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let c = input.color;
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let a = c.a * clipAlpha(input.world_pos, clip.bounds, clip.radii, clip.kind.x);
+    let a = c.a
+        * clipAlpha(
+            input.world_pos,
+            clip.bounds,
+            clip.radii,
+            clip.kind.x,
+            clip.device_to_local,
+            clip.local_origin,
+        );
     return vec4<f32>(c.rgb * a, a);
 }

--- a/crates/flui-engine/src/wgpu/shaders/shape.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/shape.wgsl
@@ -16,7 +16,7 @@ var<uniform> viewport: Viewport;
 // slot on, so the clip is bound once per `TessellatedBatch` — the granularity
 // the batcher already splits at, since it refuses to merge across a clip change.
 struct ClipUniform {
-    bounds: vec4<f32>,  // Device-space [x, y, w, h]
+    bounds: vec4<f32>,  // Clip-local [x, y, w, h]; device_to_local maps into it
     radii: vec4<f32>,   // [tl, tr, br, bl]
     kind: vec4<u32>,    // [kind, _, _, _]: 0 = none, 1 = rrect, 2 = rsuperellipse
     device_to_local: vec4<f32>, // [a, b, c, d], columns first

--- a/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
@@ -19,7 +19,9 @@ struct InstanceInput {
     @location(5) transform: vec4<f32>,     // [cos(angle), sin(angle), tx, ty]
     @location(6) clip_bounds: vec4<f32>,   // [x, y, width, height] of clip
     @location(7) clip_radii: vec4<f32>,    // [tl, tr, br, bl] of clip
-    @location(8) clip_kind: vec4<u32>,     // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
+    @location(8) clip_kind: vec4<u32>,           // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
+    @location(9) clip_device_to_local: vec4<f32>,  // [a, b, c, d], columns first
+    @location(10) clip_local_origin: vec4<f32>,    // [tx, ty, 0, 0]
 }
 
 // Vertex output / Fragment input
@@ -31,6 +33,8 @@ struct VertexOutput {
     @location(3) clip_bounds: vec4<f32>,   // Clip rect bounds
     @location(4) clip_radii: vec4<f32>,    // Clip corner radii
     @location(5) @interpolate(flat) clip_kind: u32, // 0=none, 1=rrect, 2=rsuperellipse
+    @location(6) clip_device_to_local: vec4<f32>,
+    @location(7) clip_local_origin: vec4<f32>,
 }
 
 // =============================================================================
@@ -120,6 +124,8 @@ fn vs_main(
     out.world_pos = world_pos;
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
+    out.clip_device_to_local = instance.clip_device_to_local;
+    out.clip_local_origin = instance.clip_local_origin;
     out.clip_kind = instance.clip_kind.x;
 
     return out;
@@ -134,7 +140,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     tex_color = tex_color * in.tint;
 
     // Clip coverage — see `clipAlpha` in `common/clip.wgsl`.
-    let clip_alpha = clipAlpha(in.world_pos, in.clip_bounds, in.clip_radii, in.clip_kind);
+    let clip_alpha = clipAlpha(
+        in.world_pos,
+        in.clip_bounds,
+        in.clip_radii,
+        in.clip_kind,
+        in.clip_device_to_local,
+        in.clip_local_origin,
+    );
 
     tex_color.a = tex_color.a * clip_alpha;
 

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -549,11 +549,21 @@ impl GpuStateStack {
     /// Invert the CTM's 2D affine part into the `[a, b, c, d, tx, ty]` column
     /// form `current_clip_inv` holds.
     ///
-    /// A singular matrix — `scale(0, …)` collapses geometry to a line — has no
-    /// inverse; the identity is returned, which leaves the clip evaluated in
-    /// device space. Nothing is drawn through a singular CTM anyway, so the
-    /// choice is unobservable; it exists so the arithmetic below never
-    /// produces infinities the shader would then compare against.
+    /// The fallback is keyed on the arithmetic actually breaking down, not on
+    /// the determinant clearing a threshold. An absolute epsilon rejects
+    /// matrices that ARE invertible: `f32::EPSILON` is ~1.19e-7, so
+    /// `scale(1e-4, 1e-4)` has determinant 1e-8 and would be declared
+    /// singular — and a scale animation starting near zero passes through
+    /// exactly those frames. With the clip silently identity-mapped there, its
+    /// local bounds get compared against device coordinates and the draw can
+    /// vanish for a frame or two at the start of every such animation.
+    ///
+    /// A genuinely singular matrix — `scale(0, …)` collapses geometry to a
+    /// line — yields infinities, which the finiteness check catches along with
+    /// NaN and any overflow the reciprocal produces. The identity is returned
+    /// there, which leaves the clip evaluated in device space; nothing is drawn
+    /// through a singular CTM anyway, so the choice is unobservable. It exists
+    /// so the shader never compares against a non-finite mapping.
     fn device_to_local(transform: glam::Mat4) -> [f32; 6] {
         let a = transform.x_axis.x;
         let b = transform.x_axis.y;
@@ -562,14 +572,16 @@ impl GpuStateStack {
         let tx = transform.w_axis.x;
         let ty = transform.w_axis.y;
 
-        let det = a * d - b * c;
-        if det.abs() < f32::EPSILON {
-            return CLIP_INV_IDENTITY;
-        }
-        let inv_det = 1.0 / det;
+        let inv_det = 1.0 / (a * d - b * c);
         let (ia, ib, ic, id) = (d * inv_det, -b * inv_det, -c * inv_det, a * inv_det);
         // local = M⁻¹ · (p − t)
-        [ia, ib, ic, id, -(ia * tx + ic * ty), -(ib * tx + id * ty)]
+        let inv = [ia, ib, ic, id, -(ia * tx + ic * ty), -(ib * tx + id * ty)];
+
+        if inv.iter().all(|v| v.is_finite()) {
+            inv
+        } else {
+            CLIP_INV_IDENTITY
+        }
     }
 
     /// Set an SDF superellipse (iOS-squircle) clip and clear any active rrect
@@ -1062,6 +1074,43 @@ mod tests {
         assert!(
             stack.current_scissor().is_some(),
             "the coarse scissor still applies as an early-rejection pre-pass"
+        );
+    }
+
+    /// A tiny-but-invertible scale is inverted, not written off as singular.
+    ///
+    /// An absolute determinant threshold gets this wrong: `f32::EPSILON` is
+    /// ~1.19e-7, so `scale(1e-4, 1e-4)` has determinant 1e-8 and clears no
+    /// such bar despite being perfectly invertible. A scale animation starting
+    /// near zero passes through exactly these frames, and an identity-mapped
+    /// clip there compares its local bounds against device coordinates — the
+    /// draw can vanish for a frame or two at the start of every one.
+    ///
+    /// A local 1,000,000-unit box under this scale is a 100-unit box on
+    /// screen, so a device point at 50 must map back to 500,000.
+    #[test]
+    fn a_tiny_but_invertible_scale_is_still_inverted() {
+        let mut stack = GpuStateStack::new_for_test();
+        stack.scale(1e-4, 1e-4);
+        stack.clip_rrect(
+            RRect::from_rect_circular(
+                Rect::from_xywh(px(0.0), px(0.0), px(1.0e6), px(1.0e6)),
+                px(1.0e5),
+            ),
+            (400, 400),
+        );
+
+        let m = stack.active_clip().device_to_local;
+        assert_ne!(
+            m, CLIP_INV_IDENTITY,
+            "an invertible CTM must not be written off as singular"
+        );
+
+        let local_x = m[0] * 50.0 + m[2] * 50.0 + m[4];
+        let local_y = m[1] * 50.0 + m[3] * 50.0 + m[5];
+        assert!(
+            (local_x - 500_000.0).abs() < 1.0 && (local_y - 500_000.0).abs() < 1.0,
+            "device (50, 50) must map to local (500000, 500000), got ({local_x}, {local_y})"
         );
     }
 

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -80,6 +80,58 @@ pub(super) struct GpuStateStack {
 
     /// Active SDF superellipse clip uniform. All-zeros means no clip.
     current_rsuperellipse_clip: [f32; 12],
+
+    // ===== Clip-local mapping =====
+    /// Saved device-to-clip-local mappings, one per `save()`.
+    clip_inv_stack: Vec<[f32; 6]>,
+
+    /// Maps a device-space point into the space the active clip's bounds and
+    /// radii are expressed in: `[a, b, c, d, tx, ty]`, columns first, so
+    /// `local = (a, b) * p.x + (c, d) * p.y + (tx, ty)`.
+    ///
+    /// The clip slots hold LOCAL bounds — the shape the caller asked for,
+    /// untransformed — and this is the inverse of the CTM that was current
+    /// when the clip was set. Storing device-space bounds instead cannot
+    /// express a rotation (an axis-aligned box has no rotated form) and
+    /// mangles a non-uniform scale (a scaled circular corner is an ellipse,
+    /// and one radius per corner cannot hold one).
+    ///
+    /// The drawn rrect already worked this way — `with_affine_transform` sends
+    /// local bounds plus the affine and lets the shader place them. This is
+    /// the same information, inverted, because the fragment stage starts from
+    /// a device-space position and has to get back.
+    ///
+    /// Identity is `[1, 0, 0, 1, 0, 0]`.
+    current_clip_inv: [f32; 6],
+}
+
+/// Identity device-to-clip-local mapping: columns `(1, 0)`, `(0, 1)`, no
+/// translation.
+const CLIP_INV_IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
+/// The active SDF clip, in the form every consumer stores it.
+///
+/// One value rather than three loose arrays because the three travel together
+/// everywhere — instance slots, the tessellated batch uniform, and the
+/// offscreen remaps — and a caller that carried two of them would produce a
+/// clip evaluated in the wrong space with nothing to catch it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ResolvedClip {
+    /// `[x, y, w, h, tl, tr, br, bl]` in CLIP-LOCAL space.
+    pub(crate) rrect: [f32; 8],
+    /// `[kind, _, _, _]`: 0 = none, 1 = rrect, 2 = rounded superellipse.
+    pub(crate) kind: [u32; 4],
+    /// Device-to-clip-local mapping — see `GpuStateStack::current_clip_inv`.
+    pub(crate) device_to_local: [f32; 6],
+}
+
+impl ResolvedClip {
+    /// No clip active.
+    pub(crate) const NONE: Self = Self {
+        rrect: [0.0; 8],
+        kind: [0; 4],
+        device_to_local: CLIP_INV_IDENTITY,
+    };
 }
 
 impl GpuStateStack {
@@ -95,6 +147,8 @@ impl GpuStateStack {
             current_rrect_clip: [0.0; 8],
             rsuperellipse_clip_stack: Vec::new(),
             current_rsuperellipse_clip: [0.0; 12],
+            clip_inv_stack: Vec::new(),
+            current_clip_inv: CLIP_INV_IDENTITY,
         }
     }
 
@@ -123,6 +177,8 @@ impl GpuStateStack {
         self.rrect_clip_stack.clear();
         self.current_rsuperellipse_clip = [0.0; 12];
         self.rsuperellipse_clip_stack.clear();
+        self.current_clip_inv = CLIP_INV_IDENTITY;
+        self.clip_inv_stack.clear();
         // Identity is the construction-time value. Reset to the same initial
         // value so no cross-frame CTM leak can occur.
         self.current_transform = glam::Mat4::IDENTITY;
@@ -184,6 +240,7 @@ impl GpuStateStack {
         self.rrect_clip_stack.push(self.current_rrect_clip);
         self.rsuperellipse_clip_stack
             .push(self.current_rsuperellipse_clip);
+        self.clip_inv_stack.push(self.current_clip_inv);
     }
 
     /// Pop transform, scissor (conditionally), and both SDF clip uniforms.
@@ -217,6 +274,10 @@ impl GpuStateStack {
             .rsuperellipse_clip_stack
             .pop()
             .expect("rsuperellipse_clip_stack parallel to transform_stack");
+        self.current_clip_inv = self
+            .clip_inv_stack
+            .pop()
+            .expect("BUG: clip_inv_stack is pushed in save() alongside transform_stack");
 
         #[cfg(debug_assertions)]
         tracing::trace!(
@@ -448,186 +509,91 @@ impl GpuStateStack {
         reason = "r_tl/r_tr/r_br/r_bl mirror the rrect-corner field names; renaming would obscure intent"
     )]
     pub(super) fn clip_rrect(&mut self, rrect: RRect, surface_size: (u32, u32)) {
-        let transform = self.current_transform;
         let rect = rrect.rect;
 
-        // A rotated or skewed CTM has no representation in this slot: the
-        // shader evaluates an axis-aligned box, and the bounds below are
-        // derived from two corners, which for a rotated rect is not even its
-        // AABB — a 45° rotation collapses them onto one vertical, giving a
-        // ZERO-width clip that erases everything it covers. Leaving the slot
-        // empty and relying on the coarse scissor over-includes, which is the
-        // survivable direction of wrong; a clip carried in local space with
-        // its own transform is what would represent this properly.
-        if !self.is_axis_aligned() {
-            self.current_rrect_clip = [0.0; 8];
-            self.current_rsuperellipse_clip = [0.0; 12];
-            self.clip_rect(rrect.rect, surface_size);
-            return;
-        }
-
-        let (x, y, w, h) = if transform == glam::Mat4::IDENTITY {
-            (rect.left().0, rect.top().0, rect.width().0, rect.height().0)
-        } else {
-            let tl = transform * glam::Vec4::new(rect.left().0, rect.top().0, 0.0, 1.0);
-            let br = transform * glam::Vec4::new(rect.right().0, rect.bottom().0, 0.0, 1.0);
-            let min_x = tl.x.min(br.x);
-            let min_y = tl.y.min(br.y);
-            let max_x = tl.x.max(br.x);
-            let max_y = tl.y.max(br.y);
-            (min_x, min_y, max_x - min_x, max_y - min_y)
-        };
-
-        // The radii live in the same space as the bounds, so they have to make
-        // the same trip. Transforming the bounds alone leaves them in logical
-        // pixels while the SDF evaluates against a device-pixel rect: at the
-        // root `scale(dpr)` of any HiDPI display a 100×100 circular clip
-        // becomes 200×200 with 50-pixel corners — a rounded square, not a
-        // circle. Derive the per-axis factors from what the bounds actually
-        // did rather than decomposing the matrix, so a translation-only or
-        // identity transform yields exactly 1.0 and the values stay bit-equal
-        // to the untransformed path.
-        // Only meaningful when the CTM is axis-aligned. Under rotation or
-        // skew the bounds above are the AABB of a rotated rect, so this ratio
-        // is the AABB's aspect change and not a scale at all — at 45° it would
-        // inflate every radius by ~1.41 for no reason. The SDF slot cannot
-        // express a rotated clip either way (the shader evaluates an
-        // axis-aligned box), so that case keeps its radii untouched: still an
-        // approximation, but the same one it was before, rather than a new
-        // and larger distortion layered on top. Representing a rotated clip
-        // properly needs the clip carried in local space with its own
-        // transform — a change to the instance format, not to this line.
-        let (scale_x, scale_y) = if rect.width().0 > 0.0 && rect.height().0 > 0.0 {
-            (w / rect.width().0, h / rect.height().0)
-        } else {
-            (1.0, 1.0)
-        };
-        // This slot carries ONE radius per corner, so an elliptical corner is
-        // not representable in it. Under a non-uniform scale — `scale(2, 1)`
-        // turning a circle into an ellipse with radii (100, 50) — the two
-        // scaled axes have to collapse to a scalar, and a bare `max` would
-        // hand the shader a radius larger than the box's own half-height. The
-        // rounded-box SDF is degenerate there and clips visibly INWARD.
+        // LOCAL bounds and radii — exactly what the caller asked for. The
+        // mapping below is what places them; see `current_clip_inv`.
         //
-        // So collapse, then clamp to the largest radius the box can hold. The
-        // result is the largest well-formed rounded shape inside the intended
-        // ellipse: still a divergence under non-uniform scale, but a bounded
-        // one instead of a broken one. Carrying rx/ry per corner through the
-        // instance and both shaders is the real fix and a format change of its
-        // own; the superellipse slot above already has the room for it.
-        let max_radius = (w * 0.5).min(h * 0.5).max(0.0);
-        let collapse = |rx: f32, ry: f32| (rx * scale_x).max(ry * scale_y).min(max_radius);
-        let r_tl = collapse(rrect.top_left.x.0, rrect.top_left.y.0);
-        let r_tr = collapse(rrect.top_right.x.0, rrect.top_right.y.0);
-        let r_br = collapse(rrect.bottom_right.x.0, rrect.bottom_right.y.0);
-        let r_bl = collapse(rrect.bottom_left.x.0, rrect.bottom_left.y.0);
+        // This slot carries ONE radius per corner, so a caller's own
+        // elliptical corner still has to collapse. That is now the only
+        // approximation left here: a corner made elliptical by a non-uniform
+        // CTM stays circular in this space and the mapping produces the
+        // ellipse, which is exact.
+        let max_radius = (rect.width().0 * 0.5).min(rect.height().0 * 0.5).max(0.0);
+        let collapse = |rx: f32, ry: f32| rx.max(ry).min(max_radius);
 
-        self.current_rrect_clip = [x, y, w, h, r_tl, r_tr, r_br, r_bl];
+        self.current_rrect_clip = [
+            rect.left().0,
+            rect.top().0,
+            rect.width().0,
+            rect.height().0,
+            collapse(rrect.top_left.x.0, rrect.top_left.y.0),
+            collapse(rrect.top_right.x.0, rrect.top_right.y.0),
+            collapse(rrect.bottom_right.x.0, rrect.bottom_right.y.0),
+            collapse(rrect.bottom_left.x.0, rrect.bottom_left.y.0),
+        ];
+        self.current_clip_inv = Self::device_to_local(self.current_transform);
         // Clearing the superellipse clip prevents `apply_active_clip` from
         // continuing to apply the squircle SDF after the caller switches to a
         // plain rrect. The two clip kinds are mutually exclusive at the
         // per-instance `clip_kind` level.
         self.current_rsuperellipse_clip = [0.0; 12];
 
-        // Bounding-box scissor for early rasterizer rejection.
+        // Bounding-box scissor for early rasterizer rejection. Conservative
+        // under rotation — `clip_rect` takes the AABB of all four transformed
+        // corners — which is exactly what a coarse pre-pass should be now that
+        // the SDF does the precise work.
         self.clip_rect(rrect.rect, surface_size);
-
-        #[cfg(debug_assertions)]
-        tracing::trace!(
-            "GpuStateStack::clip_rrect: SDF clip set [{:.1}, {:.1}, {:.1}, {:.1}] radii=[{:.1}, {:.1}, {:.1}, {:.1}]",
-            x,
-            y,
-            w,
-            h,
-            r_tl,
-            r_tr,
-            r_br,
-            r_bl,
-        );
     }
 
-    /// Set a SDF superellipse (iOS-squircle) clip and clear any active rrect
+    /// Invert the CTM's 2D affine part into the `[a, b, c, d, tx, ty]` column
+    /// form `current_clip_inv` holds.
+    ///
+    /// A singular matrix — `scale(0, …)` collapses geometry to a line — has no
+    /// inverse; the identity is returned, which leaves the clip evaluated in
+    /// device space. Nothing is drawn through a singular CTM anyway, so the
+    /// choice is unobservable; it exists so the arithmetic below never
+    /// produces infinities the shader would then compare against.
+    fn device_to_local(transform: glam::Mat4) -> [f32; 6] {
+        let a = transform.x_axis.x;
+        let b = transform.x_axis.y;
+        let c = transform.y_axis.x;
+        let d = transform.y_axis.y;
+        let tx = transform.w_axis.x;
+        let ty = transform.w_axis.y;
+
+        let det = a * d - b * c;
+        if det.abs() < f32::EPSILON {
+            return CLIP_INV_IDENTITY;
+        }
+        let inv_det = 1.0 / det;
+        let (ia, ib, ic, id) = (d * inv_det, -b * inv_det, -c * inv_det, a * inv_det);
+        // local = M⁻¹ · (p − t)
+        [ia, ib, ic, id, -(ia * tx + ic * ty), -(ib * tx + id * ty)]
+    }
+
+    /// Set an SDF superellipse (iOS-squircle) clip and clear any active rrect
     /// clip (the two kinds are mutually exclusive per-instance).
     ///
-    /// Also applies a bounding-box `clip_rect` for early rasterizer rejection.
-    #[allow(
-        clippy::similar_names,
-        reason = "tl_r/tr_r/br_r/bl_r mirror the rsuperellipse-corner field names; renaming would obscure intent"
-    )]
+    /// Stores LOCAL bounds and radii plus the device-to-local mapping, exactly
+    /// as [`Self::clip_rrect`] does. Unlike the rrect slot this one carries rx
+    /// and ry per corner, so nothing collapses here at all.
     pub(super) fn clip_rsuperellipse(
         &mut self,
         rse: flui_types::geometry::RSuperellipse,
         surface_size: (u32, u32),
     ) {
-        let transform = self.current_transform;
         let rect = rse.outer_rect();
-
-        // Same bail-out as `clip_rrect`, for the same reason: this slot is
-        // axis-aligned in the shader and its bounds cannot survive a rotation.
-        if !self.is_axis_aligned() {
-            self.current_rsuperellipse_clip = [0.0; 12];
-            self.current_rrect_clip = [0.0; 8];
-            self.clip_rect(rect, surface_size);
-            return;
-        }
-
-        let (x, y, w, h) = if transform == glam::Mat4::IDENTITY {
-            (rect.left().0, rect.top().0, rect.width().0, rect.height().0)
-        } else {
-            let tl = transform * glam::Vec4::new(rect.left().0, rect.top().0, 0.0, 1.0);
-            let br = transform * glam::Vec4::new(rect.right().0, rect.bottom().0, 0.0, 1.0);
-            let min_x = tl.x.min(br.x);
-            let min_y = tl.y.min(br.y);
-            let max_x = tl.x.max(br.x);
-            let max_y = tl.y.max(br.y);
-            (min_x, min_y, max_x - min_x, max_y - min_y)
-        };
-
         let tl_r = rse.tl_radius();
         let tr_r = rse.tr_radius();
         let br_r = rse.br_radius();
         let bl_r = rse.bl_radius();
 
-        // Same rule as `clip_rrect`: radii live in the bounds' space and must
-        // make the same trip, or the shader compares logical-pixel corners
-        // against a device-pixel rect. Unlike the rrect slot, this one carries
-        // rx and ry per corner, so the per-axis scale is exact here rather
-        // than an approximation.
-        let (scale_x, scale_y) = if rect.width().0 > 0.0 && rect.height().0 > 0.0 {
-            (w / rect.width().0, h / rect.height().0)
-        } else {
-            (1.0, 1.0)
-        };
-
         self.current_rsuperellipse_clip = [
-            x,
-            y,
-            w,
-            h,
-            tl_r.x.0 * scale_x,
-            tl_r.y.0 * scale_y,
-            tr_r.x.0 * scale_x,
-            tr_r.y.0 * scale_y,
-            br_r.x.0 * scale_x,
-            br_r.y.0 * scale_y,
-            bl_r.x.0 * scale_x,
-            bl_r.y.0 * scale_y,
-        ];
-        // Clear the rrect clip to prevent `apply_active_clip` from falling
-        // back to it. Mirror of the corresponding clear in `clip_rrect`.
-        self.current_rrect_clip = [0.0; 8];
-
-        // Bounding-box scissor for early rasterizer rejection.
-        self.clip_rect(rect, surface_size);
-
-        #[cfg(debug_assertions)]
-        tracing::trace!(
-            "GpuStateStack::clip_rsuperellipse: SDF clip set [{:.1}, {:.1}, {:.1}, {:.1}] \
-             radii=[(tl {:.1},{:.1}) (tr {:.1},{:.1}) (br {:.1},{:.1}) (bl {:.1},{:.1})]",
-            x,
-            y,
-            w,
-            h,
+            rect.left().0,
+            rect.top().0,
+            rect.width().0,
+            rect.height().0,
             tl_r.x.0,
             tl_r.y.0,
             tr_r.x.0,
@@ -636,7 +602,14 @@ impl GpuStateStack {
             br_r.y.0,
             bl_r.x.0,
             bl_r.y.0,
-        );
+        ];
+        self.current_clip_inv = Self::device_to_local(self.current_transform);
+        // Clear the rrect clip to prevent `apply_active_clip` from falling
+        // back to it. Mirror of the corresponding clear in `clip_rrect`.
+        self.current_rrect_clip = [0.0; 8];
+
+        // Bounding-box scissor for early rasterizer rejection.
+        self.clip_rect(rect, surface_size);
     }
 
     // =========================================================================
@@ -644,7 +617,7 @@ impl GpuStateStack {
     // =========================================================================
 
     /// The currently-active SDF clip, resolved to the single form every
-    /// consumer stores: `([x, y, w, h, tl, tr, br, bl], [kind, _, _, _])`.
+    /// consumer stores.
     ///
     /// Branch order: a non-trivial `current_rsuperellipse_clip` wins
     /// (`kind = 2`), otherwise the rrect slot is used (`kind = 1` when
@@ -653,20 +626,21 @@ impl GpuStateStack {
     /// This is the ONE place that selection happens. Instanced primitives
     /// reach it through `apply_active_clip`; tessellated geometry, which has
     /// no instance to hang a slot on, reads it directly for its batch uniform.
-    pub(super) fn active_clip(&self) -> ([f32; 8], [u32; 4]) {
+    pub(super) fn active_clip(&self) -> ResolvedClip {
         // Exact equality against the all-zero "no clip active" sentinel is
-        // intentional: the field is set bit-exact to `[0.0; 12]` whenever the
-        // clip is cleared, never via arithmetic that would introduce ULP noise.
+        // intentional: the field is set bit-exact whenever the clip is
+        // cleared, never via arithmetic that would introduce ULP noise.
         #[expect(
             clippy::float_cmp,
             reason = "exact comparison against the bit-exact 'no clip' sentinels"
         )]
         let superellipse_active = self.current_rsuperellipse_clip != [0.0; 12];
         if superellipse_active {
-            return (
-                super::instancing::reduce_superellipse_clip(self.current_rsuperellipse_clip),
-                [2, 0, 0, 0],
-            );
+            return ResolvedClip {
+                rrect: super::instancing::reduce_superellipse_clip(self.current_rsuperellipse_clip),
+                kind: [2, 0, 0, 0],
+                device_to_local: self.current_clip_inv,
+            };
         }
         #[expect(
             clippy::float_cmp,
@@ -674,9 +648,13 @@ impl GpuStateStack {
         )]
         let rrect_active = self.current_rrect_clip != [0.0; 8];
         if rrect_active {
-            (self.current_rrect_clip, [1, 0, 0, 0])
+            ResolvedClip {
+                rrect: self.current_rrect_clip,
+                kind: [1, 0, 0, 0],
+                device_to_local: self.current_clip_inv,
+            }
         } else {
-            ([0.0; 8], [0; 4])
+            ResolvedClip::NONE
         }
     }
 
@@ -688,12 +666,7 @@ impl GpuStateStack {
         &self,
         instance: I,
     ) -> I {
-        let (_, kind) = self.active_clip();
-        if kind[0] == 2 {
-            instance.with_clip_rsuperellipse(self.current_rsuperellipse_clip)
-        } else {
-            instance.with_clip_rrect(self.current_rrect_clip)
-        }
+        instance.with_clip(self.active_clip())
     }
 }
 
@@ -987,40 +960,6 @@ mod tests {
         );
     }
 
-    /// A scaled circular clip must stay a circle.
-    ///
-    /// `clip_rrect` transforms the bounds through the CTM. If the radii do not
-    /// make the same trip they stay in logical pixels while the SDF evaluates
-    /// against a device-pixel rect — so at the root `scale(dpr)` of any HiDPI
-    /// display a circular clip renders as a rounded square. The invariant that
-    /// makes it a circle is `radius == shorter_side / 2`, and it has to hold
-    /// after the transform, not just before it.
-    #[test]
-    fn a_scaled_circular_clip_keeps_its_radius_proportional_to_its_bounds() {
-        let mut stack = GpuStateStack::new_for_test();
-        let surface = (400u32, 400u32);
-
-        let circle = RRect::from_rect_circular(
-            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
-            px(50.0),
-        );
-
-        stack.scale(2.0, 2.0);
-        stack.clip_rrect(circle, surface);
-
-        let clip = stack.current_rrect_clip;
-        let (w, h) = (clip[2], clip[3]);
-        assert_eq!((w, h), (200.0, 200.0), "the bounds scale with the CTM");
-        for (corner, radius) in ["tl", "tr", "br", "bl"].iter().zip(&clip[4..8]) {
-            assert!(
-                (radius - w / 2.0).abs() < 0.01,
-                "corner {corner} must stay at half the scaled side ({}), got {radius} — a \
-                 smaller radius is a rounded square wearing a circle's bounds",
-                w / 2.0,
-            );
-        }
-    }
-
     /// The untransformed path must be untouched by the scaling fix.
     #[test]
     fn an_unscaled_clip_keeps_its_radii_bit_exact() {
@@ -1039,92 +978,110 @@ mod tests {
         );
     }
 
-    /// The superellipse slot has room for per-axis radii, so its scaling is
-    /// exact — no collapse, no clamp.
-    #[test]
-    fn a_scaled_superellipse_clip_scales_each_radius_axis() {
-        use flui_types::geometry::RSuperellipse;
-
-        let mut stack = GpuStateStack::new_for_test();
-        let rse = RSuperellipse::from_rect_circular(
-            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
-            px(20.0),
-        );
-
-        stack.scale(2.0, 3.0);
-        stack.clip_rsuperellipse(rse, (600, 600));
-
-        let clip = stack.current_rsuperellipse_clip;
-        assert_eq!((clip[2], clip[3]), (200.0, 300.0), "bounds follow the CTM");
-        for (i, corner) in ["tl", "tr", "br", "bl"].iter().enumerate() {
-            let (rx, ry) = (clip[4 + i * 2], clip[5 + i * 2]);
-            assert!(
-                (rx - 40.0).abs() < 0.01 && (ry - 60.0).abs() < 0.01,
-                "corner {corner} must scale per axis (40, 60), got ({rx}, {ry}) — leaving \
-                 either in logical pixels leaks the clip on a HiDPI display",
-            );
-        }
-    }
-
-    /// A non-uniform scale cannot be represented in the rrect slot's single
-    /// radius per corner, so the collapse must at least stay well-formed.
+    /// The clip slot holds the caller's shape untouched, whatever the CTM.
     ///
-    /// `scale(2, 1)` turns a circular clip into a 200×100 box whose intended
-    /// corners are (100, 50). The scalar collapse picks 100, which exceeds the
-    /// box's own half-height — a rounded-box SDF with a radius larger than its
-    /// half-extent is degenerate and clips inward, eating the image. Clamping
-    /// to the largest radius the box can hold keeps it a bounded divergence
-    /// rather than a broken one.
+    /// The slot used to hold DEVICE-space bounds, which forced the radii to
+    /// make the same trip — and a scaled circular corner is an ellipse, which
+    /// one radius per corner cannot hold. Keeping the shape local moves that
+    /// job to the mapping, where it is exact.
+    ///
+    /// This replaces three tests that pinned the device-space form: a HiDPI
+    /// proportionality check, a non-uniform-scale radius clamp, and a
+    /// per-axis superellipse scale. Each protected the same underlying rule —
+    /// a circular clip must not become a rounded square — which now holds by
+    /// construction rather than by arithmetic.
     #[test]
-    fn a_non_uniform_scale_clamps_the_collapsed_radius_to_the_box() {
+    fn a_scaled_clip_keeps_its_shape_and_scales_through_the_mapping() {
         let mut stack = GpuStateStack::new_for_test();
         let circle = RRect::from_rect_circular(
             Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
             px(50.0),
         );
 
-        stack.scale(2.0, 1.0);
-        stack.clip_rrect(circle, (400, 400));
+        stack.scale(2.0, 3.0);
+        stack.clip_rrect(circle, (600, 600));
 
-        let clip = stack.current_rrect_clip;
-        let (w, h) = (clip[2], clip[3]);
-        assert_eq!((w, h), (200.0, 100.0));
-        for radius in &clip[4..8] {
-            assert!(
-                *radius <= h / 2.0 + 0.01,
-                "a radius of {radius} exceeds the half-height {} — the SDF is degenerate \
-                 there and clips inward",
-                h / 2.0,
-            );
-        }
+        let clip = stack.active_clip();
+        assert_eq!(
+            &clip.rrect[0..4],
+            &[0.0, 0.0, 100.0, 100.0],
+            "bounds stay in the caller's space"
+        );
+        assert_eq!(&clip.rrect[4..8], &[50.0; 4], "and so do the radii");
+
+        // The mapping is the inverse: device (2x, 3y) must land back on (x, y).
+        let m = clip.device_to_local;
+        let local_x = m[0] * 200.0 + m[2] * 300.0 + m[4];
+        let local_y = m[1] * 200.0 + m[3] * 300.0 + m[5];
+        assert!(
+            (local_x - 100.0).abs() < 1e-3 && (local_y - 100.0).abs() < 1e-3,
+            "device (200, 300) must map to local (100, 100), got ({local_x}, {local_y})"
+        );
     }
 
-    /// A rotated CTM must leave the SDF slot empty rather than fill it with
-    /// something the shader cannot represent.
+    /// A rotated CTM now populates the slot instead of surrendering to the
+    /// scissor.
     ///
-    /// The bounds are derived from two corners, which for a rotated rect is
-    /// not even its AABB: a 45° rotation puts both on one vertical, giving a
-    /// zero-width box. Combined with the radius clamp that is a clip which
-    /// erases everything it covers. Falling back to the coarse scissor
-    /// over-includes instead, which is the survivable direction of wrong.
+    /// The old device-space form could not express a rotation at all — its
+    /// bounds came from two corners, which for a rotated rect is not even the
+    /// AABB — so `clip_rrect` detected the case and fell back to the coarse
+    /// scissor, over-including by 41% per axis at 45°. A local shape plus a
+    /// mapping has no such limit.
     #[test]
-    fn a_rotated_clip_populates_no_sdf_slot() {
+    fn a_rotated_clip_populates_the_slot_and_maps_back() {
         let mut stack = GpuStateStack::new_for_test();
         let rrect = RRect::from_rect_circular(
             Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
             px(10.0),
         );
 
-        stack.rotate(std::f32::consts::FRAC_PI_4);
+        stack.rotate(std::f32::consts::FRAC_PI_2);
         stack.clip_rrect(rrect, (400, 400));
 
+        let clip = stack.active_clip();
         assert_eq!(
-            stack.current_rrect_clip, [0.0; 8],
-            "a rotated clip must not populate the axis-aligned SDF slot",
+            clip.kind[0], 1,
+            "a rotated clip must still populate the slot"
         );
+        assert_eq!(
+            &clip.rrect[0..4],
+            &[0.0, 0.0, 100.0, 100.0],
+            "with the caller's own bounds"
+        );
+
+        // A 90° rotation sends local (100, 0) to device (0, 100); the mapping
+        // must send it back.
+        let m = clip.device_to_local;
+        let local_x = m[0] * 0.0 + m[2] * 100.0 + m[4];
+        let local_y = m[1] * 0.0 + m[3] * 100.0 + m[5];
+        assert!(
+            (local_x - 100.0).abs() < 1e-3 && local_y.abs() < 1e-3,
+            "device (0, 100) must map to local (100, 0), got ({local_x}, {local_y})"
+        );
+
         assert!(
             stack.current_scissor().is_some(),
-            "the coarse scissor still applies — the clip is loosened, not dropped",
+            "the coarse scissor still applies as an early-rejection pre-pass"
+        );
+    }
+
+    /// A singular CTM has no inverse; the mapping falls back to the identity
+    /// rather than producing infinities the shader would compare against.
+    #[test]
+    fn a_singular_ctm_yields_the_identity_mapping() {
+        let mut stack = GpuStateStack::new_for_test();
+        stack.scale(0.0, 1.0);
+        stack.clip_rrect(
+            RRect::from_rect_circular(
+                Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+                px(10.0),
+            ),
+            (400, 400),
+        );
+        assert_eq!(
+            stack.active_clip().device_to_local,
+            CLIP_INV_IDENTITY,
+            "a collapsed CTM must not put NaN or inf in the mapping"
         );
     }
 }


### PR DESCRIPTION
## The bug

A rotated `ClipRRect` did not round anything. The clip slot held **device-space** bounds; an axis-aligned box has no rotated form, so `clip_rrect` detected a non-axis-aligned CTM and surrendered to the coarse scissor — the AABB of the rotated rect, **41% larger per axis at 45°**. Content leaked well outside the intended shape.

A non-uniform scale was mangled rather than refused. A scaled circular corner is an ellipse, and one radius per corner cannot hold one, so the two axes collapsed to a scalar and were then clamped to the box's half-extent to stop the rounded-box SDF going degenerate and clipping *inward*. `scale(1, 3)` on a 96×32 clip with radius 16 produced a stadium.

## The fix already existed, one layer over

The drawn rrect solved this long ago: `RectInstance::with_affine_transform` sends **local bounds plus the affine** and lets the shader place them. `o4_rotated_rrect_correct_size_orientation_and_aa`'s own comment describes fixing this exact AABB bug — for geometry. The clip never adopted it.

It does now, inverted, because a fragment shader starts from a device-space position and has to get back:

```rust
pub(crate) struct ResolvedClip {
    rrect: [f32; 8],            // the caller's bounds + radii, untransformed
    kind: [u32; 4],
    device_to_local: [f32; 6],  // [a, b, c, d, tx, ty], columns first
}
```

`clipAlpha` maps, then evaluates.

## What else falls out

- **The offscreen rebases stop moving bounds and compose into the mapping** (`rebase_clip`). Exact under rotation, because there is no AABB step to lose the orientation in.
- **AA is unaffected.** `sdfToAlpha` measures the field's rate of change per *screen* pixel via `dpdx`/`dpdy`, so it picks up the mapping's Jacobian for free.
- **`ClippableInstance` collapses to one method.** The two-method form made each of six implementors re-derive the kind flag and the superellipse reduction. One right answer, one place.

## Replaced tests

Three `state_stack` tests pinned the device-space form: a HiDPI proportionality check, a non-uniform-scale radius clamp, and a per-axis superellipse scale. Each protected the same underlying rule — *a circular clip must not become a rounded square* — which now holds by construction rather than by arithmetic. They are replaced by tests of the shape-and-mapping invariant, plus one for the singular-CTM fallback (a collapsed CTM must not put NaN in the mapping).

## Evidence

| Oracle | Reverted |
|---|---|
| `a_rotated_clip_follows_the_rotation` | restore the `is_axis_aligned` bail-out → sampled corner painted |
| `the_rebase_composes_with_the_framebuffer_transform` | rebased mapping must land where the original does |
| `a_non_uniformly_scaled_clip_keeps_elliptical_corners` | `clipAlpha` using `world_pos` directly → `[0,0,0,0]` |
| `every_clip_carrier_is_remapped_the_same_way` | any one loop in `remap_segment_clips` |

Two things worth flagging, because both bit me:

- **The rotated sample must be near an AABB corner.** The clip rotates about its own centre, so a point pushed straight out along an axis — (18, 64) — is still inside the rotated square and correctly painted either way. My first version sampled exactly that and would have passed against both implementations.
- **The anisotropic oracle's counterfactual is the entire previous representation**, not a line to revert; in local space the anisotropy problem cannot be expressed at all, which is the point. The test says so rather than claiming a revert it cannot produce, and the old arithmetic is pinned by the `state_stack` unit tests that replaced its device-space ones.

`cargo nextest run -p flui-engine --features enable-wgpu-tests` → 570 passed. Workspace clippy clean, both invocations.

## Cost

Every clip-carrying instance grows by 32 bytes (two `vec4` attributes): rect 128→160, circle/texture/gradients 112→144. `transform_translate` in `rect_instanced.wgsl` moved from location 9 to 11 to make room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo