### PR TITLE
feat(widgets): put the repaint-boundary opt-out on the widgets themselves

### DIFF
--- a/crates/flui-widgets/src/scroll/grid_view.rs
+++ b/crates/flui-widgets/src/scroll/grid_view.rs
@@ -74,6 +74,11 @@ pub struct GridView {
     children: Vec<BoxedView>,
     /// Builder delegate for the lazy variant.  `None` in the eager variants.
     builder_source: Option<SliverChildBuilderDelegate>,
+    /// Wrap each tile in a `RepaintBoundary` (default `true`).
+    ///
+    /// Flutter parity: `addRepaintBoundaries` on the delegates `GridView`
+    /// builds, which defaults to `true`.
+    add_repaint_boundaries: bool,
 }
 
 impl GridView {
@@ -90,8 +95,9 @@ impl GridView {
             offset_source: OffsetSource::Pixels(0.0),
             shrink_wrap: false,
             grid_delegate: Arc::new(delegate),
-            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
+            children: children.into_boxed_vec(),
             builder_source: None,
+            add_repaint_boundaries: true,
         }
     }
 
@@ -110,8 +116,9 @@ impl GridView {
             offset_source: OffsetSource::Pixels(0.0),
             shrink_wrap: false,
             grid_delegate: Arc::new(delegate),
-            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
+            children: children.into_boxed_vec(),
             builder_source: None,
+            add_repaint_boundaries: true,
         }
     }
 
@@ -139,7 +146,20 @@ impl GridView {
             grid_delegate,
             children: Vec::new(),
             builder_source: Some(SliverChildBuilderDelegate::new(item_count, builder)),
+            add_repaint_boundaries: true,
         }
+    }
+
+    /// Wrap each tile in a `RepaintBoundary` (default `true`).
+    ///
+    /// Flutter parity: the `addRepaintBoundaries` knob its delegates carry,
+    /// defaulting to `true` for the reason its doc gives — children in a
+    /// scrolling container "do not need to be repainted as the list scrolls".
+    /// Pass `false` when a tile is cheaper to repaint than to composite.
+    #[must_use]
+    pub fn repaint_boundaries(mut self, add: bool) -> Self {
+        self.add_repaint_boundaries = add;
+        self
     }
 
     /// Set the scroll axis (default [`Axis::Vertical`]).
@@ -196,7 +216,8 @@ impl fmt::Debug for GridView {
             s.field("builder_source", &self.builder_source);
         } else {
             s.field("grid_delegate", &self.grid_delegate)
-                .field("children", &self.children.len());
+                .field("children", &self.children.len())
+                .field("add_repaint_boundaries", &self.add_repaint_boundaries);
         }
         s.finish()
     }
@@ -213,15 +234,25 @@ impl StatelessView for GridView {
 
         let sliver: BoxedView = if let Some(ref delegate) = self.builder_source {
             // Lazy variant: wire SliverGridLazy (element-owned request strategy).
+            let builder = if self.add_repaint_boundaries {
+                super::sliver_list::wrap_builder_in_repaint_boundaries(&delegate.builder)
+            } else {
+                Rc::clone(&delegate.builder)
+            };
             SliverGridLazy::new(
                 Arc::clone(&self.grid_delegate),
                 delegate.item_count,
-                Rc::clone(&delegate.builder),
+                builder,
             )
             .boxed()
         } else {
             // Eager variant: all children pre-attached.
-            SliverGrid::new(Arc::clone(&self.grid_delegate), self.children.clone()).boxed()
+            let children = if self.add_repaint_boundaries {
+                super::sliver_list::wrap_in_repaint_boundaries(self.children.clone())
+            } else {
+                self.children.clone()
+            };
+            SliverGrid::new(Arc::clone(&self.grid_delegate), children).boxed()
         };
 
         if self.shrink_wrap {

--- a/crates/flui-widgets/src/scroll/list_view.rs
+++ b/crates/flui-widgets/src/scroll/list_view.rs
@@ -74,6 +74,14 @@ pub struct ListView {
     children: Vec<BoxedView>,
     /// Builder delegate for the lazy variant. `None` in the static variant.
     builder_source: Option<SliverChildBuilderDelegate>,
+    /// Wrap each item in a `RepaintBoundary` (default `true`).
+    ///
+    /// Flutter parity: the same knob its delegates carry as
+    /// `addRepaintBoundaries`, defaulting to `true` for the reason its doc
+    /// gives — children in a scrolling container "do not need to be repainted
+    /// as the list scrolls". Set `false` when an item is cheaper to repaint
+    /// than to composite.
+    add_repaint_boundaries: bool,
 }
 
 impl ListView {
@@ -90,8 +98,9 @@ impl ListView {
             item_extent_estimate: item_extent,
             offset_source: OffsetSource::Pixels(0.0),
             shrink_wrap: false,
-            children: super::sliver_list::wrap_in_repaint_boundaries(children.into_boxed_vec()),
+            children: children.into_boxed_vec(),
             builder_source: None,
+            add_repaint_boundaries: true,
         }
     }
 
@@ -121,7 +130,20 @@ impl ListView {
             shrink_wrap: false,
             children: Vec::new(),
             builder_source: Some(SliverChildBuilderDelegate::new(item_count, builder)),
+            add_repaint_boundaries: true,
         }
+    }
+
+    /// Wrap each item in a `RepaintBoundary` (default `true`).
+    ///
+    /// Flutter parity: the `addRepaintBoundaries` knob its delegates carry,
+    /// defaulting to `true` for the reason its doc gives — children in a
+    /// scrolling container "do not need to be repainted as the list scrolls".
+    /// Pass `false` when a item is cheaper to repaint than to composite.
+    #[must_use]
+    pub fn repaint_boundaries(mut self, add: bool) -> Self {
+        self.add_repaint_boundaries = add;
+        self
     }
 
     /// Set the scroll axis (default [`Axis::Vertical`]).
@@ -179,7 +201,8 @@ impl fmt::Debug for ListView {
             s.field("builder_source", &self.builder_source);
         } else {
             s.field("item_extent", &self.item_extent)
-                .field("children", &self.children.len());
+                .field("children", &self.children.len())
+                .field("add_repaint_boundaries", &self.add_repaint_boundaries);
         }
         s.finish()
     }
@@ -202,14 +225,19 @@ impl StatelessView for ListView {
         // widgets-side wrapper. The element's `view_type_id()` now returns
         // `TypeId::of::<SliverList>()`, fixing BLOCKER 1 (element identity).
         let sliver: BoxedView = if let Some(ref delegate) = self.builder_source {
-            SliverList::new(
-                delegate.item_count,
-                self.item_extent_estimate,
-                Rc::clone(&delegate.builder),
-            )
-            .boxed()
+            let builder = if self.add_repaint_boundaries {
+                super::sliver_list::wrap_builder_in_repaint_boundaries(&delegate.builder)
+            } else {
+                Rc::clone(&delegate.builder)
+            };
+            SliverList::new(delegate.item_count, self.item_extent_estimate, builder).boxed()
         } else {
-            SliverFixedExtentList::new(self.item_extent, self.children.clone()).boxed()
+            let children = if self.add_repaint_boundaries {
+                super::sliver_list::wrap_in_repaint_boundaries(self.children.clone())
+            } else {
+                self.children.clone()
+            };
+            SliverFixedExtentList::new(self.item_extent, children).boxed()
         };
         if self.shrink_wrap {
             let viewport = ShrinkWrappingViewport::new((sliver,)).axis_direction(axis_direction);

--- a/crates/flui-widgets/src/scroll/sliver_list.rs
+++ b/crates/flui-widgets/src/scroll/sliver_list.rs
@@ -56,45 +56,9 @@ impl SliverChildBuilderDelegate {
     where
         F: Fn(usize) -> Option<BoxedView> + 'static,
     {
-        Self::with_options(item_count, true, builder)
-    }
-
-    /// Like [`Self::new`], but lets the caller decline the per-item repaint
-    /// boundary.
-    ///
-    /// Flutter parity: `SliverChildBuilderDelegate.addRepaintBoundaries`,
-    /// which defaults to `true` for the reason its own doc gives — children in
-    /// a scrolling container "do not need to be repainted as the list
-    /// scrolls". Without the boundary the paint walk descends into every
-    /// visible item on every frame, and nothing the retention path
-    /// (`PipelineOwner::retained_boundaries`) can reuse ever exists.
-    ///
-    /// Pass `false` when the items are cheaper to repaint than to composite —
-    /// solid colour blocks, a short line of text — which is the same guidance
-    /// Flutter gives.
-    ///
-    /// `pub(crate)` on purpose: no scroll widget accepts a prebuilt delegate,
-    /// so a public form would be unreachable API. Flutter exposes the flag on
-    /// `ListView.builder` / `GridView.count` themselves; giving the FLUI
-    /// widgets the same knob is the follow-up, and this stays internal until
-    /// there is a caller.
-    #[must_use]
-    pub(crate) fn with_options<F>(
-        item_count: usize,
-        add_repaint_boundaries: bool,
-        builder: F,
-    ) -> Self
-    where
-        F: Fn(usize) -> Option<BoxedView> + 'static,
-    {
-        let builder: Rc<dyn Fn(usize) -> Option<BoxedView>> = if add_repaint_boundaries {
-            Rc::new(move |index| builder(index).map(wrap_in_repaint_boundary))
-        } else {
-            Rc::new(builder)
-        };
         Self {
             item_count,
-            builder,
+            builder: Rc::new(builder),
         }
     }
 }
@@ -109,6 +73,19 @@ impl SliverChildBuilderDelegate {
 #[must_use]
 pub(crate) fn wrap_in_repaint_boundaries(children: Vec<BoxedView>) -> Vec<BoxedView> {
     children.into_iter().map(wrap_in_repaint_boundary).collect()
+}
+
+/// Wrap a lazy builder's output in per-item repaint boundaries.
+///
+/// Applied where a widget builds its sliver rather than where the delegate is
+/// constructed, so `repaint_boundaries(false)` still takes effect on a widget
+/// whose delegate already exists.
+#[must_use]
+pub(crate) fn wrap_builder_in_repaint_boundaries(
+    builder: &Rc<dyn Fn(usize) -> Option<BoxedView>>,
+) -> Rc<dyn Fn(usize) -> Option<BoxedView>> {
+    let inner = Rc::clone(builder);
+    Rc::new(move |index| inner(index).map(wrap_in_repaint_boundary))
 }
 
 /// Wrap one child, keeping its key visible to the parent.

--- a/crates/flui-widgets/tests/lazy_list.rs
+++ b/crates/flui-widgets/tests/lazy_list.rs
@@ -492,3 +492,48 @@ fn lazy_list_view_builder_wraps_each_item_in_a_repaint_boundary() {
         boundaries.len()
     );
 }
+
+/// `repaint_boundaries(false)` actually reaches the tree.
+///
+/// The knob exists because Flutter's does (`addRepaintBoundaries`), for the
+/// case its doc names: items cheaper to repaint than to composite. An earlier
+/// version of this work put the opt-out on the delegate, where no widget could
+/// reach it — the flag was public API that nothing could call. This pins that
+/// it is wired end to end.
+#[test]
+fn lazy_list_view_builder_repaint_boundaries_false_drops_the_wrappers() {
+    const ITEMS: usize = 3;
+
+    let build = |add: bool| {
+        let mut laid = lay_out(
+            ListView::builder(ITEMS, 100.0, |i| {
+                (i < ITEMS).then(|| SizedBox::square(100.0).boxed())
+            })
+            .repaint_boundaries(add),
+            tight(200.0, 400.0),
+        );
+        laid.tick();
+        laid.tick();
+        (
+            laid.find_all_by_render_type("RenderRepaintBoundary").len(),
+            laid.find_all_by_render_type("RenderConstrainedBox").len(),
+        )
+    };
+
+    let (with_boundaries, items_with) = build(true);
+    let (without_boundaries, items_without) = build(false);
+
+    assert_eq!(
+        (items_with, items_without),
+        (ITEMS, ITEMS),
+        "precondition: the items themselves are built either way"
+    );
+    assert_eq!(
+        with_boundaries, ITEMS,
+        "the default wraps every item; got {with_boundaries}"
+    );
+    assert_eq!(
+        without_boundaries, 0,
+        "repaint_boundaries(false) must drop them; got {without_boundaries}"
+    );
+}


### PR DESCRIPTION
Follow-up to #757, closing the half Codex flagged there.

## The gap it closes

`SliverChildBuilderDelegate::with_options` was unreachable — no scroll widget accepts a prebuilt delegate, so the Flutter-style opt-out was public API nothing could call. Demoting it to `pub(crate)` answered the "dead API" half. This answers the other half: `ListView` and `GridView` carry `repaint_boundaries(bool)`, defaulting to `true`, which is where Flutter puts the flag — on `ListView.builder` / `GridView.count`, not on the delegate.

## What it required

A chainable setter cannot un-wrap children the constructor already wrapped, so the wrap moved from the constructor to the point each widget builds its sliver. The delegate is a plain carrier again; the wrap is applied per build — the lazy variant wraps the builder closure, the eager one wraps the child vector.

`PageView` keeps its constructor-side wrap: it has no lazy variant and no other knobs, so there is nothing for a deferred decision to wait for.

## Evidence

`lazy_list_view_builder_repaint_boundaries_false_drops_the_wrappers` builds the same list both ways and asserts the wrappers appear and disappear **while the items themselves do not**. That last clause is the point: it distinguishes "the flag is wired" from "the flag broke the list".

`cargo nextest run --workspace --exclude flui-platform` → 9060 passed. Workspace clippy clean, typos clean.

## Incidental

The local `just gate` caught two things before CI could: `Debug` impls that omitted the new field, and doc links to the private field that resolved only under `--document-private-items`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJUGMZUyuYbiv1qDVaQsRo