### PR TITLE
ci: stop documenting flui-cli's bin — it collides with the facade lib on target/doc/flui

### DIFF
--- a/crates/flui-cli/Cargo.toml
+++ b/crates/flui-cli/Cargo.toml
@@ -17,6 +17,12 @@ autotests = false
 [[bin]]
 name = "flui"
 path = "src/main.rs"
+# The bin shares its name with the root facade LIB target; both resolve to
+# target/doc/flui and race in the merge-blocking doc job (cargo#6313 —
+# rustdoc reports it as a warning locally and fails with a phantom I/O
+# error under parallel jobs). The binary carries no public API worth
+# documenting; the crate's docs live in its lib and README.
+doc = false
 
 [dependencies]
 # Build system


### PR DESCRIPTION
## What

Closes #744 — the merge-blocking `doc` job failed on arbitrary PRs with phantom I/O errors naming files the PR never touched.

## How

The bin target `flui` (flui-cli) and the root facade's lib target `flui` resolve to the same `target/doc/flui` output path — cargo#6313. Locally it's a warning; under the CI job's parallel rustdoc it intermittently races into a hard failure. `doc = false` on the bin target removes the collision at its root: the binary has no public API worth documenting, and the crate keeps its lib/README docs. One line + a comment citing the mechanism.

## Evidence

`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked --document-private-items` completes with the collision warning GONE (it printed on every prior run). `just ci` green, log-verified (`JUST_CI_EXIT: 0`). The flake itself is nondeterministic, so the proof of absence is the removed collision — the necessary precondition of the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM