### PR TITLE
fix(input): three pointer-delivery contract fixes from the live-wire audit

### DIFF
--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -859,14 +859,18 @@ impl PlatformToUi {
                 // recognizer mid-drag) until a superseding Down. The
                 // lifecycle ladder below reaches only Inactive here, so
                 // `emit_lifecycle_transition`'s own gesture drain — gated
-                // on Hidden/Paused/Detached — never covers this case. A
-                // panic from a user cancel handler is deferred so the
-                // lifecycle transition still runs.
+                // on Hidden/Paused/Detached — never covers this case.
+                // Addressed to THIS event's presentation, whose own gesture
+                // binding is where its pointer input lands (pointer input
+                // routes per presentation; the realm-level `gestures()` is
+                // primary-only and would miss a non-primary window under a
+                // shared-realm policy). A panic from a user cancel handler
+                // is deferred so the lifecycle transition still runs.
                 let gesture_cancel_panic = if focused {
                     None
                 } else {
                     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        realm.gestures().cancel_active_pointers();
+                        realm.cancel_pointer_sequences_for(presentation_id);
                     }))
                     .err()
                 };
@@ -6087,18 +6091,21 @@ mod realm_dispatch_tests {
         teardown_platform_realm();
     }
 
-    /// Losing OS focus mid-contact must cancel the realm's in-flight
-    /// pointer sequences (alt-tab means the matching Up may never arrive),
-    /// but ONLY for an authoritative focus loss: a stale `WindowFocus(false)`
-    /// from a presentation that is not the realm's active one is a normal
-    /// consequence of focus moving to a sibling window of the SAME realm,
-    /// and must leave a drag in the still-focused sibling untouched. Driven
-    /// through the REAL dispatch seam, so this pins the wire from
-    /// `PlatformToUi::run`'s `WindowFocus` arm to
-    /// `GestureBinding::cancel_active_pointers`, including its interplay
-    /// with the stale-focus-loss guard.
+    /// Losing OS focus mid-contact must cancel in-flight pointer sequences
+    /// (alt-tab means the matching Up may never arrive), with two scoping
+    /// rules pinned through the REAL dispatch seam:
+    ///
+    /// - ONLY an authoritative focus loss cancels: a stale
+    ///   `WindowFocus(false)` from a presentation that is not the realm's
+    ///   active one is a normal consequence of focus moving to a sibling
+    ///   window of the SAME realm, and must leave every sequence untouched.
+    /// - The cancellation is ADDRESSED: pointer input lands in each
+    ///   presentation's own gesture binding (`handle_input_addressed`), so
+    ///   the defocused presentation's own binding drains while a sibling
+    ///   presentation's sequences survive. A primary-only cancel would
+    ///   invert both assertions under a shared-realm window policy.
     #[test]
-    fn window_focus_loss_cancels_pointer_sequences_only_when_authoritative() {
+    fn window_focus_loss_cancels_the_addressed_presentations_sequences_only() {
         let platform = flui_platform::headless_platform();
         let window_a = platform
             .open_window(flui_platform::WindowOptions::default())
@@ -6109,31 +6116,52 @@ mod realm_dispatch_tests {
 
         let realm = super::super::ui_realm::UiRealm::for_test();
         let dispatcher_a = install_platform_realm(realm, &window_a);
+        let a_id = dispatcher_a.address.presentation_id;
         let dispatcher_b = install_presentation_alongside(dispatcher_a, &window_b)
             .expect("B installs alongside A with a real window mapping");
+        let b_id = dispatcher_b.address.presentation_id;
 
-        // B's window holds OS focus; B is the realm's active presentation.
+        // A contact lands in A's own binding through the real addressed
+        // input path, while A is the active presentation.
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Event(PlatformToUi::Input(down_input(8.0))),
+        )
+        .expect("down for A dispatches");
+
+        // Focus moves to B; a second contact lands in B's own binding.
         dispatch_platform_realm(
             dispatcher_b,
             RealmTask::Event(PlatformToUi::WindowFocus(true)),
         )
         .expect("WindowFocus(true) for B dispatches");
-
-        // A contact lands and stays in flight (no Up).
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Event(PlatformToUi::Input(down_input(21.0))),
+        )
+        .expect("down for B dispatches");
         dispatch_platform_realm(
             dispatcher_a,
-            RealmTask::Frame(Box::new(|realm| {
-                let down =
-                    make_down_event(Offset::new(Pixels(8.0), Pixels(13.0)), PointerType::Mouse);
-                realm
-                    .gestures()
-                    .handle_pointer_event(&down, |_| HitTestResult::new());
-                assert_eq!(realm.gestures().active_pointer_count(), 1);
+            RealmTask::Frame(Box::new(move |realm| {
+                assert_eq!(
+                    realm
+                        .presentation_gestures_for_test(a_id)
+                        .active_pointer_count(),
+                    1,
+                    "precondition: A's own binding holds its contact"
+                );
+                assert_eq!(
+                    realm
+                        .presentation_gestures_for_test(b_id)
+                        .active_pointer_count(),
+                    1,
+                    "precondition: B's own binding holds its contact"
+                );
             })),
         )
-        .expect("down frame task dispatches");
+        .expect("frame task dispatches");
 
-        // Stale focus loss (A is not active): the sequence must survive.
+        // Stale focus loss (A is not active): every sequence must survive.
         dispatch_platform_realm(
             dispatcher_a,
             RealmTask::Event(PlatformToUi::WindowFocus(false)),
@@ -6141,18 +6169,28 @@ mod realm_dispatch_tests {
         .expect("stale WindowFocus(false) for A dispatches");
         dispatch_platform_realm(
             dispatcher_a,
-            RealmTask::Frame(Box::new(|realm| {
+            RealmTask::Frame(Box::new(move |realm| {
                 assert_eq!(
-                    realm.gestures().active_pointer_count(),
+                    realm
+                        .presentation_gestures_for_test(a_id)
+                        .active_pointer_count(),
                     1,
-                    "a stale focus loss from a non-active presentation must never cancel \
-                     the active sibling's in-flight sequence"
+                    "a stale focus loss must never cancel anything"
+                );
+                assert_eq!(
+                    realm
+                        .presentation_gestures_for_test(b_id)
+                        .active_pointer_count(),
+                    1,
+                    "a stale focus loss must never cancel the active sibling's sequence"
                 );
             })),
         )
         .expect("frame task dispatches");
 
-        // Authoritative focus loss (B IS active): the sequence cancels.
+        // Authoritative focus loss (B IS active): B's own binding drains;
+        // A's — the PRIMARY's — must be untouched, proving the cancel is
+        // addressed rather than primary-blasted.
         dispatch_platform_realm(
             dispatcher_b,
             RealmTask::Event(PlatformToUi::WindowFocus(false)),
@@ -6160,14 +6198,29 @@ mod realm_dispatch_tests {
         .expect("authoritative WindowFocus(false) for B dispatches");
         dispatch_platform_realm(
             dispatcher_a,
-            RealmTask::Frame(Box::new(|realm| {
+            RealmTask::Frame(Box::new(move |realm| {
                 assert_eq!(
-                    realm.gestures().active_pointer_count(),
+                    realm
+                        .presentation_gestures_for_test(b_id)
+                        .active_pointer_count(),
                     0,
-                    "an authoritative focus loss must cancel every in-flight pointer \
-                     sequence -- the platform may never deliver the matching Up"
+                    "an authoritative focus loss must cancel the addressed presentation's \
+                     in-flight sequences -- the platform may never deliver the matching Up"
                 );
-                assert!(realm.gestures().arena().is_empty());
+                assert!(
+                    realm
+                        .presentation_gestures_for_test(b_id)
+                        .arena()
+                        .is_empty()
+                );
+                assert_eq!(
+                    realm
+                        .presentation_gestures_for_test(a_id)
+                        .active_pointer_count(),
+                    1,
+                    "the sibling presentation's own binding must be untouched -- a \
+                     primary-only cancel would have drained A instead of B"
+                );
             })),
         )
         .expect("frame task dispatches");

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -852,6 +852,24 @@ impl PlatformToUi {
                     );
                     return;
                 }
+                // An authoritative focus loss terminates in-flight pointer
+                // sequences with a synthesized Cancel: a defocused window
+                // may never receive the Up matching a Down landed before
+                // the alt-tab, which would strand the sequence (and any
+                // recognizer mid-drag) until a superseding Down. The
+                // lifecycle ladder below reaches only Inactive here, so
+                // `emit_lifecycle_transition`'s own gesture drain — gated
+                // on Hidden/Paused/Detached — never covers this case. A
+                // panic from a user cancel handler is deferred so the
+                // lifecycle transition still runs.
+                let gesture_cancel_panic = if focused {
+                    None
+                } else {
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        realm.gestures().cancel_active_pointers();
+                    }))
+                    .err()
+                };
                 let (old, new) = APP_RUNTIME.with(|slot| {
                     let mut state = slot.borrow_mut();
                     let old = derive_lifecycle_state(state.visible, state.focused);
@@ -866,6 +884,9 @@ impl PlatformToUi {
                     realm.notify_presentation_focus_gained(presentation_id);
                 }
                 emit_lifecycle_transition(realm, old, new);
+                if let Some(payload) = gesture_cancel_panic {
+                    std::panic::resume_unwind(payload);
+                }
             }
             Self::WindowHover(inside) => {
                 realm.handle_window_hover_addressed(presentation_id, inside);
@@ -6059,6 +6080,94 @@ mod realm_dispatch_tests {
                      still suspend the realm -- the guard drops only NON-active focus-loss, \
                      never focus-loss unconditionally"
                 );
+            })),
+        )
+        .expect("frame task dispatches");
+
+        teardown_platform_realm();
+    }
+
+    /// Losing OS focus mid-contact must cancel the realm's in-flight
+    /// pointer sequences (alt-tab means the matching Up may never arrive),
+    /// but ONLY for an authoritative focus loss: a stale `WindowFocus(false)`
+    /// from a presentation that is not the realm's active one is a normal
+    /// consequence of focus moving to a sibling window of the SAME realm,
+    /// and must leave a drag in the still-focused sibling untouched. Driven
+    /// through the REAL dispatch seam, so this pins the wire from
+    /// `PlatformToUi::run`'s `WindowFocus` arm to
+    /// `GestureBinding::cancel_active_pointers`, including its interplay
+    /// with the stale-focus-loss guard.
+    #[test]
+    fn window_focus_loss_cancels_pointer_sequences_only_when_authoritative() {
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
+
+        let realm = super::super::ui_realm::UiRealm::for_test();
+        let dispatcher_a = install_platform_realm(realm, &window_a);
+        let dispatcher_b = install_presentation_alongside(dispatcher_a, &window_b)
+            .expect("B installs alongside A with a real window mapping");
+
+        // B's window holds OS focus; B is the realm's active presentation.
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Event(PlatformToUi::WindowFocus(true)),
+        )
+        .expect("WindowFocus(true) for B dispatches");
+
+        // A contact lands and stays in flight (no Up).
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(|realm| {
+                let down =
+                    make_down_event(Offset::new(Pixels(8.0), Pixels(13.0)), PointerType::Mouse);
+                realm
+                    .gestures()
+                    .handle_pointer_event(&down, |_| HitTestResult::new());
+                assert_eq!(realm.gestures().active_pointer_count(), 1);
+            })),
+        )
+        .expect("down frame task dispatches");
+
+        // Stale focus loss (A is not active): the sequence must survive.
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Event(PlatformToUi::WindowFocus(false)),
+        )
+        .expect("stale WindowFocus(false) for A dispatches");
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(|realm| {
+                assert_eq!(
+                    realm.gestures().active_pointer_count(),
+                    1,
+                    "a stale focus loss from a non-active presentation must never cancel \
+                     the active sibling's in-flight sequence"
+                );
+            })),
+        )
+        .expect("frame task dispatches");
+
+        // Authoritative focus loss (B IS active): the sequence cancels.
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Event(PlatformToUi::WindowFocus(false)),
+        )
+        .expect("authoritative WindowFocus(false) for B dispatches");
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(|realm| {
+                assert_eq!(
+                    realm.gestures().active_pointer_count(),
+                    0,
+                    "an authoritative focus loss must cancel every in-flight pointer \
+                     sequence -- the platform may never deliver the matching Up"
+                );
+                assert!(realm.gestures().arena().is_empty());
             })),
         )
         .expect("frame task dispatches");

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -962,6 +962,18 @@ impl UiRealm {
             .widgets()
     }
 
+    /// This realm's `GestureBinding` for the presentation named `id` — the
+    /// addressed counterpart to [`Self::gestures`] (primary-only), for the
+    /// tests proving focus-loss cancellation reaches exactly the binding
+    /// the addressed presentation's pointer input lands in.
+    #[cfg(test)]
+    pub(crate) fn presentation_gestures_for_test(&self, id: PresentationId) -> &GestureBinding {
+        self.presentations
+            .get(id)
+            .expect("BUG: presentation_gestures_for_test called with an unknown id")
+            .gestures()
+    }
+
     /// This realm's `TextInputHandle` for the presentation named `id` — the
     /// addressed counterpart to [`Self::text_input_handle`] (primary-only),
     /// for the isolation suite proving IME sessions stay exclusive to the
@@ -1241,6 +1253,30 @@ impl UiRealm {
     /// realm dispatch path rather than exposing a second public owner seam.
     pub(crate) fn gestures(&self) -> &GestureBinding {
         self.presentations.primary().gestures()
+    }
+
+    /// Cancel in-flight pointer sequences on the ADDRESSED presentation's
+    /// own gesture binding.
+    ///
+    /// Pointer input routes per presentation
+    /// ([`Self::handle_input_addressed`] dispatches to
+    /// `presentation.gestures()`), so a focus-loss cancellation must reach
+    /// the same binding that presentation's Downs landed in — the
+    /// realm-level [`Self::gestures`] wrapper is primary-only, and under a
+    /// shared-realm window policy it would cancel a sibling presentation's
+    /// sequences while leaving the defocused window's own drag stranded. A
+    /// presentation this realm no longer hosts is a traced no-op, matching
+    /// the addressed-input path's posture for the same race.
+    pub(crate) fn cancel_pointer_sequences_for(&self, presentation_id: PresentationId) {
+        let Some(presentation) = self.presentations.get(presentation_id) else {
+            tracing::debug!(
+                { flui_foundation::diagnostics::PRESENTATION_ID } = presentation_id.as_u64(),
+                "dropping a pointer-sequence cancellation addressed to a presentation this \
+                 realm no longer hosts"
+            );
+            return;
+        };
+        presentation.gestures().cancel_active_pointers();
     }
 
     /// Focus state for the realm's current primary presentation. Since

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -59,6 +59,9 @@
 //! 4. **Pointer Up**: Use cached hit test → dispatch → sweep arena → clear cache
 //! 5. **Pointer Cancel**: Use cached hit test → dispatch recognizer rejection →
 //!    clear cache without a binding sweep
+//! 6. **Enter/Leave**: cached route mid-contact; otherwise a fresh ephemeral
+//!    hit test at the device's last-known hover position (the events carry
+//!    no position of their own)
 //!
 //! # Example
 //!
@@ -1048,7 +1051,33 @@ impl GestureBinding {
                 }
             }
             PointerEvent::Enter(_) | PointerEvent::Leave(_) => {
-                if let Some(panic) = self.dispatch_on_cached_route(pointer_id, event) {
+                // An active contact keeps capture semantics: deliver on the
+                // route hit-tested at Down, like every other mid-contact
+                // event of the sequence (Flutter parity:
+                // `gestures/binding.dart` routes a down pointer's events
+                // over the result stored for it at Down).
+                let panic = if self.hit_tests.contains_key(&pointer_id) {
+                    self.dispatch_on_cached_route(pointer_id, event)
+                } else {
+                    // A HOVERING pointer — the only state in which a
+                    // window-boundary Enter/Leave normally arrives — has no
+                    // cached route, so resolve a fresh ephemeral path the
+                    // way Scroll does. The event itself carries no position
+                    // (the macOS and Android producers only identify the
+                    // pointer), so the path is resolved at the device's
+                    // last-known hover position. A device this binding has
+                    // never seen has no position to resolve; the event
+                    // still reaches the pointer router (Flutter parity:
+                    // an added/removed-class event dispatches with no hit
+                    // path, router only).
+                    use crate::events::PointerEventExt as _;
+                    let result = match self.mouse_tracker.device_position(event.device_id()) {
+                        Some(position) => hit_test_fn(position),
+                        None => HitTestResult::new(),
+                    };
+                    self.dispatch_ephemeral(event, &result)
+                };
+                if let Some(panic) = panic {
                     panic.resume();
                 }
             }
@@ -2704,6 +2733,122 @@ mod tests {
                 handler_dropped.get(),
                 "Cancel must release the cached route, dropping the last handler owner"
             );
+        });
+    }
+
+    /// Builds the window-boundary Enter/Leave shape the macOS and Android
+    /// backends produce: pointer identity only, no position payload.
+    fn make_boundary_event(entering: bool) -> PointerEvent {
+        use ui_events::pointer::PointerInfo;
+
+        let info = PointerInfo {
+            pointer_id: Some(PointerId::PRIMARY),
+            pointer_type: PointerType::Mouse,
+            persistent_device_id: None,
+        };
+        if entering {
+            PointerEvent::Enter(info)
+        } else {
+            PointerEvent::Leave(info)
+        }
+    }
+
+    /// A HOVERING pointer (no active contact) has no cached Down route, so
+    /// Enter/Leave must resolve a fresh ephemeral path — at the device's
+    /// last-known hover position, since the events carry none of their own —
+    /// instead of being silently dropped by the cached-route lookup.
+    #[test]
+    fn enter_and_leave_without_contact_deliver_over_a_fresh_hit_test() {
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let binding = GestureBinding::new();
+        let log = Rc::new(RefCell::new(Vec::new()));
+        lane.enter(|| {
+            let sink = Rc::clone(&log);
+            let target = handle
+                .register_pointer(move |event| {
+                    sink.borrow_mut().push(match event {
+                        PointerEvent::Enter(_) => "enter",
+                        PointerEvent::Leave(_) => "leave",
+                        _ => "other",
+                    });
+                })
+                .expect("register");
+            let result = hit_result(target);
+
+            // A hover move teaches the mouse tracker this device's position.
+            let hover_position = Offset::new(Pixels(30.0), Pixels(40.0));
+            let mv = make_move_event(hover_position, PointerType::Mouse);
+            binding.handle_pointer_event(&mv, |_| result.clone());
+
+            let enter_result = result.clone();
+            binding.handle_pointer_event(&make_boundary_event(true), move |position| {
+                assert_eq!(
+                    position, hover_position,
+                    "the ephemeral path must resolve at the last-known hover position"
+                );
+                enter_result
+            });
+            assert_eq!(&*log.borrow(), &["enter"]);
+
+            binding.handle_pointer_event(&make_boundary_event(false), move |_| result);
+            assert_eq!(&*log.borrow(), &["enter", "leave"]);
+        });
+    }
+
+    /// An Enter for a device the binding has never seen has no position to
+    /// resolve a path at: the hit-test callback must not run, but the event
+    /// still reaches the pointer router rather than vanishing.
+    #[test]
+    fn enter_for_an_unseen_device_reaches_the_pointer_router_without_hit_testing() {
+        let binding = GestureBinding::new();
+        let routed = Rc::new(Cell::new(0));
+        let counter = Rc::clone(&routed);
+        let global: crate::routing::GlobalPointerHandler = Rc::new(move |event| {
+            if matches!(event, PointerEvent::Enter(_)) {
+                counter.set(counter.get() + 1);
+            }
+        });
+        binding.pointer_router().add_global_handler(global);
+
+        binding.handle_pointer_event(&make_boundary_event(true), |_| {
+            panic!("no known device position: the hit-test callback must not run");
+        });
+        assert_eq!(routed.get(), 1);
+    }
+
+    /// Mid-contact (a button held while the pointer crosses the window
+    /// boundary) the sequence keeps capture semantics: Enter/Leave deliver
+    /// on the route hit-tested at Down, with no fresh hit test.
+    #[test]
+    fn leave_mid_contact_delivers_on_the_cached_down_route() {
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let binding = GestureBinding::new();
+        let log = Rc::new(RefCell::new(Vec::new()));
+        lane.enter(|| {
+            let sink = Rc::clone(&log);
+            let target = handle
+                .register_pointer(move |event| {
+                    sink.borrow_mut().push(match event {
+                        PointerEvent::Down(_) => "down",
+                        PointerEvent::Leave(_) => "leave",
+                        _ => "other",
+                    });
+                })
+                .expect("register");
+            let result = hit_result(target);
+
+            let down = make_down_event(Offset::new(Pixels(5.0), Pixels(5.0)), PointerType::Mouse);
+            binding.handle_pointer_event(&down, |_| result);
+
+            binding.handle_pointer_event(&make_boundary_event(false), |_| {
+                panic!("an active contact must reuse its Down route, never re-hit-test");
+            });
+            assert_eq!(&*log.borrow(), &["down", "leave"]);
+
+            let up = make_up_event(Offset::new(Pixels(5.0), Pixels(5.0)), PointerType::Mouse);
+            binding.handle_pointer_event(&up, |_| HitTestResult::new());
         });
     }
 

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -832,6 +832,7 @@ impl GestureBinding {
             .map(|entry| (*entry.key(), entry.pointer_type))
             .collect();
         pointers.sort_unstable_by_key(|(pointer_id, _)| *pointer_id);
+        let mut first_panic = None;
         for (pointer_id, pointer_type) in pointers {
             // A handler run by an earlier iteration may have re-entered the
             // binding and already terminated this sequence.
@@ -844,10 +845,20 @@ impl GestureBinding {
                 persistent_device_id: None,
             });
             // The terminal arm never invokes the hit-test callback: Cancel
-            // resolves over the route cached at Down.
-            self.handle_pointer_event_kernel(&cancel, |_| {
-                unreachable!("BUG: a terminal Cancel must never hit-test")
+            // resolves over the route cached at Down. A panicking handler
+            // must not exempt the remaining contacts from cancellation —
+            // every snapshotted pointer is cancelled first, then the first
+            // panic resumes (the same all-work-first posture the kernel
+            // itself has within one sequence).
+            let delivered = RoutePanic::capture(|| {
+                self.handle_pointer_event_kernel(&cancel, |_| {
+                    unreachable!("BUG: a terminal Cancel must never hit-test")
+                });
             });
+            RoutePanic::preserve_first(&mut first_panic, delivered, "focus-loss pointer cancel");
+        }
+        if let Some(panic) = first_panic {
+            panic.resume();
         }
     }
 
@@ -2935,6 +2946,68 @@ mod tests {
             // Idempotent: nothing left to cancel.
             binding.cancel_active_pointers();
             assert_eq!(&*log.borrow(), &["down", "cancel"]);
+        });
+    }
+
+    /// A panicking Cancel handler must not exempt the remaining contacts:
+    /// every snapshotted pointer is cancelled before the first panic
+    /// resumes, so no sequence survives a focus loss just because an
+    /// earlier-sorted pointer's handler blew up.
+    #[test]
+    fn cancel_active_pointers_cancels_every_contact_before_resuming_a_handler_panic() {
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let binding = GestureBinding::new();
+        let second_saw_cancel = Rc::new(Cell::new(false));
+
+        lane.enter(|| {
+            let panicking = handle
+                .register_pointer(|event| {
+                    if matches!(event, PointerEvent::Cancel(_)) {
+                        panic!("first contact cancel panic");
+                    }
+                })
+                .expect("register panicking target");
+            let observed = Rc::clone(&second_saw_cancel);
+            let second = handle
+                .register_pointer(move |event| {
+                    if matches!(event, PointerEvent::Cancel(_)) {
+                        observed.set(true);
+                    }
+                })
+                .expect("register second target");
+
+            // PRIMARY sorts before pointer 2, so the panicking handler runs
+            // first — the arrangement the loop must survive.
+            let first_down =
+                make_down_event(Offset::new(Pixels(5.0), Pixels(5.0)), PointerType::Touch);
+            binding.handle_pointer_event(&first_down, |_| hit_result(panicking));
+            let second_down = make_down_event_for_id(
+                PointerId::new(2).expect("nonzero pointer id"),
+                Offset::new(Pixels(50.0), Pixels(50.0)),
+                PointerType::Touch,
+            );
+            binding.handle_pointer_event(&second_down, |_| hit_result(second));
+            assert_eq!(binding.active_pointer_count(), 2);
+
+            let unwind = catch_unwind(AssertUnwindSafe(|| binding.cancel_active_pointers()));
+            let payload = unwind.expect_err("the handler panic must propagate");
+            assert_eq!(
+                payload.downcast_ref::<&str>(),
+                Some(&"first contact cancel panic"),
+                "the FIRST panic in cancellation order must win"
+            );
+
+            assert!(
+                second_saw_cancel.get(),
+                "the second contact must still observe its Cancel"
+            );
+            assert_eq!(
+                binding.active_pointer_count(),
+                0,
+                "no sequence may survive the sweep because an earlier handler panicked"
+            );
+            assert!(binding.arena().is_empty());
         });
     }
 

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -119,6 +119,10 @@ struct CachedPointerRoute {
     token: Option<ResolvedRouteToken>,
     sequence: PointerSequence,
     resampler: PointerEventResampler,
+    /// Device kind stamped on the sequence's Down, so a synthesized
+    /// terminal event (cancel-on-defocus) carries the same kind the
+    /// sequence's recognizers have been observing.
+    pointer_type: PointerType,
 }
 
 struct DetachedPointerSequence {
@@ -802,6 +806,51 @@ impl GestureBinding {
         }
     }
 
+    /// Synthesize a terminal [`PointerEvent::Cancel`] for every pointer
+    /// with an active contact sequence, delivered through the normal
+    /// terminal path — recognizers observe a real Cancel (route dispatch,
+    /// arena abandonment, cache release), exactly as if the platform had
+    /// sent one.
+    ///
+    /// Call this when the window loses OS focus: a defocused window may
+    /// never receive the Up matching an in-flight Down (alt-tab mid-drag),
+    /// which would otherwise strand the sequence until a superseding Down.
+    /// This is the contract Flutter's platforms honor by sending a cancel
+    /// for in-flight contacts when the view deactivates; FLUI's backends
+    /// send no such event, so the app runner synthesizes it here.
+    ///
+    /// Unlike [`Self::cancel_all_pointer_sequences`] — the silent teardown
+    /// for pause/detach, where user code should no longer run — this
+    /// delivers the Cancel to handlers, so a widget mid-drag can undo the
+    /// gesture's visible effect. Hover state (pending hover moves, mouse
+    /// tracker) is untouched: a pointer can keep hovering an unfocused
+    /// window.
+    pub fn cancel_active_pointers(&self) {
+        let mut pointers: Vec<(PointerId, PointerType)> = self
+            .hit_tests
+            .iter()
+            .map(|entry| (*entry.key(), entry.pointer_type))
+            .collect();
+        pointers.sort_unstable_by_key(|(pointer_id, _)| *pointer_id);
+        for (pointer_id, pointer_type) in pointers {
+            // A handler run by an earlier iteration may have re-entered the
+            // binding and already terminated this sequence.
+            if !self.hit_tests.contains_key(&pointer_id) {
+                continue;
+            }
+            let cancel = PointerEvent::Cancel(ui_events::pointer::PointerInfo {
+                pointer_id: Some(pointer_id),
+                pointer_type,
+                persistent_device_id: None,
+            });
+            // The terminal arm never invokes the hit-test callback: Cancel
+            // resolves over the route cached at Down.
+            self.handle_pointer_event_kernel(&cancel, |_| {
+                unreachable!("BUG: a terminal Cancel must never hit-test")
+            });
+        }
+    }
+
     /// Defensive cleanup for app-lifecycle pause / detach transitions.
     ///
     /// Cancels every binding-owned pointer sequence. Call this from the app
@@ -979,6 +1028,7 @@ impl GestureBinding {
                         token,
                         sequence,
                         resampler,
+                        pointer_type: down.pointer.pointer_type,
                     },
                 );
 
@@ -1562,6 +1612,7 @@ mod tests {
             token: None,
             sequence: PointerSequence(1),
             resampler: PointerEventResampler::new(PointerId::PRIMARY),
+            pointer_type: PointerType::Mouse,
         }
     }
 
@@ -2815,6 +2866,76 @@ mod tests {
             panic!("no known device position: the hit-test callback must not run");
         });
         assert_eq!(routed.get(), 1);
+    }
+
+    /// Losing OS focus mid-contact must terminate the sequence like a real
+    /// platform Cancel: the route cached at Down observes the Cancel, the
+    /// arena rejects its members, and a following Move — the pointer may
+    /// keep moving while the window is defocused — is a hover, not a drag
+    /// update on the dead sequence's route.
+    #[test]
+    fn cancel_active_pointers_delivers_cancel_and_demotes_following_moves_to_hover() {
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let binding = Rc::new(GestureBinding::new());
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let arena_member = Arc::new(CountingArenaMember::default());
+
+        lane.enter(|| {
+            let sink = Rc::clone(&log);
+            let target = handle
+                .register_pointer(move |event| {
+                    sink.borrow_mut().push(match event {
+                        PointerEvent::Down(_) => "down",
+                        PointerEvent::Move(_) => "move",
+                        PointerEvent::Cancel(_) => "cancel",
+                        _ => "other",
+                    });
+                })
+                .expect("register");
+            let result = hit_result(target);
+
+            let down = make_down_event(Offset::new(Pixels(5.0), Pixels(5.0)), PointerType::Touch);
+            let binding_for_down = Rc::clone(&binding);
+            let member = arena_member.clone();
+            binding.handle_pointer_event(&down, move |_| {
+                binding_for_down.arena().add(PointerId::PRIMARY, member);
+                result
+            });
+            assert_eq!(&*log.borrow(), &["down"]);
+            assert!(binding.has_hit_test(PointerId::PRIMARY));
+
+            binding.cancel_active_pointers();
+
+            assert_eq!(
+                &*log.borrow(),
+                &["down", "cancel"],
+                "the cached route must observe a synthesized terminal Cancel"
+            );
+            assert_eq!(
+                arena_member.rejects.load(Ordering::Relaxed),
+                1,
+                "the arena must reject its members, never silently keep them"
+            );
+            assert!(!binding.has_hit_test(PointerId::PRIMARY));
+            assert!(binding.arena().is_empty());
+
+            // The pointer keeps moving after defocus: with the sequence
+            // gone this is a hover (fresh hit test, ephemeral dispatch) —
+            // the dead sequence's route must not receive it as a drag.
+            let mv = make_move_event(Offset::new(Pixels(9.0), Pixels(9.0)), PointerType::Touch);
+            binding.handle_pointer_event(&mv, |_| HitTestResult::new());
+            binding.flush_pending_moves();
+            assert_eq!(
+                &*log.borrow(),
+                &["down", "cancel"],
+                "a post-cancel Move must not be delivered on the cancelled route"
+            );
+
+            // Idempotent: nothing left to cancel.
+            binding.cancel_active_pointers();
+            assert_eq!(&*log.borrow(), &["down", "cancel"]);
+        });
     }
 
     /// Mid-contact (a button held while the pointer crosses the window

--- a/crates/flui-platform/src/platforms/winit/events.rs
+++ b/crates/flui-platform/src/platforms/winit/events.rs
@@ -72,14 +72,59 @@ fn pointer_state(
 /// Convert winit MouseButton to W3C PointerButton
 pub(crate) fn convert_mouse_button(button: MouseButton) -> PointerButton {
     match button {
-        // `Other` carries a vendor-specific button id ui-events has no slot
-        // for; treat it as the primary button like an unrecognized click.
-        MouseButton::Left | MouseButton::Other(_) => PointerButton::Primary,
+        MouseButton::Left => PointerButton::Primary,
         MouseButton::Right => PointerButton::Secondary,
         MouseButton::Middle => PointerButton::Auxiliary,
         MouseButton::Back => PointerButton::X1,
         MouseButton::Forward => PointerButton::X2,
+        MouseButton::Other(id) => vendor_button(id),
     }
+}
+
+/// Map a vendor-specific button id onto ui-events' exotic-button band.
+///
+/// winit reports mouse buttons beyond left/right/middle/back/forward as
+/// `Other(id)` with a backend-specific id. Such a button must never alias
+/// onto an actuating button — `Primary` in particular makes every tap/click
+/// recognizer treat the press as tap-eligible, so a vendor side-button would
+/// click whatever is under the cursor. ui-events reserves `B7`..`B32` for
+/// exactly these devices; the id is folded onto that band with a modulo, so
+/// the release of a vendor button always carries the same `PointerButton`
+/// as its press. Two ids a multiple of the band width apart share a slot —
+/// acceptable, because nothing in the gesture layer actuates on this band;
+/// determinism per id is the load-bearing property (the raw winit button
+/// set tracked by the platform, not this normalized value, is what decides
+/// which physical buttons are still held).
+fn vendor_button(id: u16) -> PointerButton {
+    const EXOTIC_BAND: [PointerButton; 26] = [
+        PointerButton::B7,
+        PointerButton::B8,
+        PointerButton::B9,
+        PointerButton::B10,
+        PointerButton::B11,
+        PointerButton::B12,
+        PointerButton::B13,
+        PointerButton::B14,
+        PointerButton::B15,
+        PointerButton::B16,
+        PointerButton::B17,
+        PointerButton::B18,
+        PointerButton::B19,
+        PointerButton::B20,
+        PointerButton::B21,
+        PointerButton::B22,
+        PointerButton::B23,
+        PointerButton::B24,
+        PointerButton::B25,
+        PointerButton::B26,
+        PointerButton::B27,
+        PointerButton::B28,
+        PointerButton::B29,
+        PointerButton::B30,
+        PointerButton::B31,
+        PointerButton::B32,
+    ];
+    EXOTIC_BAND[usize::from(id) % EXOTIC_BAND.len()]
 }
 
 /// Convert winit modifiers state to keyboard-types Modifiers
@@ -532,6 +577,55 @@ mod pointer_translation_tests {
             panic!("release must translate to PointerEvent::Up");
         };
         assert_eq!(event.state.buttons, PointerButtons::default());
+    }
+
+    /// A vendor side-button (winit `MouseButton::Other`) must never
+    /// translate to an actuating button: `Primary` makes every tap
+    /// recognizer treat the press as a left click, so button 6/7/... on a
+    /// gaming mouse would click whatever is under the cursor. It lands in
+    /// ui-events' exotic `B7`..`B32` band, deterministically per id, so a
+    /// release always carries the same button as its press.
+    #[test]
+    fn vendor_side_buttons_do_not_synthesize_primary_clicks() {
+        let actuating = [
+            PointerButton::Primary,
+            PointerButton::Secondary,
+            PointerButton::Auxiliary,
+            PointerButton::X1,
+            PointerButton::X2,
+        ];
+        for id in [0u16, 6, 7, 25, 26, 1000] {
+            let converted = convert_mouse_button(MouseButton::Other(id));
+            for banned in actuating {
+                assert_ne!(
+                    converted, banned,
+                    "Other({id}) must not alias onto the actuating button {banned:?}"
+                );
+            }
+            assert_eq!(
+                converted,
+                convert_mouse_button(MouseButton::Other(id)),
+                "press and release of Other({id}) must carry the same button"
+            );
+        }
+
+        // Full translation shape: the Down event for Other(6) carries the
+        // non-actuating button, and the held set never gains Primary.
+        let side_button = convert_mouse_button(MouseButton::Other(6));
+        let down = mouse_button_event(
+            MouseButton::Other(6),
+            ElementState::Pressed,
+            winit::dpi::PhysicalPosition::new(10.0, 10.0),
+            1.0,
+            KeyboardModifiers::empty(),
+            PointerButtons::from(side_button),
+        );
+        let PlatformInput::Pointer(PointerEvent::Down(event)) = down else {
+            panic!("press must translate to PointerEvent::Down");
+        };
+        assert_eq!(event.button, Some(side_button));
+        assert_ne!(event.button, Some(PointerButton::Primary));
+        assert!(!event.state.buttons.contains(PointerButton::Primary));
     }
 }
 

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -250,11 +250,12 @@ struct WinitPlatformState {
     /// the gesture layer, so without this the pan recognizer never receives
     /// drag updates (live drag-scrolling did nothing).
     ///
-    /// Raw, not normalized: `convert_mouse_button` maps every
-    /// `MouseButton::Other(_)` onto `Primary`, so a normalized set would
-    /// let releasing an aliased button clear `Primary` while the physical
-    /// left button is still down. The normalized set is DERIVED per event
-    /// by [`held_pointer_buttons`].
+    /// Raw, not normalized: `convert_mouse_button` folds the unbounded
+    /// `MouseButton::Other(_)` id space onto ui-events' finite exotic
+    /// button band, so two distinct vendor buttons can normalize to the
+    /// same `PointerButton` — a normalized set would let releasing one
+    /// clear the shared bit while the other is still down. The normalized
+    /// set is DERIVED per event by [`held_pointer_buttons`].
     pressed_buttons: std::collections::HashSet<winit::event::MouseButton>,
 }
 


### PR DESCRIPTION
Three pointer-delivery contract fixes from the 2026-08-14 live-wire audit, one commit each. They share a review context: each is a case where the input wire silently did the wrong thing (phantom click, dropped event, stranded sequence) while every existing test stayed green.

Closes #727
Closes #729
Closes #730

## 1. Vendor mouse side-buttons no longer synthesize left clicks (#727)

**What.** `winit/events.rs` mapped `MouseButton::Other(_)` onto `PointerButton::Primary`, so pressing button 6/7/... on a gaming mouse clicked whatever was under the cursor (every tap recognizer treats a Primary Down as tap-eligible).

**How.** `Other(id)` now folds deterministically (modulo) onto ui-events' exotic `B7`..`B32` band — the range that crate reserves for exactly these devices — so a vendor button is never actuating and its release always carries the same `PointerButton` as its press. Back/Forward keep `X1`/`X2` (audited: correct W3C mapping). The platform's raw held-button tracking is untouched; its rationale comment now describes band aliasing instead of the retired Primary aliasing. End-to-end check: `TapButton::try_from` errs on everything outside Primary/Secondary/Auxiliary, so B-band buttons are ignored by the tap recognizer entirely.

**Evidence.** New translation-level test `vendor_side_buttons_do_not_synthesize_primary_clicks` (ids 0, 6, 7, 25, 26, 1000; asserts no actuating alias, per-id determinism, and the full Down shape). Sabotage-verified: restoring the old `Other(_) => Primary` arm fails the test.

## 2. Hover Enter/Leave delivered instead of silently dropped (#729)

**What.** The binding routed `PointerEvent::Enter`/`Leave` exclusively through `dispatch_on_cached_route`, which requires an active contact. A hovering pointer — the only state in which a window-boundary Enter/Leave normally arrives (macOS `NSMouseEntered`/`Exited`, Android `HoverEnter`/`HoverExit`) — has no cached route, so the events were dropped.

**How.** Without an active contact the events now resolve a fresh ephemeral path, the same shape as the Scroll arm. Two wrinkles, both decided from Flutter's model (`gestures/binding.dart`, verified against the `.flutter/` reference in the main checkout):

- The events carry no position (both producers only identify the pointer), so the path resolves at the device's last-known hover position from the mouse tracker. A device the binding has never seen dispatches to the pointer router only — Flutter parity with added/removed-class events, which dispatch with a null hit-test result rather than a speculative hit test at the origin.
- Mid-contact delivery keeps the cached Down route: capture semantics, like every other event of an active sequence (Flutter routes a down pointer's events over the result stored at Down).

**Evidence.** Three binding-level tests: fresh-path delivery at the last hover position (born-red: sabotaging the branch back to cached-route-only fails it), router-only delivery for an unseen device (asserts the hit-test callback does not run), and cached-route mid-contact delivery (asserts no re-hit-test). `MouseRegion` exit-on-window-leave was already handled separately by `MouseTracker::dispatch_window_left` and is untouched.

## 3. Window focus loss cancels in-flight pointer sequences (#730)

**What.** `Focused(false)` reached the lifecycle (Inactive) but gesture teardown ran only for Hidden/Paused/Detached — a ladder alt-tab never reaches. A Down whose matching Up the platform never delivers was stranded until a superseding Down.

**How.** New `GestureBinding::cancel_active_pointers()` synthesizes a terminal `PointerEvent::Cancel` per active contact and feeds it through the normal Up/Cancel machinery (`handle_pointer_event_kernel`'s terminal arm: detach, route dispatch, arena abandonment, cache release) — no second hand-rolled teardown. Unlike the silent `cancel_all_pointer_sequences` pause-drain, handlers run, so a widget mid-drag can undo its visible effect; hover state is untouched (a pointer can keep hovering an unfocused window). The cached route now records the Down's device kind so the synthesized Cancel carries what the sequence observed. The app runner wires it from the **authoritative** `WindowFocus(false)` path only — the existing stale-focus-loss guard still drops a non-active presentation's focus loss before any cancellation — and a panicking cancel handler defers its unwind until after the lifecycle transition.

**Evidence.** Binding test: Down → `cancel_active_pointers` → route observed Cancel, arena rejected its member, and a following Move is a hover, never a drag update on the dead route (sabotage-verified: swapping in the silent teardown fails it). Runner test through the real dispatch seam: stale focus loss leaves the sequence alive, authoritative focus loss drains it (sabotage-verified: removing the wire fails it).

## Verification

- `cargo nextest run -p flui-interaction -p flui-widgets -p flui-app`: 2635 passed, 6 skipped
- `FLUI_HEADLESS=1 xvfb-run -a cargo nextest run -p flui-platform --all-features`: 200 passed, 8 skipped (default-features run of flui-platform fails by construction — no Linux backend enabled — per the documented CI mechanism)
- `just ci`: JUST_CI_EXIT: 0
- `typos` on all touched files: clean

**Honest denominators / named gaps.** The macOS and Android Enter/Leave producers are exercised only by `cross-typecheck` (clippy, no link, no tests) — the binding-level fix is tested on Linux, the producers themselves still have zero executing coverage anywhere, as before this PR. The Enter-for-an-unseen-device case delivers router-only (no hit path); if a backend ever stamps positions on Enter/Leave, the ephemeral path should switch to the event's own position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
