### PR TITLE
bench(rendering): measure a frame where one repaint boundary changed

### DIFF
--- a/crates/flui-rendering/benches/helpers.rs
+++ b/crates/flui-rendering/benches/helpers.rs
@@ -8,7 +8,8 @@
 // uses only the subset it needs, so unused-in-this-unit helpers are expected.
 #![allow(dead_code)]
 
-use flui_objects::{RenderColoredBox, RenderFlex, RenderPadding};
+use flui_foundation::RenderId;
+use flui_objects::{RenderColoredBox, RenderFlex, RenderPadding, RenderRepaintBoundary};
 use flui_rendering::{
     constraints::BoxConstraints,
     pipeline::{Compositing, Layout, PaintPhase, PipelineOwner},
@@ -121,4 +122,61 @@ fn advance_to_paint(mut layout_owner: PipelineOwner<Layout>) -> PipelineOwner<Pa
         .run_compositing()
         .expect("run_compositing must succeed: all nodes were freshly inserted");
     compositing_owner.into_paint()
+}
+
+// ============================================================================
+// Boundaries: RenderFlex root + N repaint-boundary-wrapped leaves
+// ============================================================================
+
+/// Build a wide tree whose every leaf sits under its own
+/// `RenderRepaintBoundary`, painted once so the pipeline is in steady state,
+/// and return it alongside the ids of the labelled leaves.
+///
+/// This is the shape retention is for: an app where a single boundary's
+/// content changes per frame while the rest of the tree is untouched. The
+/// caller marks some subset of the returned leaves and re-runs paint, so the
+/// measurement is the cost of a frame in which almost nothing changed.
+///
+/// The warm-up pass's layer tree is TAKEN before returning. Leaving it in
+/// place would make the timed `run_paint` drop an entire N-boundary tree while
+/// building the next one, putting an O(N) destruction inside the measurement
+/// that a real frame does not pay: `PipelineOwner::run_frame` ends with
+/// `take_layer_tree()` before returning to idle.
+pub fn build_boundary_tree_painted_once(n: usize) -> (PipelineOwner<PaintPhase>, Vec<RenderId>) {
+    const LABELS: [&str; 8] = [
+        "leaf-0", "leaf-1", "leaf-2", "leaf-3", "leaf-4", "leaf-5", "leaf-6", "leaf-7",
+    ];
+    let spec = box_node(RenderFlex::row()).children((0..n).map(|i| {
+        let leaf = box_node(RenderColoredBox::red(1.0, 1.0));
+        // Label a bounded sample rather than all `n`: the labels only exist so
+        // the bench can dirty specific leaves, and one is enough for the
+        // single-dirty case while eight gives the control something to spread
+        // across without a per-`n` label table.
+        let leaf = match LABELS.get(i) {
+            Some(&label) => leaf.label(label),
+            None => leaf,
+        };
+        box_node(RenderRepaintBoundary::new()).child(leaf)
+    }));
+
+    let mut owner = PipelineOwner::new();
+    let (root_id, registry) = tree::mount(&mut owner, spec);
+    owner.set_root_id(Some(root_id));
+    owner.set_root_constraints(Some(root_constraints()));
+
+    let leaf_ids: Vec<RenderId> = LABELS
+        .iter()
+        .filter_map(|label| registry.get(label))
+        .collect();
+    assert!(
+        !leaf_ids.is_empty(),
+        "at least one leaf must be labelled at construction"
+    );
+
+    let mut owner = advance_to_paint(owner.into_layout());
+    owner
+        .run_paint()
+        .expect("the first paint must succeed on a freshly composited tree");
+    drop(owner.take_layer_tree());
+    (owner, leaf_ids)
 }

--- a/crates/flui-rendering/benches/paint.rs
+++ b/crates/flui-rendering/benches/paint.rs
@@ -86,10 +86,89 @@ fn bench_deep_run_paint(c: &mut Criterion) {
     group.finish();
 }
 
+// ============================================================================
+// run_paint — one dirty boundary in a tree of N
+// ============================================================================
+
+/// The frame retention exists for: N repaint boundaries, ONE of them dirty.
+///
+/// `run_paint` builds a dirty-node set and threads it through the whole walk,
+/// but `paint_subtree` never reads it — the descent repaints everything and a
+/// fresh `LayerTree` is produced each pass (documented on `run_paint`). This
+/// benchmark is the measurement that says what that costs: compare it against
+/// `paint/paint_flat` at the same N, where every node is genuinely dirty.
+///
+/// Two numbers close together mean the clean boundaries are being repainted
+/// for nothing. It is deliberately measured BEFORE any retention work, so the
+/// claim that retention helps has a baseline to be checked against rather than
+/// an assertion.
+///
+/// The setup takes the warm-up pass's layer tree — see the helper. Leaving it
+/// would put an O(N) drop of the previous tree inside the timed region, which
+/// a real frame does not pay; it was worth ~15% at N = 1000.
+fn bench_single_dirty_boundary(c: &mut Criterion) {
+    let mut group = c.benchmark_group("paint/one_dirty_boundary");
+    for &n in &[10_usize, 100, 1_000] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let (mut owner, leaf_ids) = helpers::build_boundary_tree_painted_once(n);
+                    // Dirty exactly one leaf; `mark_needs_paint` walks to its
+                    // enclosing boundary, so the queue holds one boundary.
+                    owner.mark_needs_paint(leaf_ids[0]);
+                    owner
+                },
+                |mut owner| {
+                    owner
+                        .run_paint()
+                        .expect("run_paint must succeed with one dirty boundary");
+                    black_box(owner)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// The control for `one_dirty_boundary`: the SAME tree, eight dirty
+/// boundaries instead of one.
+///
+/// Comparing one-dirty against `paint/paint_flat` would prove nothing — that
+/// tree has half the nodes and no `OffsetLayer` per child. Comparing it
+/// against itself with eight times the dirty work is the measurement that
+/// isolates the dirty set's effect, and two matching numbers say it has none.
+fn bench_eight_dirty_boundaries(c: &mut Criterion) {
+    let mut group = c.benchmark_group("paint/eight_dirty_boundaries");
+    for &n in &[10_usize, 100, 1_000] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let (mut owner, leaf_ids) = helpers::build_boundary_tree_painted_once(n);
+                    for &id in &leaf_ids {
+                        owner.mark_needs_paint(id);
+                    }
+                    owner
+                },
+                |mut owner| {
+                    owner
+                        .run_paint()
+                        .expect("run_paint must succeed with eight dirty boundaries");
+                    black_box(owner)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_flat_run_compositing,
     bench_flat_run_paint,
     bench_deep_run_paint,
+    bench_single_dirty_boundary,
+    bench_eight_dirty_boundaries,
 );
 criterion_main!(benches);


### PR DESCRIPTION
Groundwork for RFC steps 8–10 (paint dirty bookkeeping → retained layers → damage tracking). No behaviour change; two benchmarks and the helper they need.

## What the code already says

`run_paint` builds a dirty-node set and threads it through the entire walk — and `paint_subtree` never reads it. `dirty_set` is a parameter that gets passed down and nothing else. The descent repaints everything, and a fresh `LayerTree` is produced each pass, which `run_paint`'s own doc states plainly.

That much is readable. What it *costs* was not measured, and a performance claim without a number is the thing this repo's `AGENTS.md` calls out.

## The control matters as much as the measurement

Comparing one-dirty against the existing `paint/paint_flat` proves nothing: that tree has half the nodes (no boundary wrapper per child) and no `OffsetLayer` per child. The honest comparison is the same tree against itself with eight times the dirty work:

| N | 1 dirty boundary | 8 dirty boundaries | ratio |
|---|---|---|---|
| 10 | 3.35 µs | 3.76 µs | 1.12× |
| 100 | 32.3 µs | 32.7 µs | 1.01× |
| 1000 | 394 µs | 391 µs | 0.99× |

**Eight times the dirty work costs the same.** The dirty set has no effect on the walk — now measured, not inferred. (At N=10 the eight-dirty case is marginally *more* expensive: building and deep-sorting the dirty list costs a little, and that is all it does.)

At N=1000, a frame in which one leaf changed colour spends **394 µs** in paint. These leaves are `RenderColoredBox`, about the cheapest `paint_raw` in the tree, so real content (text, images, gradients) only widens the gap.

## Fixed after review

Codex was right that the first numbers were contaminated. The warm-up pass left its `LayerTree` in the owner, so the timed `run_paint` dropped an entire N-boundary tree while building the next one — an O(N) destruction inside the measurement that a real frame does not pay, since `run_frame` ends with `take_layer_tree()` before returning to idle. Draining it moved N=1000 from **461 µs to 394 µs**, about 15%. The ratio conclusion is unchanged, but the absolute figure was wrong, and this is a benchmark whose whole job is to be trustworthy.

Copilot's point is fixed too — the helper's doc still described the old single-id return after I widened it to a `Vec`.

## What this does not claim

It does not claim retention will be fast. `PictureLayer` holds a plain `DisplayList { commands: Vec<DrawCommand> }`, so cloning a retained subtree is O(commands) with a real allocation — roughly what regenerating it costs. That is exactly the "structural-sharing substrate" `run_paint`'s doc names as a prerequisite, and it is real. Whatever lands next has this table to beat.

`cargo nextest run -p flui-rendering` → 863 passed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo
