### PR TITLE
fix(rendering): queue every repaint boundary a relayout touched

### DIFF
--- a/crates/flui-rendering/src/pipeline/owner/layout.rs
+++ b/crates/flui-rendering/src/pipeline/owner/layout.rs
@@ -815,15 +815,23 @@ impl PipelineOwner<Layout> {
     /// # Known imprecision
     ///
     /// This queues every boundary under `root`, including ones whose layout
-    /// the walk skipped because their constraints were unchanged. That is the
-    /// safe direction — an extra repaint, never a stale one — but it is
+    /// the walk skipped. Those are not hypothetical:
+    /// `layout_subtree_borrowed_impl` short-circuits a node that is not dirty
+    /// and is offered the constraints it already has, returning its cached
+    /// geometry without descending. In a list where one row changed, every
+    /// other row is skipped by layout and queued by this sweep anyway.
+    ///
+    /// It is the safe direction — an extra repaint, never a stale one — but
     /// blunter than Flutter, which marks exactly the objects it laid out
-    /// because the mark happens inside `RenderObject.layout`. Reaching the
-    /// same precision here means recording ids from inside the layout walk
-    /// (`subtree_arena`), where the node's slot is exclusively borrowed and
-    /// the scheduler is not in scope. Worth doing before a retaining paint
-    /// pass relies on the queue to decide what to skip, since over-queueing
-    /// costs exactly the repaints retention is meant to avoid.
+    /// because the mark happens inside `RenderObject.layout`. Reaching that
+    /// precision here means recording ids from inside the layout walk, where
+    /// the node's slot is exclusively borrowed and the scheduler is out of
+    /// scope; `SubtreeArena` already carries four side-collections drained
+    /// after the walk for exactly this shape of problem.
+    ///
+    /// Worth doing BEFORE a retaining paint pass trusts the queue to decide
+    /// what to skip: over-queueing costs precisely the repaints retention
+    /// exists to avoid.
     fn queue_boundaries_under(&mut self, root: RenderId) {
         let mut stack = vec![root];
         while let Some(id) = stack.pop() {

--- a/crates/flui-rendering/src/pipeline/owner/layout.rs
+++ b/crates/flui-rendering/src/pipeline/owner/layout.rs
@@ -832,10 +832,24 @@ impl PipelineOwner<Layout> {
             };
             stack.extend_from_slice(node.children());
             // The root itself is already handled by the `mark_needs_paint`
-            // above; queueing it again is harmless but pointless.
-            if id != root && node.is_repaint_boundary_flag() {
-                let depth = node.depth() as usize;
-                self.scheduler.schedule_paint_boundary(id, depth);
+            // above.
+            //
+            // Route through `mark_needs_paint` rather than enqueueing
+            // directly. It is the one place that decides WHICH node owns the
+            // affected retained layer, and the answer is not always this node:
+            // a boundary introduced this frame
+            // (`is_repaint_boundary_flag() && !was_repaint_boundary()`) owns
+            // no layer yet, so invalidation has to walk past it to an
+            // established ancestor — the contract
+            // `mark_needs_paint_walks_past_a_new_repaint_boundary` pins.
+            // Enqueueing here would also leave `NEEDS_PAINT` unset on the
+            // node, putting the queue and the per-node flags out of step.
+            //
+            // It stays cheap: the walk returns at the first already-dirty
+            // node, so an established boundary costs one step.
+            let is_boundary = node.is_repaint_boundary_flag();
+            if id != root && is_boundary {
+                self.mark_needs_paint(id);
             }
         }
     }

--- a/crates/flui-rendering/src/pipeline/owner/layout.rs
+++ b/crates/flui-rendering/src/pipeline/owner/layout.rs
@@ -215,10 +215,18 @@ impl PipelineOwner<Layout> {
                 // unconditionally ends with `markNeedsPaint()`): a
                 // subtree that re-laid out must repaint, otherwise a
                 // pure-layout invalidation (setState moving a child)
-                // leaves stale pixels on screen. One entry per dirty
-                // root suffices — run_paint walks the whole tree from
-                // the root, so triggering the phase is what matters.
+                // leaves stale pixels on screen.
+                //
+                // Flutter marks per OBJECT, and the difference is not
+                // cosmetic. `mark_needs_paint` walks UP to the nearest
+                // established boundary, so marking only the relayout root
+                // reaches the boundary ABOVE the subtree and never the
+                // boundaries INSIDE it — which also re-laid out and whose
+                // content is therefore stale. A full-tree paint descent
+                // hides that; a paint pass that lets a clean boundary reuse
+                // its previous layers would show the stale pixels.
                 self.mark_needs_paint(dirty_node.id);
+                self.queue_boundaries_under(dirty_node.id);
             }
 
             // exit_phase clears debug_doing_layout AND drains
@@ -782,6 +790,54 @@ impl PipelineOwner<Layout> {
         self.pending_retain_bands.extend(pending_retain_bands);
 
         result
+    }
+}
+
+impl PipelineOwner<Layout> {
+    /// Queue every repaint boundary inside `root`'s subtree for paint.
+    ///
+    /// [`Self::mark_needs_paint`] walks UP to the nearest established
+    /// boundary, which is the right shape for an invalidation originating at a
+    /// leaf. It is the wrong shape for "this whole subtree just re-laid out":
+    /// the boundaries INSIDE the subtree also ran layout, their content is
+    /// stale, and nothing walking upward from the subtree's root will ever
+    /// reach them.
+    ///
+    /// Flutter has no equivalent sweep because it marks per object —
+    /// `RenderObject.layout` ends with `markNeedsPaint()` for every object it
+    /// lays out. This is that behaviour expressed once per relayout root
+    /// instead of once per object, which costs one downward walk over a
+    /// subtree layout has just traversed anyway.
+    ///
+    /// Descends through boundaries rather than stopping at them: a boundary
+    /// nested inside another one laid out just the same.
+    ///
+    /// # Known imprecision
+    ///
+    /// This queues every boundary under `root`, including ones whose layout
+    /// the walk skipped because their constraints were unchanged. That is the
+    /// safe direction — an extra repaint, never a stale one — but it is
+    /// blunter than Flutter, which marks exactly the objects it laid out
+    /// because the mark happens inside `RenderObject.layout`. Reaching the
+    /// same precision here means recording ids from inside the layout walk
+    /// (`subtree_arena`), where the node's slot is exclusively borrowed and
+    /// the scheduler is not in scope. Worth doing before a retaining paint
+    /// pass relies on the queue to decide what to skip, since over-queueing
+    /// costs exactly the repaints retention is meant to avoid.
+    fn queue_boundaries_under(&mut self, root: RenderId) {
+        let mut stack = vec![root];
+        while let Some(id) = stack.pop() {
+            let Some(node) = self.render_tree.get(id) else {
+                continue;
+            };
+            stack.extend_from_slice(node.children());
+            // The root itself is already handled by the `mark_needs_paint`
+            // above; queueing it again is harmless but pointless.
+            if id != root && node.is_repaint_boundary_flag() {
+                let depth = node.depth() as usize;
+                self.scheduler.schedule_paint_boundary(id, depth);
+            }
+        }
     }
 }
 

--- a/crates/flui-rendering/tests/layout_marks_laid_out_boundaries.rs
+++ b/crates/flui-rendering/tests/layout_marks_laid_out_boundaries.rs
@@ -29,7 +29,13 @@ use flui_types::{Size, geometry::px};
 /// Relayout an outer subtree that contains an inner repaint boundary; the
 /// inner boundary must be queued for paint.
 ///
-/// Tree: root → outer boundary → padding → inner boundary → leaf.
+/// Tree: padding root → outer boundary → padding → inner boundary → leaf.
+///
+/// The root is a `RenderPadding`, not a `RenderColoredBox`: a coloured box
+/// paints no children, so the paint walk would stop at it and no boundary
+/// below would ever record `was_repaint_boundary` — which
+/// `mark_needs_paint` reads to decide whether a boundary owns a retained
+/// layer.
 ///
 /// The padding is marked for layout, so the walk re-lays out the padding, the
 /// inner boundary, and the leaf. The inner boundary's content is therefore
@@ -40,7 +46,7 @@ fn a_boundary_nested_in_a_relayout_subtree_is_queued_for_paint() {
     let mut owner = PipelineOwner::new();
     let (root_id, registry) = tree::mount(
         &mut owner,
-        box_node(RenderColoredBox::red(1.0, 1.0)).child(
+        box_node(RenderPadding::all(0.0)).child(
             box_node(RenderRepaintBoundary::new()).label("outer").child(
                 box_node(RenderPadding::all(0.0)).label("padding").child(
                     box_node(RenderRepaintBoundary::new())
@@ -78,6 +84,20 @@ fn a_boundary_nested_in_a_relayout_subtree_is_queued_for_paint() {
         .iter()
         .map(|d| d.id)
         .collect();
+
+    // The queue and the per-node flags must agree. Enqueueing the boundary
+    // directly would satisfy the assertion below while leaving this false —
+    // and `mark_needs_paint` is also the only place that knows a boundary
+    // introduced this frame owns no retained layer yet and must be walked
+    // past (see `mark_needs_paint_walks_past_a_new_repaint_boundary`).
+    assert!(
+        layout_owner
+            .render_tree()
+            .get(inner_id)
+            .expect("inner boundary is in the tree")
+            .needs_paint(),
+        "the inner boundary must carry NEEDS_PAINT, not just sit in the queue"
+    );
 
     assert!(
         queued.contains(&inner_id),

--- a/crates/flui-rendering/tests/layout_marks_laid_out_boundaries.rs
+++ b/crates/flui-rendering/tests/layout_marks_laid_out_boundaries.rs
@@ -1,0 +1,89 @@
+//! Every object that re-lays out must be queued for paint, not just the
+//! dirty layout root.
+//!
+//! Flutter does this per object: `RenderObject.layout` ends with
+//! `_needsLayout = false; markNeedsPaint();`
+//! (`.flutter/packages/flutter/lib/src/rendering/object.dart`, and again in
+//! `_layoutWithoutResize`). FLUI shortcut it to one `mark_needs_paint` per
+//! dirty layout root, with the reason stated in `run_layout`: "run_paint walks
+//! the whole tree from the root, so triggering the phase is what matters."
+//!
+//! That shortcut is invisible today and load-bearing tomorrow. `run_paint`
+//! builds a dirty set and threads it through the walk without reading it
+//! (measured in `benches/paint.rs` — eight dirty boundaries cost the same as
+//! one). The moment a clean boundary is allowed to reuse its previous layers,
+//! a boundary that re-laid out but was never queued shows stale pixels.
+//!
+//! `mark_needs_paint` walks UP to the nearest established boundary and returns
+//! early on an already-dirty node, so a boundary nested INSIDE a relayout
+//! subtree is never reached from that subtree's root.
+
+use flui_objects::{RenderColoredBox, RenderPadding, RenderRepaintBoundary};
+use flui_rendering::{
+    constraints::BoxConstraints,
+    pipeline::PipelineOwner,
+    testing::{box_node, tree},
+};
+use flui_types::{Size, geometry::px};
+
+/// Relayout an outer subtree that contains an inner repaint boundary; the
+/// inner boundary must be queued for paint.
+///
+/// Tree: root → outer boundary → padding → inner boundary → leaf.
+///
+/// The padding is marked for layout, so the walk re-lays out the padding, the
+/// inner boundary, and the leaf. The inner boundary's content is therefore
+/// stale, and it has to be in the paint queue for a retaining paint pass to
+/// know that.
+#[test]
+fn a_boundary_nested_in_a_relayout_subtree_is_queued_for_paint() {
+    let mut owner = PipelineOwner::new();
+    let (root_id, registry) = tree::mount(
+        &mut owner,
+        box_node(RenderColoredBox::red(1.0, 1.0)).child(
+            box_node(RenderRepaintBoundary::new()).label("outer").child(
+                box_node(RenderPadding::all(0.0)).label("padding").child(
+                    box_node(RenderRepaintBoundary::new())
+                        .label("inner")
+                        .child(box_node(RenderColoredBox::red(1.0, 1.0)).label("leaf")),
+                ),
+            ),
+        ),
+    );
+    owner.set_root_id(Some(root_id));
+    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(200.0), px(200.0)))));
+
+    let padding_id = registry.get("padding").expect("padding is labelled");
+    let inner_id = registry.get("inner").expect("inner boundary is labelled");
+
+    // Settle the first frame so nothing is dirty from construction.
+    let (owner_idle, result) = owner.run_frame();
+    result.expect("the first frame must succeed");
+    let mut owner = owner_idle;
+
+    assert!(
+        owner.nodes_needing_paint().is_empty(),
+        "precondition: the settled frame leaves nothing queued for paint"
+    );
+
+    // Dirty the padding only. Layout re-runs for it and everything under it,
+    // which includes the inner boundary.
+    owner.mark_needs_layout(padding_id);
+
+    let mut layout_owner = owner.into_layout();
+    layout_owner.run_layout().expect("relayout must succeed");
+
+    let queued: Vec<_> = layout_owner
+        .nodes_needing_paint()
+        .iter()
+        .map(|d| d.id)
+        .collect();
+
+    assert!(
+        queued.contains(&inner_id),
+        "the inner boundary re-laid out, so it must be queued for paint; \
+         queue held {queued:?} and the inner boundary is {inner_id:?} — \
+         `mark_needs_paint` walks UP from the relayout root, so a boundary \
+         nested inside that subtree is never reached"
+    );
+}

--- a/crates/flui-rendering/tests/main.rs
+++ b/crates/flui-rendering/tests/main.rs
@@ -37,6 +37,8 @@ mod intrinsics_cache;
 mod layout_cycle_guard;
 #[path = "layout_dirty_root.rs"]
 mod layout_dirty_root;
+#[path = "layout_marks_laid_out_boundaries.rs"]
+mod layout_marks_laid_out_boundaries;
 #[path = "layout_offset_commit.rs"]
 mod layout_offset_commit;
 #[path = "layout_poison.rs"]
@@ -45,6 +47,7 @@ mod layout_poison;
 mod layout_raw_bridge;
 #[path = "lazy_sliver_list_child_build_contract.rs"]
 mod lazy_sliver_list_child_build_contract;
+
 #[path = "paint_dirty_flag_discipline.rs"]
 mod paint_dirty_flag_discipline;
 #[path = "paint_fragment_snapshot.rs"]


### PR DESCRIPTION
The prerequisite for RFC step 9 (retained layers), and a Flutter-parity fix in its own right.

## The divergence

Flutter marks needs-paint per **object**: `RenderObject.layout` ends with `_needsLayout = false; markNeedsPaint();`, and `_layoutWithoutResize` does the same (`.flutter/packages/flutter/lib/src/rendering/object.dart`). FLUI shortcut it to one `mark_needs_paint` per dirty layout root, with the reason stated in `run_layout`:

> One entry per dirty root suffices — run_paint walks the whole tree from the root, so triggering the phase is what matters.

That is accurate about today and load-bearing about tomorrow.

## Why it matters

`mark_needs_paint` walks **up** to the nearest established boundary. So marking only the relayout root reaches the boundary *above* the subtree and never the boundaries *inside* it — which also re-laid out, and whose content is therefore stale.

A full-tree paint descent hides that completely, which is exactly why nothing fails today. It stops being hidden the moment a paint pass may skip a clean boundary. `run_paint` already builds a dirty set and threads it through the whole walk without reading it, and #752 measured the consequence: **eight dirty boundaries cost the same as one**. Whatever makes that dirty set live inherits this as stale pixels.

## Evidence

The test builds `root → boundary → padding → boundary → leaf`, dirties the padding, and asserts the inner boundary is queued. Reverted, it reports:

```
the inner boundary re-laid out, so it must be queued for paint;
queue held [GenId<Render>(index=0, generation=1)] and the inner boundary is
GenId<Render>(index=3, generation=1)
```

— only the root. The precondition (a settled frame leaves nothing queued) passes either way, so the test is not passing on an empty queue.

## Known imprecision, documented at the sweep

It queues every boundary under the dirty root, including ones whose layout was skipped for unchanged constraints. That is the safe direction — an extra repaint, never a stale one — but blunter than Flutter, which marks exactly what it laid out because the mark happens inside `layout`. Matching that precision here means recording ids from inside the layout walk (`subtree_arena`), where the node's slot is exclusively borrowed and the scheduler is out of scope. Worth doing before retention relies on the queue to decide what to skip, since over-queueing costs exactly the repaints retention is meant to avoid — the doc comment says so at the call site.

## Cost

One downward walk per dirty root, over a subtree layout has just traversed, doing a flag check per node.

Not resolvable above this machine's noise floor, and I checked rather than assuming: re-running the paint benchmark with **no code change at all** swings ±2–7% with p between 0.14 and 0.57. The first before/after comparison reported "performance has regressed" at 3–5%, and one layout shape reported a 6.7% *improvement*, which adding work cannot produce. Both were noise.

`cargo nextest run --workspace --exclude flui-platform` → 9052 passed. (flui-platform needs `FLUI_HEADLESS=1` + `xvfb-run` per `AGENTS.md` and is excluded from the CI `test` job for the same reason.) Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo