### PR TITLE
fix(widgets): wrap scrolling children in repaint boundaries, as Flutter does

### DIFF
--- a/crates/flui-engine/benches/render_throughput.rs
+++ b/crates/flui-engine/benches/render_throughput.rs
@@ -41,6 +41,7 @@ use flui_engine::WgpuPainter;
 use flui_engine::wgpu::path_cache::PathCache;
 use flui_engine::wgpu::superellipse_cache::{SuperellipseKey, SuperellipsePathCache};
 use flui_painting::Paint;
+use flui_types::Rect;
 use flui_types::painting::path::Path;
 use flui_types::{Offset, geometry::px, painting::Shader, styling::Color};
 
@@ -322,6 +323,113 @@ fn alloc_micro(c: &mut Criterion) {
     group.finish();
 }
 
+// ============================================================================
+// damage_scissor — what a partial repaint would save
+// ============================================================================
+
+/// The same scene rasterised full-screen versus clipped to a small damage
+/// rect, at a realistic surface size.
+///
+/// `DamageTracker` and the scissor that consumes it both exist and are wired
+/// in `render_scene`; what is missing is a PRODUCER — `Renderer::mark_dirty`
+/// has no production caller, so every frame calls `mark_full_repaint` and the
+/// scissor never narrows. This measures what that costs, so the producer, when
+/// it lands, has a baseline to be checked against rather than an assertion.
+///
+/// The layer counts are the axis that matters: with the damage rect fixed at
+/// 0.8% of the surface, the scissored cost stays roughly flat while the full
+/// cost grows with the fragment work, so the ratio shows how much of a frame
+/// is pixels that did not change.
+fn damage_scissor(c: &mut Criterion) {
+    let Some((device, queue)) = try_create_gpu() else {
+        println!("skipping damage benches: no GPU available");
+        return;
+    };
+
+    let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+    let (width, height) = (1920_u32, 1080_u32);
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("damage-bench-target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let mut painter = WgpuPainter::with_shared_device(
+        Arc::clone(&device),
+        Arc::clone(&queue),
+        format,
+        (width, height),
+    );
+
+    // Translucent full-surface rects: the shape that makes fragment work, and
+    // the one a scissor can actually cull. A UI's own layers are smaller, so
+    // treat these as an upper bound on the saving per layer, not a forecast.
+    fn build(painter: &mut WgpuPainter, layers: u32, damage: Option<f32>, w: f32, h: f32) {
+        painter.save();
+        if let Some(side) = damage {
+            painter.clip_rect(Rect::from_xywh(px(0.0), px(0.0), px(side), px(side)));
+        }
+        for i in 0..layers {
+            let f = i as f32;
+            painter.rect(
+                Rect::from_xywh(px(f * 2.0), px(f * 1.5), px(w), px(h)),
+                &Paint::fill(Color::rgba(0, 0, 255, 40)),
+            );
+        }
+        painter.restore();
+    }
+
+    const VARIANTS: [(&str, Option<f32>); 2] = [("full", None), ("damage_128px", Some(128.0))];
+
+    let mut group = c.benchmark_group("damage_scissor");
+    for &layers in &[4_u32, 16, 64] {
+        // Warm BOTH variants before timing EITHER. The damaged variant is
+        // timed second, so anything that makes later work look faster — GPU
+        // clock ramp, warmed caches — would flatter exactly the case whose
+        // saving this benchmark reports. Warming both first removes the
+        // cache half; the probe that produced these numbers also ran the
+        // order reversed and agreed, which removes the ramp half.
+        for (_, damage) in VARIANTS {
+            for _ in 0..2 {
+                build(&mut painter, layers, damage, width as f32, height as f32);
+                let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("damage-warmup"),
+                });
+                let _ = painter.render_to_view(&view, &mut enc);
+                queue.submit([enc.finish()]);
+                let _ = device.poll(wgpu::PollType::wait_indefinitely());
+            }
+        }
+
+        for (label, damage) in VARIANTS {
+            group.bench_function(format!("{label}/{layers}"), |b| {
+                b.iter(|| {
+                    build(&mut painter, layers, damage, width as f32, height as f32);
+                    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("damage-frame"),
+                    });
+                    let result = painter.render_to_view(&view, &mut enc);
+                    queue.submit([enc.finish()]);
+                    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+                    black_box(result)
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(benches, render_throughput);
 criterion_group!(alloc_benches, alloc_micro);
-criterion_main!(benches, alloc_benches);
+criterion_group!(damage_benches, damage_scissor);
+criterion_main!(benches, damage_benches, alloc_benches);

--- a/crates/flui-widgets/src/paint/repaint_boundary.rs
+++ b/crates/flui-widgets/src/paint/repaint_boundary.rs
@@ -2,7 +2,7 @@
 
 use flui_objects::RenderRepaintBoundary;
 use flui_rendering::protocol::BoxProtocol;
-use flui_view::{Child, IntoView, RenderView, View, impl_render_view};
+use flui_view::{Child, IntoView, RenderView, View};
 
 /// Isolates its child into a separate compositing layer so repaints of the
 /// child (or its siblings) don't force each other to re-paint.
@@ -13,6 +13,22 @@ use flui_view::{Child, IntoView, RenderView, View, impl_render_view};
 #[derive(Clone, Debug, Default)]
 pub struct RepaintBoundary {
     child: Child,
+    /// Report the child's key as this boundary's own.
+    ///
+    /// Off by default: a boundary that borrowed its child's key would change
+    /// which element a `GlobalKey` resolves to for every direct user of this
+    /// widget.
+    ///
+    /// The scrolling delegates turn it on. Flutter keeps the boundary keyless
+    /// and restores the key OUTSIDE it with `KeyedSubtree`
+    /// (`widgets/scroll_delegate.dart:559`, `:572`), which FLUI cannot copy
+    /// verbatim: a lazy sliver requires every child element to own a render
+    /// node (`sparse_children.rs`'s "a lazy sliver child must own a render
+    /// node to carry its logical index"), and a `KeyedSubtree` equivalent is a
+    /// stateless view with none. Carrying the key on the boundary — which does
+    /// own one — puts it at the same level Flutter puts it: the outermost
+    /// element the parent reconciles.
+    forwards_child_key: bool,
 }
 
 impl RepaintBoundary {
@@ -25,6 +41,14 @@ impl RepaintBoundary {
     #[must_use]
     pub fn child(mut self, child: impl IntoView) -> Self {
         self.child = Child::some(child.into_view());
+        self
+    }
+
+    /// Report the child's key as this boundary's own — see
+    /// [`Self::forwards_child_key`].
+    #[must_use]
+    pub(crate) fn forwarding_child_key(mut self) -> Self {
+        self.forwards_child_key = true;
         self
     }
 }
@@ -60,4 +84,18 @@ impl RenderView for RepaintBoundary {
     }
 }
 
-impl_render_view!(RepaintBoundary);
+// Hand-written rather than `impl_render_view!`, which emits only
+// `create_element` and leaves `key` at the trait default of `None`.
+impl View for RepaintBoundary {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::render_variable(self)
+    }
+
+    fn key(&self) -> Option<&dyn flui_foundation::ViewKey> {
+        if self.forwards_child_key {
+            self.child.as_ref()?.key()
+        } else {
+            None
+        }
+    }
+}

--- a/crates/flui-widgets/src/scroll/grid_view.rs
+++ b/crates/flui-widgets/src/scroll/grid_view.rs
@@ -90,7 +90,7 @@ impl GridView {
             offset_source: OffsetSource::Pixels(0.0),
             shrink_wrap: false,
             grid_delegate: Arc::new(delegate),
-            children: children.into_boxed_vec(),
+            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
             builder_source: None,
         }
     }
@@ -110,7 +110,7 @@ impl GridView {
             offset_source: OffsetSource::Pixels(0.0),
             shrink_wrap: false,
             grid_delegate: Arc::new(delegate),
-            children: children.into_boxed_vec(),
+            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
             builder_source: None,
         }
     }

--- a/crates/flui-widgets/src/scroll/list_view.rs
+++ b/crates/flui-widgets/src/scroll/list_view.rs
@@ -90,7 +90,7 @@ impl ListView {
             item_extent_estimate: item_extent,
             offset_source: OffsetSource::Pixels(0.0),
             shrink_wrap: false,
-            children: children.into_boxed_vec(),
+            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
             builder_source: None,
         }
     }

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -466,7 +466,7 @@ impl PageView {
             scroll_direction: Axis::Horizontal,
             on_page_changed: None,
             cache_extent: Some((0.0, CacheExtentStyle::Viewport)),
-            children: children.into_boxed_vec(),
+            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
         }
     }
 

--- a/crates/flui-widgets/src/scroll/sliver_list.rs
+++ b/crates/flui-widgets/src/scroll/sliver_list.rs
@@ -56,11 +56,56 @@ impl SliverChildBuilderDelegate {
     where
         F: Fn(usize) -> Option<BoxedView> + 'static,
     {
+        Self::with_options(item_count, true, builder)
+    }
+
+    /// Like [`Self::new`], but lets the caller decline the per-item repaint
+    /// boundary.
+    ///
+    /// Flutter parity: `SliverChildBuilderDelegate.addRepaintBoundaries`,
+    /// which defaults to `true` for the reason its own doc gives — children in
+    /// a scrolling container "do not need to be repainted as the list
+    /// scrolls". Without the boundary the paint walk descends into every
+    /// visible item on every frame, and nothing the retention path
+    /// (`PipelineOwner::retained_boundaries`) can reuse ever exists.
+    ///
+    /// Pass `false` when the items are cheaper to repaint than to composite —
+    /// solid colour blocks, a short line of text — which is the same guidance
+    /// Flutter gives.
+    #[must_use]
+    pub fn with_options<F>(item_count: usize, add_repaint_boundaries: bool, builder: F) -> Self
+    where
+        F: Fn(usize) -> Option<BoxedView> + 'static,
+    {
+        let builder: Rc<dyn Fn(usize) -> Option<BoxedView>> = if add_repaint_boundaries {
+            Rc::new(move |index| {
+                builder(index).map(|child| {
+                    BoxedView(Box::new(crate::paint::RepaintBoundary::new().child(child)))
+                })
+            })
+        } else {
+            Rc::new(builder)
+        };
         Self {
             item_count,
-            builder: Rc::new(builder),
+            builder,
         }
     }
+}
+
+/// Wrap each child in a [`RepaintBoundary`](crate::paint::RepaintBoundary).
+///
+/// Flutter parity: the delegates in `widgets/scroll_delegate.dart` do this by
+/// default (`addRepaintBoundaries = true`) so that "children in a scrolling
+/// container ... do not need to be repainted as the list scrolls". Without it
+/// the paint walk descends into every visible item every frame and there is
+/// nothing for `PipelineOwner::retained_boundaries` to reuse.
+#[must_use]
+pub(crate) fn wrap_in_repaint_boundaries(children: Vec<BoxedView>) -> Vec<BoxedView> {
+    children
+        .into_iter()
+        .map(|child| BoxedView(Box::new(crate::paint::RepaintBoundary::new().child(child))))
+        .collect()
 }
 
 impl fmt::Debug for SliverChildBuilderDelegate {

--- a/crates/flui-widgets/src/scroll/sliver_list.rs
+++ b/crates/flui-widgets/src/scroll/sliver_list.rs
@@ -72,17 +72,23 @@ impl SliverChildBuilderDelegate {
     /// Pass `false` when the items are cheaper to repaint than to composite —
     /// solid colour blocks, a short line of text — which is the same guidance
     /// Flutter gives.
+    ///
+    /// `pub(crate)` on purpose: no scroll widget accepts a prebuilt delegate,
+    /// so a public form would be unreachable API. Flutter exposes the flag on
+    /// `ListView.builder` / `GridView.count` themselves; giving the FLUI
+    /// widgets the same knob is the follow-up, and this stays internal until
+    /// there is a caller.
     #[must_use]
-    pub fn with_options<F>(item_count: usize, add_repaint_boundaries: bool, builder: F) -> Self
+    pub(crate) fn with_options<F>(
+        item_count: usize,
+        add_repaint_boundaries: bool,
+        builder: F,
+    ) -> Self
     where
         F: Fn(usize) -> Option<BoxedView> + 'static,
     {
         let builder: Rc<dyn Fn(usize) -> Option<BoxedView>> = if add_repaint_boundaries {
-            Rc::new(move |index| {
-                builder(index).map(|child| {
-                    BoxedView(Box::new(crate::paint::RepaintBoundary::new().child(child)))
-                })
-            })
+            Rc::new(move |index| builder(index).map(wrap_in_repaint_boundary))
         } else {
             Rc::new(builder)
         };
@@ -102,10 +108,23 @@ impl SliverChildBuilderDelegate {
 /// nothing for `PipelineOwner::retained_boundaries` to reuse.
 #[must_use]
 pub(crate) fn wrap_in_repaint_boundaries(children: Vec<BoxedView>) -> Vec<BoxedView> {
-    children
-        .into_iter()
-        .map(|child| BoxedView(Box::new(crate::paint::RepaintBoundary::new().child(child))))
-        .collect()
+    children.into_iter().map(wrap_in_repaint_boundary).collect()
+}
+
+/// Wrap one child, keeping its key visible to the parent.
+///
+/// The key matters: a lazy sliver reconciles its children by key, and an
+/// unkeyed wrapper would hide the item's own key, costing element state on
+/// insert, remove, and reorder. Flutter restores the key outside the boundary
+/// with `KeyedSubtree`; FLUI carries it on the boundary itself, because a lazy
+/// sliver child must own a render node and a stateless `KeyedSubtree`
+/// equivalent has none — see `RepaintBoundary::forwards_child_key`.
+fn wrap_in_repaint_boundary(child: BoxedView) -> BoxedView {
+    BoxedView(Box::new(
+        crate::paint::RepaintBoundary::new()
+            .child(child)
+            .forwarding_child_key(),
+    ))
 }
 
 impl fmt::Debug for SliverChildBuilderDelegate {
@@ -121,6 +140,54 @@ mod tests {
     use flui_view::ViewExt;
 
     use super::*;
+
+    /// The repaint-boundary wrap keeps the item's own key visible.
+    ///
+    /// A lazy sliver reconciles its children by key. An unkeyed wrapper hides
+    /// the item's key from the parent, which then treats every insert, remove,
+    /// or reorder as a fresh child and drops its element state. Flutter avoids
+    /// this by restoring the key OUTSIDE the boundary with `KeyedSubtree`
+    /// (`widgets/scroll_delegate.dart:559`, `:572`); FLUI carries it on the
+    /// boundary, which is the outermost element the parent reconciles either
+    /// way.
+    ///
+    /// Reverted (drop `forwarding_child_key`) the wrapper reports `None`.
+    #[test]
+    fn the_repaint_boundary_wrap_keeps_the_items_key() {
+        use flui_foundation::ValueKey;
+        use flui_view::{BuildContext, IntoView, StatelessView, View};
+
+        #[derive(Clone)]
+        struct KeyedItem(ValueKey<u32>);
+
+        impl View for KeyedItem {
+            fn create_element(&self) -> flui_view::element::ElementKind {
+                flui_view::element::ElementKind::stateless(self)
+            }
+
+            fn key(&self) -> Option<&dyn flui_foundation::ViewKey> {
+                Some(&self.0)
+            }
+        }
+
+        impl StatelessView for KeyedItem {
+            fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+                self.clone()
+            }
+        }
+
+        let wrapped =
+            wrap_in_repaint_boundary(BoxedView(Box::new(KeyedItem(ValueKey::new(7_u32)))));
+        let expected = ValueKey::new(7_u32);
+
+        let actual = wrapped
+            .key()
+            .expect("the wrapper must expose the item's key, not swallow it");
+        assert!(
+            actual.key_eq(&expected),
+            "the wrapper's key must BE the item's key, not merely present"
+        );
+    }
 
     #[test]
     fn new_stores_the_item_count_and_invokes_the_builder_by_index() {

--- a/crates/flui-widgets/tests/lazy_grid.rs
+++ b/crates/flui-widgets/tests/lazy_grid.rs
@@ -48,9 +48,9 @@ fn lazy_grid_view_builder_builds_visible_tiles() {
     // Expected: 1 (RenderViewport) + 1 (RenderSliverGridLazy) + 4 (tiles) = 6.
     let nodes_after_settle = laid.render_node_count();
     assert_eq!(
-        nodes_after_settle, 6,
-        "after settle, render tree should have 1 viewport + 1 lazy grid + 4 tiles = 6; \
-         got {nodes_after_settle}"
+        nodes_after_settle, 10,
+        "after settle, render tree should have 1 viewport + 1 lazy grid + 4 \
+         repaint boundaries + 4 tiles = 10; got {nodes_after_settle}"
     );
 }
 
@@ -85,7 +85,11 @@ fn lazy_grid_view_builder_places_tiles_at_oracle_positions() {
     laid.tick();
     laid.tick();
 
-    let tile_ids = laid.find_all_by_render_type("RenderConstrainedBox");
+    // The grid positions the per-item `RenderRepaintBoundary`; the tile inside
+    // it sits at (0, 0) relative to that. Reading the leaf's offset would give
+    // four zeroes — the same structure Flutter produces, since its delegates
+    // wrap children in a boundary by default.
+    let tile_ids = laid.find_all_by_render_type("RenderRepaintBoundary");
     assert_eq!(
         tile_ids.len(),
         4,
@@ -302,7 +306,10 @@ fn lazy_grid_view_builder_none_at_k_caps_build_count() {
 
     // Expected: 1 (viewport) + 1 (lazy grid) + K (tiles capped by None-return) = 5.
     let nodes_after_settle = laid.render_node_count();
-    let expected = 1 + 1 + K;
+    // `+ 2 * K`, not `+ K`: each item carries its own `RenderRepaintBoundary`,
+    // which `SliverChildBuilderDelegate` adds by default exactly as Flutter's
+    // does (`widgets/scroll_delegate.dart:560`).
+    let expected = 1 + 1 + 2 * K;
     assert_eq!(
         nodes_after_settle, expected,
         "None-at-K must cap build count: expected {expected} nodes, \

--- a/crates/flui-widgets/tests/lazy_list.rs
+++ b/crates/flui-widgets/tests/lazy_list.rs
@@ -56,12 +56,18 @@ fn lazy_list_view_builder_builds_visible_items() {
     // tick2: sliver dirty → laid out with real children.
     laid.tick();
 
-    // Expected: 1 (RenderViewport) + 1 (RenderSliverList) + 3 (item nodes) = 5.
+    // Expected: 1 (RenderViewport) + 1 (RenderSliverList) + 3 (per-item
+    // RenderRepaintBoundary) + 3 (item nodes) = 8.
+    //
+    // The per-item boundary is Flutter's: `SliverChildBuilderDelegate` defaults
+    // `addRepaintBoundaries` to `true` and wraps each child
+    // (`widgets/scroll_delegate.dart:560`), so a scrolling list does not
+    // repaint items that did not change.
     let nodes_after_settle = laid.render_node_count();
     assert_eq!(
-        nodes_after_settle, 5,
-        "after settle, render tree should have 1 viewport + 1 sliver + 3 items = 5 nodes; \
-         got {nodes_after_settle}"
+        nodes_after_settle, 8,
+        "after settle, render tree should have 1 viewport + 1 sliver + 3 boundaries \
+         + 3 items = 8 nodes; got {nodes_after_settle}"
     );
 }
 
@@ -92,7 +98,10 @@ fn lazy_list_view_builder_none_at_k_caps_build_count() {
 
     // Expected: 1 (viewport) + 1 (sliver) + K (items capped by None-return) = 4.
     let nodes_after_settle = laid.render_node_count();
-    let expected = 1 + 1 + K;
+    // `+ 2 * K`, not `+ K`: each item carries its own `RenderRepaintBoundary`,
+    // which `SliverChildBuilderDelegate` adds by default exactly as Flutter's
+    // does (`widgets/scroll_delegate.dart:560`).
+    let expected = 1 + 1 + 2 * K;
     assert_eq!(
         nodes_after_settle, expected,
         "None-at-K must cap build count: expected {expected} nodes, \
@@ -135,9 +144,10 @@ fn lazy_list_view_builder_multi_node_child() {
     // 1 (RenderViewport) + 1 (RenderSliverList) + 3 × 2 (Padding + SizedBox) = 8.
     let nodes_after_settle = laid.render_node_count();
     assert_eq!(
-        nodes_after_settle, 8,
-        "each 2-node item must contribute exactly 2 render nodes; \
-         got {nodes_after_settle} (expected 8 = 1 viewport + 1 sliver + 3 × 2 items)"
+        nodes_after_settle, 11,
+        "each 2-node item must contribute exactly 2 render nodes, plus its own \
+         repaint boundary; got {nodes_after_settle} (expected 11 = 1 viewport \
+         + 1 sliver + 3 boundaries + 3 × 2 items)"
     );
 }
 
@@ -433,5 +443,52 @@ fn lazy_list_view_builder_off_band_eviction_bounded() {
         nodes_after_relayout <= nodes_after_settle,
         "a post-settle relayout tick must not leak render nodes; \
          count went from {nodes_after_settle} to {nodes_after_relayout}"
+    );
+}
+
+// ============================================================================
+// Repaint boundaries per item (Flutter parity)
+// ============================================================================
+
+/// Every list item sits under its own `RenderRepaintBoundary`.
+///
+/// Flutter parity: `SliverChildBuilderDelegate` and `SliverChildListDelegate`
+/// both default `addRepaintBoundaries` to `true` and wrap each child
+/// (`widgets/scroll_delegate.dart:560` and `:774`). Their doc gives the reason
+/// — children in a scrolling container "do not need to be repainted as the
+/// list scrolls".
+///
+/// This is the structural precondition for
+/// `PipelineOwner::retained_boundaries` to do anything in a list: without a
+/// boundary per item, the paint walk descends into every visible item on every
+/// frame and there is nothing to reuse. The behaviour that follows from it is
+/// pinned in `flui-rendering`'s `retained_boundary_layers` tests.
+#[test]
+fn lazy_list_view_builder_wraps_each_item_in_a_repaint_boundary() {
+    const ITEMS: usize = 3;
+
+    let mut laid = lay_out(
+        ListView::builder(ITEMS, 100.0, |i| {
+            (i < ITEMS).then(|| SizedBox::square(100.0).boxed())
+        }),
+        tight(200.0, 400.0),
+    );
+    laid.tick();
+    laid.tick();
+
+    let boundaries = laid.find_all_by_render_type("RenderRepaintBoundary");
+    let items = laid.find_all_by_render_type("RenderConstrainedBox");
+
+    assert_eq!(
+        items.len(),
+        ITEMS,
+        "precondition: all {ITEMS} items are built and attached; got {items:?}"
+    );
+    assert_eq!(
+        boundaries.len(),
+        ITEMS,
+        "each item must carry its own repaint boundary — one per item, not one \
+         for the list; got {} boundaries for {ITEMS} items",
+        boundaries.len()
     );
 }

--- a/crates/flui-widgets/tests/parity/grid_view_interaction_test.rs
+++ b/crates/flui-widgets/tests/parity/grid_view_interaction_test.rs
@@ -1453,10 +1453,14 @@ fn sliver_grid_delegate_negative_main_axis_extent_recovers_from_an_internal_asse
 
     assert_eq!(
         laid.render_node_count(),
-        4,
+        5,
         "the frame recovers rather than crashing, but into a still-degraded tree — \
-         only 4 nodes (viewport + sliver + 2 tiles) exist against the 50 requested, \
-         unlike Flutter's clean, message-carrying rejection at construction time"
+         5 nodes exist against the 50 requested, unlike Flutter's clean, \
+         message-carrying rejection at construction time. The number is a \
+         description of the damage a recovered panic leaves, not a contract; \
+         it moved from 4 when list/grid delegates began wrapping each item in \
+         a repaint boundary, and a probe at that point found one boundary and \
+         one tile attached"
     );
 }
 
@@ -1581,8 +1585,8 @@ fn sliver_grid_delegate_with_max_cross_axis_extent_negative_main_axis_extent_rec
 
     assert_eq!(
         laid.render_node_count(),
-        4,
-        "same degraded-recovery shape as the FixedCrossAxisCount half: only 4 nodes \
-         (viewport + sliver + 2 tiles) exist against the 50 requested"
+        5,
+        "same degraded-recovery shape as the FixedCrossAxisCount half: only 5 \
+         nodes exist against the 50 requested"
     );
 }

--- a/crates/flui-widgets/tests/parity/grid_view_test.rs
+++ b/crates/flui-widgets/tests/parity/grid_view_test.rs
@@ -42,7 +42,7 @@ use crate::harness;
 /// 200-wide grid. Node-count form used in place of `find.byType` (see
 /// divergence notes above).
 #[test]
-fn grid_view_extent_four_tiles_builds_six_render_nodes() {
+fn grid_view_extent_four_tiles_builds_ten_render_nodes() {
     let children: Vec<flui_view::BoxedView> = (0..4).map(|_| SizedBox::shrink().boxed()).collect();
     let root = GridView::extent(100.0, children);
     // 200 × 600: same cross-axis budget as Flutter's `SizedBox(width: 200)`.
@@ -50,28 +50,36 @@ fn grid_view_extent_four_tiles_builds_six_render_nodes() {
 
     assert_eq!(
         laid.render_node_count(),
-        6,
-        "GridView.extent(100, 4 tiles) on 200-wide surface: \
-         expected 6 render nodes (1 viewport + 1 sliver-grid + 4 tiles)"
+        10,
+        "GridView.extent(100, 4 tiles) on 200-wide surface: expected 10 render \
+         nodes (1 viewport + 1 sliver-grid + 4 repaint boundaries + 4 tiles)"
     );
 }
 
 /// `GridView.count(cross_axis_count=3)` on an 800-wide surface with 6 children
-/// builds 8 render nodes: 1 viewport + 1 sliver-grid + 6 tiles.
+/// builds 14 render nodes: 1 viewport + 1 sliver-grid + 6 repaint boundaries
+/// + 6 tiles.
 ///
 /// Flutter parity: derived from `grid_view_layout_test.dart` — the 3-column
 /// variant places all 6 tiles in 2 rows (3 × 2) within the visible band.
+///
+/// The per-tile boundary is Flutter's, not an addition: `GridView.count`
+/// builds a `SliverChildListDelegate` with `addRepaintBoundaries` defaulting
+/// to `true` (`widgets/scroll_view.dart:2143`), and that delegate wraps each
+/// child in a `RepaintBoundary` (`widgets/scroll_delegate.dart:774`). The
+/// counts here used to omit them, which pinned FLUI's divergence rather than
+/// the parity the module claims.
 #[test]
-fn grid_view_count_three_columns_six_tiles_builds_eight_render_nodes() {
+fn grid_view_count_three_columns_six_tiles_builds_fourteen_render_nodes() {
     let children: Vec<flui_view::BoxedView> = (0..6).map(|_| SizedBox::shrink().boxed()).collect();
     let root = GridView::count(3, children);
     let laid = harness::pump_widget(root, harness::screen());
 
     assert_eq!(
         laid.render_node_count(),
-        8,
-        "GridView.count(3, 6 tiles): expected 8 render nodes \
-         (1 viewport + 1 sliver-grid + 6 tiles)"
+        14,
+        "GridView.count(3, 6 tiles): expected 14 render nodes \
+         (1 viewport + 1 sliver-grid + 6 repaint boundaries + 6 tiles)"
     );
 }
 

--- a/crates/flui-widgets/tests/parity/list_view_test.rs
+++ b/crates/flui-widgets/tests/parity/list_view_test.rs
@@ -79,12 +79,18 @@ fn list_view_builder_builds_all_visible_items() {
     // tick 2: sliver re-lays with the built children.
     laid.tick();
 
-    // 1 RenderViewport + 1 RenderSliverList + 3 SizedBox nodes = 5.
+    // 1 RenderViewport + 1 RenderSliverList + 3 RenderRepaintBoundary
+    // + 3 SizedBox nodes = 8.
+    //
+    // The per-item boundary matches Flutter: `SliverChildBuilderDelegate`
+    // defaults `addRepaintBoundaries` to `true` and wraps each child
+    // (`widgets/scroll_delegate.dart:560`), so items that did not change are
+    // not repainted as the list scrolls.
     assert_eq!(
         laid.render_node_count(),
-        5,
-        "ListView(3 items) must have exactly 5 render nodes after settle \
-         (1 viewport + 1 sliver-list + 3 items)"
+        8,
+        "ListView(3 items) must have exactly 8 render nodes after settle \
+         (1 viewport + 1 sliver-list + 3 boundaries + 3 items)"
     );
 }
 

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -1107,3 +1107,33 @@ fn next_page_and_previous_page_navigate_and_clamp_at_the_ends() {
         "previous_page below the first page must clamp at 0.0, not go negative"
     );
 }
+
+/// Every page sits under its own `RenderRepaintBoundary`.
+///
+/// Flutter parity: `PageView` builds a `SliverChildListDelegate(children)`
+/// (`widgets/page_view.dart:711`) and takes that delegate's default
+/// `addRepaintBoundaries: true`, so each page is wrapped
+/// (`widgets/scroll_delegate.dart:774`).
+///
+/// A page carousel is the case the boundary is most obviously for: swiping
+/// between pages changes which page is visible, not what any page contains.
+/// Without the boundary every visible page repaints on every frame of the
+/// swipe.
+#[test]
+fn page_view_wraps_each_page_in_a_repaint_boundary() {
+    const PAGES: usize = 3;
+
+    let laid = lay_out(PageView::new(pages(PAGES)), tight(300.0, 300.0));
+
+    let boundaries = laid.find_all_by_render_type("RenderRepaintBoundary");
+    assert!(
+        !boundaries.is_empty(),
+        "pages must carry repaint boundaries; found none"
+    );
+    assert!(
+        boundaries.len() <= PAGES,
+        "at most one boundary per page — {} boundaries for {PAGES} pages means \
+         something is wrapping more than once",
+        boundaries.len()
+    );
+}


### PR DESCRIPTION
Found while scoping RFC step 10 (damage tracking) — and it turned out to be the thing blocking both that step *and* the payoff of #755.

## The gap

Flutter's list and grid delegates wrap every child in a `RepaintBoundary` **by default**. `addRepaintBoundaries` is `true` on both `SliverChildBuilderDelegate` and `SliverChildListDelegate` (`widgets/scroll_view.dart:2143`), and the wrap happens in their `build` (`widgets/scroll_delegate.dart:560` and `:774`). Their own doc gives the reason:

> Typically, children in a scrolling container are wrapped in repaint boundaries so that they do not need to be repainted as the list scrolls.

FLUI wrapped nothing — `flui-widgets/src/scroll/` contained no `RepaintBoundary` at all. A list repainted every visible item on every frame, including a scroll, where nothing about the items changed.

**It also left #755 with no input.** Retention reuses a clean repaint boundary's layers; a list had no boundaries to reuse. The 53% that PR measured on a synthetic boundary tree was unreachable in the case that matters most.

And it is why I stopped short of building damage tracking: damage derived from the paint phase is the union of everything repainted, so without per-item boundaries a list scroll damages the whole viewport and the feature would have measured as no improvement.

`SliverChildBuilderDelegate::with_options` carries Flutter's opt-out for the case its doc names — items cheaper to repaint than to composite.

## The test fallout is the interesting part

Eleven tests pinned trees **without** boundaries, in a module named `parity`. A `GridView.count` with 6 children asserted "1 viewport + 1 sliver-grid + 6 tiles = 8"; Flutter's tree for that same widget has 6 `RenderRepaintBoundary` nodes too, so the correct count is 14. Those numbers encoded the divergence rather than the parity they claimed. Updated, with the Flutter lines cited in each doc.

One was not a count. `lazy_grid_view_builder_places_tiles_at_oracle_positions` read the leaf tiles' offsets and got four zeroes: the grid positions the **boundary** now, and the tile inside sits at the origin relative to it — again Flutter's structure. It reads the boundary's offset.

Two degraded-recovery tests moved 4 → 5 nodes. Their prose claimed a composition ("viewport + sliver + 2 tiles") that a probe did **not** confirm — it found one boundary and one tile — so rather than substitute a new guess, the message now says what the number is: a description of the damage a recovered panic leaves, not a contract.

## Evidence

`lazy_list_view_builder_wraps_each_item_in_a_repaint_boundary` pins the contract directly — one boundary per item, not one for the list. Reverted (default the flag to `false`) it reports `got 0 boundaries for 3 items`.

`cargo nextest run --workspace --exclude flui-platform` → 9057 passed. Workspace clippy clean, typos clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo