### PR TITLE
fix(platform): normalize the wheel-delta contract at every backend boundary

### DIFF
--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -47,6 +47,22 @@
 //! let cursor = CursorIcon::Pointer; // Hand cursor for clickable elements
 //! let text_cursor = CursorIcon::Text; // I-beam for text selection
 //! ```
+//!
+//! # Scroll Delta Contract
+//!
+//! Every [`ScrollDelta`] delivered here obeys one cross-backend convention,
+//! normalized by each platform backend at ITS translation boundary
+//! (`flui-platform`'s `shared::scroll` module holds the per-backend sign/unit
+//! table) — consumers must never re-flip or re-scale per platform:
+//!
+//! - **Sign**: positive = content scrolls down / right (the scroll offset
+//!   increases) — the W3C `WheelEvent.deltaX`/`deltaY` convention.
+//! - **`PixelDelta`** is LOGICAL pixels (scale-factor independent, like
+//!   pointer positions).
+//! - **`LineDelta`** is unit-less wheel lines; THIS crate owns the line
+//!   height and converts at 53 logical pixels per line in
+//!   [`ScrollEventData::delta_to_offset`].
+//! - **`PageDelta`** is unit-less pages, likewise converted only here.
 
 use flui_types::geometry::{Offset, PixelDelta, Pixels};
 
@@ -487,14 +503,19 @@ impl ScrollEventData {
         }
     }
 
-    /// Converts a ScrollDelta to pixel offset.
+    /// Converts a ScrollDelta to a logical-pixel offset.
+    ///
+    /// This is the single owner of the line-height and page-height factors
+    /// in the scroll delta contract (see the module docs): backends deliver
+    /// normalized signs and units, and only this function turns lines and
+    /// pages into pixels.
     pub fn delta_to_offset(delta: &ScrollDelta) -> Offset<PixelDelta> {
         match delta {
             ScrollDelta::PixelDelta(pos) => {
                 Offset::new(PixelDelta(pos.x as f32), PixelDelta(pos.y as f32))
             }
             ScrollDelta::LineDelta(x, y) => {
-                // One wheel line = 53 physical pixels — the exact factor
+                // One wheel line = 53 logical pixels — the exact factor
                 // Flutter's Linux embedder applies to GTK scroll units
                 // (`kScrollOffsetMultiplier`, `fl_scrolling_manager.cc`), so
                 // wheel speed and `InteractiveViewer`'s scroll-to-scale

--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -33,7 +33,6 @@ use dpi::{PhysicalPosition, PhysicalSize};
 use keyboard_types::{Key, Modifiers, NamedKey};
 use objc::{class, msg_send, sel, sel_impl};
 use ui_events::{
-    ScrollDelta,
     keyboard::{Code, KeyState, KeyboardEvent, Location},
     pointer::{
         PointerButton, PointerButtonEvent, PointerButtons, PointerEvent, PointerId, PointerInfo,
@@ -408,6 +407,15 @@ unsafe fn convert_mouse_move(ns_event: id, scale_factor: f64, view_height: f64) 
 
 /// Convert scroll wheel event
 ///
+/// AppKit's `scrollingDeltaX/Y` are positive for a swipe/scroll UP or LEFT
+/// (Apple's NSEvent docs: same sign as the legacy `deltaX/deltaY`; the
+/// system applies the natural-scrolling preference before delivery) — the
+/// inverse of the cross-backend convention (positive = content scrolls
+/// down/right), so `from_appkit` negates both axes at this boundary. Precise
+/// (trackpad) deltas are points, which are already logical pixels — no
+/// scale-factor conversion. See `crate::shared::scroll` for the sign/unit
+/// table and citations.
+///
 /// # Safety
 ///
 /// `ns_event` must be a valid, live `NSEvent*` of a scroll-wheel event.
@@ -417,20 +425,14 @@ unsafe fn convert_scroll_event(ns_event: id, scale_factor: f64, view_height: f64
     unsafe {
         let state = pointer_state(ns_event, scale_factor, view_height);
 
-        // Get scroll delta
         let delta_x: f64 = msg_send![ns_event, scrollingDeltaX];
         let delta_y: f64 = msg_send![ns_event, scrollingDeltaY];
 
-        // Check if precise scrolling (trackpad) or line scrolling (mouse wheel)
+        // Precise scrolling (trackpad) delivers point deltas; a conventional
+        // mouse wheel delivers whole lines.
         let has_precise_delta: bool = msg_send![ns_event, hasPreciseScrollingDeltas];
 
-        let delta = if has_precise_delta {
-            // Trackpad: use pixel delta
-            ScrollDelta::PixelDelta(PhysicalPosition::new(delta_x, delta_y))
-        } else {
-            // Mouse wheel: use line delta
-            ScrollDelta::LineDelta(delta_x as f32, delta_y as f32)
-        };
+        let delta = crate::shared::scroll::from_appkit(delta_x, delta_y, has_precise_delta);
 
         PlatformInput::Pointer(PointerEvent::Scroll(PointerScrollEvent {
             pointer: primary_mouse_info(),

--- a/crates/flui-platform/src/platforms/web/events.rs
+++ b/crates/flui-platform/src/platforms/web/events.rs
@@ -290,22 +290,21 @@ fn convert_pointer_move(pe: &web_sys::PointerEvent) -> PlatformInput {
     }))
 }
 
+/// Convert a DOM `WheelEvent` to a W3C `PointerEvent::Scroll`.
+///
+/// The DOM already speaks the cross-backend wheel convention (positive =
+/// content scrolls down/right; `DOM_DELTA_PIXEL` deltas are CSS = logical
+/// pixels), so `from_web` is a passthrough that only maps `deltaMode` onto
+/// the `ScrollDelta` variants — kept in `crate::shared::scroll` so this
+/// boundary appears in the same sign/unit table (and executing contract
+/// tests) as the backends that DO have to flip or rescale.
 fn convert_wheel_event(we: &web_sys::WheelEvent) -> PlatformInput {
     use dpi::PhysicalPosition;
-    use ui_events::ScrollDelta;
     use ui_events::pointer::{
         PointerEvent, PointerInfo, PointerScrollEvent, PointerState, PointerType,
     };
 
-    let delta = match we.delta_mode() {
-        // DOM_DELTA_PIXEL = 0
-        0 => ScrollDelta::PixelDelta(PhysicalPosition::new(we.delta_x(), we.delta_y())),
-        // DOM_DELTA_LINE = 1
-        1 => ScrollDelta::LineDelta(we.delta_x() as f32, we.delta_y() as f32),
-        // DOM_DELTA_PAGE = 2
-        2 => ScrollDelta::PageDelta(we.delta_x() as f32, we.delta_y() as f32),
-        _ => ScrollDelta::PixelDelta(PhysicalPosition::new(we.delta_x(), we.delta_y())),
-    };
+    let delta = crate::shared::scroll::from_web(we.delta_mode(), we.delta_x(), we.delta_y());
 
     let modifiers = extract_modifiers_from_mouse(we);
 

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -33,7 +33,7 @@ use windows::Win32::{
 };
 
 use super::util::{get_x_lparam, get_y_lparam, is_key_pressed};
-use crate::traits::{Key, PlatformInput, ScrollDelta, device_to_logical};
+use crate::traits::{Key, PlatformInput, device_to_logical};
 
 /// Process-start epoch for monotonic event timestamps.
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
@@ -299,18 +299,44 @@ pub fn mouse_move_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> Pl
     PlatformInput::Pointer(event)
 }
 
-/// Convert WM_MOUSEWHEEL to W3C PointerEvent with Scroll
-pub fn mouse_wheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
-    let delta = ((wparam.0 as i32) >> 16) as i16 as f32;
-    let lines = delta / 120.0; // WHEEL_DELTA = 120
+/// The signed scroll distance both wheel messages carry in the high word of
+/// `wParam` (`GET_WHEEL_DELTA_WPARAM`), in multiples of `WHEEL_DELTA` (120).
+fn wheel_distance(wparam: WPARAM) -> i16 {
+    ((wparam.0 as i32) >> 16) as i16
+}
 
+/// Convert WM_MOUSEWHEEL to W3C PointerEvent with Scroll
+///
+/// Win32's vertical sign (positive = wheel rotated away from the user) is the
+/// inverse of the cross-backend convention — positive = content scrolls down —
+/// so `from_win32_wheel` negates it at this boundary; see
+/// `crate::shared::scroll` for the sign/unit table and citations.
+pub fn mouse_wheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
     let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
     let _ = modifiers;
 
     let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {
         pointer: primary_mouse_info(),
         state,
-        delta: ScrollDelta::LineDelta(0.0, lines),
+        delta: crate::shared::scroll::from_win32_wheel(wheel_distance(wparam)),
+    });
+
+    PlatformInput::Pointer(event)
+}
+
+/// Convert WM_MOUSEHWHEEL to W3C PointerEvent with Scroll
+///
+/// Win32's horizontal sign (positive = wheel tilted right) already matches
+/// the cross-backend convention — positive = content scrolls right — so only
+/// the `WHEEL_DELTA` division applies; see `crate::shared::scroll`.
+pub fn mouse_hwheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
+    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
+    let _ = modifiers;
+
+    let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {
+        pointer: primary_mouse_info(),
+        state,
+        delta: crate::shared::scroll::from_win32_hwheel(wheel_distance(wparam)),
     });
 
     PlatformInput::Pointer(event)

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -20,7 +20,8 @@ use ui_events::{
     },
 };
 use windows::Win32::{
-    Foundation::{LPARAM, WPARAM},
+    Foundation::{HWND, LPARAM, POINT, WPARAM},
+    Graphics::Gdi::ScreenToClient,
     UI::Input::KeyboardAndMouse::{
         VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9, VK_A, VK_B,
         VK_BACK, VK_C, VK_CONTROL, VK_D, VK_DELETE, VK_DOWN, VK_E, VK_END, VK_ESCAPE, VK_F, VK_F1,
@@ -227,8 +228,26 @@ fn pointer_state(
     pressure: f32,
     buttons: PointerButtons,
 ) -> (PointerState, KeyboardModifiers) {
-    let x = get_x_lparam(lparam);
-    let y = get_y_lparam(lparam);
+    pointer_state_at(
+        get_x_lparam(lparam),
+        get_y_lparam(lparam),
+        scale_factor,
+        pressure,
+        buttons,
+    )
+}
+
+/// [`pointer_state`] with the CLIENT-space device coordinates already in
+/// hand — for the wheel messages, whose `lParam` needs a screen-to-client
+/// conversion first (see [`wheel_pointer_state`]).
+#[inline]
+fn pointer_state_at(
+    x: i32,
+    y: i32,
+    scale_factor: f32,
+    pressure: f32,
+    buttons: PointerButtons,
+) -> (PointerState, KeyboardModifiers) {
     // SAFETY: see `get_modifiers`'s own `# Safety` section — no
     // precondition to discharge here.
     let modifiers = unsafe { get_modifiers() };
@@ -305,14 +324,52 @@ fn wheel_distance(wparam: WPARAM) -> i16 {
     ((wparam.0 as i32) >> 16) as i16
 }
 
+/// Build the pointer state for a wheel message.
+///
+/// Unlike every other client-area mouse message, `WM_MOUSEWHEEL` and
+/// `WM_MOUSEHWHEEL` deliver the cursor position in SCREEN coordinates
+/// (both messages' `lParam` docs:
+/// <https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel>),
+/// so the point is converted to client space here before the shared
+/// [`pointer_state_at`] path DPI-scales it — otherwise scroll hit-testing
+/// targets the wrong child whenever the window's client origin is not the
+/// desktop origin.
+fn wheel_pointer_state(
+    hwnd: HWND,
+    wparam: WPARAM,
+    lparam: LPARAM,
+    scale_factor: f32,
+) -> (PointerState, KeyboardModifiers) {
+    let mut point = POINT {
+        x: get_x_lparam(lparam),
+        y: get_y_lparam(lparam),
+    };
+    // SAFETY: `point` is a live, writable local; `ScreenToClient` writes
+    // nothing else. On failure (invalid `hwnd`) it returns FALSE and leaves
+    // `point` unchanged.
+    let converted = unsafe { ScreenToClient(hwnd, &raw mut point) };
+    if !converted.as_bool() {
+        tracing::warn!(
+            "ScreenToClient failed for a wheel message; scroll position stays in screen space"
+        );
+    }
+    pointer_state_at(point.x, point.y, scale_factor, 0.0, held_buttons(wparam))
+}
+
 /// Convert WM_MOUSEWHEEL to W3C PointerEvent with Scroll
 ///
 /// Win32's vertical sign (positive = wheel rotated away from the user) is the
 /// inverse of the cross-backend convention — positive = content scrolls down —
 /// so `from_win32_wheel` negates it at this boundary; see
-/// `crate::shared::scroll` for the sign/unit table and citations.
-pub fn mouse_wheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
-    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
+/// `crate::shared::scroll` for the sign/unit table and citations. The cursor
+/// position arrives in screen coordinates; see [`wheel_pointer_state`].
+pub fn mouse_wheel_event(
+    hwnd: HWND,
+    wparam: WPARAM,
+    lparam: LPARAM,
+    scale_factor: f32,
+) -> PlatformInput {
+    let (state, modifiers) = wheel_pointer_state(hwnd, wparam, lparam, scale_factor);
     let _ = modifiers;
 
     let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {
@@ -328,9 +385,16 @@ pub fn mouse_wheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> P
 ///
 /// Win32's horizontal sign (positive = wheel tilted right) already matches
 /// the cross-backend convention — positive = content scrolls right — so only
-/// the `WHEEL_DELTA` division applies; see `crate::shared::scroll`.
-pub fn mouse_hwheel_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
-    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
+/// the `WHEEL_DELTA` division applies; see `crate::shared::scroll`. The
+/// cursor position arrives in screen coordinates; see
+/// [`wheel_pointer_state`].
+pub fn mouse_hwheel_event(
+    hwnd: HWND,
+    wparam: WPARAM,
+    lparam: LPARAM,
+    scale_factor: f32,
+) -> PlatformInput {
+    let (state, modifiers) = wheel_pointer_state(hwnd, wparam, lparam, scale_factor);
     let _ = modifiers;
 
     let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -887,7 +887,7 @@ impl WindowsPlatform {
                 WM_MOUSEWHEEL => {
                     if let Some(ctx) = ctx {
                         use super::events::mouse_wheel_event;
-                        let event = mouse_wheel_event(wparam, lparam, ctx.scale_factor.get());
+                        let event = mouse_wheel_event(hwnd, wparam, lparam, ctx.scale_factor.get());
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)
@@ -896,7 +896,8 @@ impl WindowsPlatform {
                 WM_MOUSEHWHEEL => {
                     if let Some(ctx) = ctx {
                         use super::events::mouse_hwheel_event;
-                        let event = mouse_hwheel_event(wparam, lparam, ctx.scale_factor.get());
+                        let event =
+                            mouse_hwheel_event(hwnd, wparam, lparam, ctx.scale_factor.get());
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -22,9 +22,9 @@ use windows::{
                 SetWindowLongPtrW, SetWindowPos, TranslateMessage, WINDOW_EX_STYLE, WINDOW_STYLE,
                 WM_CHAR, WM_CLOSE, WM_CREATE, WM_DESTROY, WM_DPICHANGED, WM_ERASEBKGND,
                 WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN,
-                WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_MOVE,
-                WM_PAINT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS,
-                WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WNDCLASSW,
+                WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE,
+                WM_MOUSEWHEEL, WM_MOVE, WM_PAINT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR,
+                WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WNDCLASSW,
             },
         },
     },
@@ -888,6 +888,15 @@ impl WindowsPlatform {
                     if let Some(ctx) = ctx {
                         use super::events::mouse_wheel_event;
                         let event = mouse_wheel_event(wparam, lparam, ctx.scale_factor.get());
+                        ctx.callbacks.dispatch_input(event);
+                    }
+                    LRESULT(0)
+                }
+
+                WM_MOUSEHWHEEL => {
+                    if let Some(ctx) = ctx {
+                        use super::events::mouse_hwheel_event;
+                        let event = mouse_hwheel_event(wparam, lparam, ctx.scale_factor.get());
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)

--- a/crates/flui-platform/src/platforms/winit/events.rs
+++ b/crates/flui-platform/src/platforms/winit/events.rs
@@ -7,7 +7,6 @@ use std::{sync::LazyLock, time::Instant};
 use dpi::{PhysicalPosition, PhysicalSize};
 use keyboard_types::Modifiers as KeyboardModifiers;
 use ui_events::{
-    ScrollDelta,
     keyboard::{Code, KeyState, KeyboardEvent, Location},
     pointer::{
         PointerButton, PointerButtonEvent, PointerButtons, PointerEvent, PointerId, PointerInfo,
@@ -248,14 +247,14 @@ pub fn mouse_wheel_event(
     // way). winit's wheel axes are the inverse (positive = away from the
     // user), and its `PixelDelta` is PHYSICAL pixels while pointer
     // positions (and the scroll positions consuming this) are logical —
-    // flip the sign and divide by the scale factor here, never in a
+    // flip the sign and divide by the scale factor here (via the shared
+    // per-backend table in `crate::shared::scroll`), never in a
     // platform-neutral widget.
     let scroll_delta = match delta {
-        MouseScrollDelta::LineDelta(x, y) => ScrollDelta::LineDelta(-x, -y),
-        MouseScrollDelta::PixelDelta(pos) => ScrollDelta::PixelDelta(PhysicalPosition::new(
-            -pos.x / scale_factor,
-            -pos.y / scale_factor,
-        )),
+        MouseScrollDelta::LineDelta(x, y) => crate::shared::scroll::from_winit_lines(x, y),
+        MouseScrollDelta::PixelDelta(pos) => {
+            crate::shared::scroll::from_winit_pixels(pos.x, pos.y, scale_factor)
+        }
     };
 
     let state = pointer_state(
@@ -499,7 +498,7 @@ pub fn keyboard_event(
 #[cfg(test)]
 mod pointer_translation_tests {
     use super::*;
-    use ui_events::pointer::PointerEvent;
+    use ui_events::{ScrollDelta, pointer::PointerEvent};
 
     /// A cursor move with a button held is a DRAG move: the emitted
     /// `PointerState.buttons` carries the held set (what the gesture layer

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -4,5 +4,6 @@
 //! duplication.
 
 mod handlers;
+pub mod scroll;
 
 pub use handlers::{PlatformHandlers, WindowCallbacks};

--- a/crates/flui-platform/src/shared/scroll.rs
+++ b/crates/flui-platform/src/shared/scroll.rs
@@ -1,0 +1,195 @@
+//! Cross-backend wheel/scroll delta normalization.
+//!
+//! Every backend hands its raw platform wheel data to one of these helpers at
+//! its translation boundary, so the shared consumers downstream
+//! (`flui_interaction::events::ScrollEventData::delta_to_offset` states the
+//! full contract) always receive the same convention:
+//!
+//! - **Sign**: positive = content scrolls down / right (the scroll offset
+//!   increases), exactly the W3C `WheelEvent.deltaX/deltaY` convention
+//!   (<https://w3c.github.io/uievents/#events-wheelevents>).
+//! - **Units**: `PixelDelta` is LOGICAL pixels (scale-factor independent);
+//!   `LineDelta` is unit-less lines, converted by the consumer (not here) at
+//!   its own line height; `PageDelta` likewise stays in pages.
+//!
+//! This module is deliberately free of `cfg` gates and platform types so the
+//! per-backend sign/unit decisions compile — and their tests execute — on any
+//! host, even though the Win32/AppKit/web callers themselves only compile on
+//! their own targets.
+
+use dpi::PhysicalPosition;
+use ui_events::ScrollDelta;
+
+/// The Win32 wheel detent, from `winuser.h` (`WHEEL_DELTA`): one notch of a
+/// conventional wheel reports ±120 so finer-resolution wheels can report
+/// fractions of a notch.
+const WIN32_WHEEL_DELTA: f32 = 120.0;
+
+/// Normalize a winit `MouseScrollDelta::LineDelta`.
+///
+/// winit documents positive values as "the content that is being scrolled
+/// should move right and down (revealing more content left and up)" — i.e.
+/// the scroll offset *decreases*: the inverse of this contract on both axes,
+/// so both are negated.
+pub fn from_winit_lines(x: f32, y: f32) -> ScrollDelta {
+    ScrollDelta::LineDelta(-x, -y)
+}
+
+/// Normalize a winit `MouseScrollDelta::PixelDelta`.
+///
+/// Same sign convention (and therefore the same negation) as
+/// [`from_winit_lines`], and winit's pixel deltas are PHYSICAL pixels while
+/// this contract — like pointer positions — is logical, so both axes are
+/// divided by the window scale factor. Doing either transform in a
+/// platform-neutral widget instead would double-apply it under winit.
+pub fn from_winit_pixels(x: f64, y: f64, scale_factor: f64) -> ScrollDelta {
+    ScrollDelta::PixelDelta(PhysicalPosition::new(-x / scale_factor, -y / scale_factor))
+}
+
+/// Normalize a Win32 `WM_MOUSEWHEEL` distance (the signed high word of
+/// `wParam`).
+///
+/// Per the `WM_MOUSEWHEEL` docs, "a positive value indicates that the wheel
+/// was rotated forward, away from the user" — which scrolls toward *earlier*
+/// content, the inverse of this contract's down-positive y — so the value is
+/// negated as well as divided by `WHEEL_DELTA`.
+/// <https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel>
+pub fn from_win32_wheel(raw_distance: i16) -> ScrollDelta {
+    ScrollDelta::LineDelta(0.0, -(f32::from(raw_distance)) / WIN32_WHEEL_DELTA)
+}
+
+/// Normalize a Win32 `WM_MOUSEHWHEEL` distance (the signed high word of
+/// `wParam`).
+///
+/// Per the `WM_MOUSEHWHEEL` docs, "a positive value indicates that the wheel
+/// was rotated to the right" — which scrolls content right, already this
+/// contract's right-positive x (and W3C `deltaX`) — so unlike the vertical
+/// wheel the sign passes through; only the `WHEEL_DELTA` division applies.
+/// <https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousehwheel>
+pub fn from_win32_hwheel(raw_distance: i16) -> ScrollDelta {
+    ScrollDelta::LineDelta(f32::from(raw_distance) / WIN32_WHEEL_DELTA, 0.0)
+}
+
+/// Normalize an AppKit `NSEvent` scroll (`scrollingDeltaX/Y` +
+/// `hasPreciseScrollingDeltas`).
+///
+/// AppKit's scrolling deltas keep the legacy `deltaX/deltaY` sign, which is
+/// positive for a swipe/scroll *up* (content moves down, revealing earlier
+/// content) — the system applies the user's natural-scrolling preference
+/// before delivery (`isDirectionInvertedFromDevice` reports the flip), so
+/// that semantic is stable either way. That is the inverse of this contract
+/// on both axes, so both are negated.
+/// <https://developer.apple.com/documentation/appkit/nsevent/scrollingdeltay>
+///
+/// Precise deltas (trackpads) are in points, and macOS points ARE logical
+/// pixels, so no scale-factor conversion applies; non-precise wheels report
+/// whole lines.
+pub fn from_appkit(delta_x: f64, delta_y: f64, has_precise_deltas: bool) -> ScrollDelta {
+    if has_precise_deltas {
+        ScrollDelta::PixelDelta(PhysicalPosition::new(-delta_x, -delta_y))
+    } else {
+        ScrollDelta::LineDelta(-delta_x as f32, -delta_y as f32)
+    }
+}
+
+/// Normalize a W3C DOM `WheelEvent` (`deltaMode` + `deltaX/deltaY`).
+///
+/// The DOM already speaks this contract's sign convention — this contract
+/// *is* the W3C one — and `DOM_DELTA_PIXEL` deltas are CSS pixels, which are
+/// logical pixels, so every mode passes through unscaled and unflipped.
+/// `DOM_DELTA_PAGE` stays in pages: the shared consumer converts pages to
+/// pixels itself, next to its line height.
+/// <https://w3c.github.io/uievents/#events-wheelevents>
+pub fn from_web(delta_mode: u32, delta_x: f64, delta_y: f64) -> ScrollDelta {
+    match delta_mode {
+        // DOM_DELTA_LINE = 1
+        1 => ScrollDelta::LineDelta(delta_x as f32, delta_y as f32),
+        // DOM_DELTA_PAGE = 2
+        2 => ScrollDelta::PageDelta(delta_x as f32, delta_y as f32),
+        // DOM_DELTA_PIXEL = 0, and anything unknown, is pixels
+        _ => ScrollDelta::PixelDelta(PhysicalPosition::new(delta_x, delta_y)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(delta: ScrollDelta) -> (f32, f32) {
+        match delta {
+            ScrollDelta::LineDelta(x, y) => (x, y),
+            other => panic!("expected LineDelta, got {other:?}"),
+        }
+    }
+
+    fn pixels(delta: ScrollDelta) -> (f64, f64) {
+        match delta {
+            ScrollDelta::PixelDelta(pos) => (pos.x, pos.y),
+            other => panic!("expected PixelDelta, got {other:?}"),
+        }
+    }
+
+    /// The cross-backend contract table: for each backend, the raw value a
+    /// physical "scroll one step toward later content" (wheel toward the
+    /// user / swipe down / tilt right) produces, and the single normalized
+    /// delta every one of them must land on. A same-direction gesture that
+    /// scrolls opposite ways on two backends is exactly the bug this table
+    /// pins.
+    #[test]
+    fn one_physical_gesture_lands_on_one_normalized_delta() {
+        // Wheel toward the user (scroll down), one notch:
+        // winit reports line-y = -1.0 → contract +1.0.
+        assert_eq!(lines(from_winit_lines(0.0, -1.0)), (0.0, 1.0));
+        // Win32 reports distance -120 → contract +1.0 line.
+        assert_eq!(lines(from_win32_wheel(-120)), (0.0, 1.0));
+        // AppKit (non-precise) reports scrollingDeltaY = +1.0 for scroll UP,
+        // so scroll down is -1.0 → contract +1.0.
+        assert_eq!(lines(from_appkit(0.0, -1.0, false)), (0.0, 1.0));
+        // DOM (mode 1) already reports +1.0 for scroll down → passthrough.
+        assert_eq!(lines(from_web(1, 0.0, 1.0)), (0.0, 1.0));
+    }
+
+    #[test]
+    fn horizontal_right_is_positive_on_every_backend() {
+        // winit's positive line-x means content moves right (scroll LEFT):
+        // a scroll-right gesture is x = -1.0 → contract +1.0.
+        assert_eq!(lines(from_winit_lines(-1.0, 0.0)), (1.0, 0.0));
+        // Win32 horizontal wheel: tilt right is ALREADY positive → +1.0.
+        assert_eq!(lines(from_win32_hwheel(120)), (1.0, 0.0));
+        // AppKit: swipe left (scroll right) is scrollingDeltaX = -1.0.
+        assert_eq!(lines(from_appkit(-1.0, 0.0, false)), (1.0, 0.0));
+        // DOM: scroll right is already deltaX = +1.0.
+        assert_eq!(lines(from_web(1, 1.0, 0.0)), (1.0, 0.0));
+    }
+
+    /// Pixel-mode deltas must come out in LOGICAL pixels: winit's physical
+    /// pixels are divided by the scale factor; AppKit points and CSS pixels
+    /// already are logical and pass through unscaled. A 2x-DPI trackpad tick
+    /// must not scroll twice as far on one backend as another.
+    #[test]
+    fn pixel_deltas_are_logical_on_every_backend() {
+        assert_eq!(pixels(from_winit_pixels(0.0, -100.0, 2.0)), (0.0, 50.0));
+        assert_eq!(pixels(from_appkit(0.0, -50.0, true)), (0.0, 50.0));
+        assert_eq!(pixels(from_web(0, 0.0, 50.0)), (0.0, 50.0));
+    }
+
+    /// Fractional Win32 distances (fine-resolution wheels report fractions
+    /// of `WHEEL_DELTA`) survive the division instead of truncating.
+    #[test]
+    fn win32_fractional_detents_stay_fractional() {
+        assert_eq!(lines(from_win32_wheel(-60)), (0.0, 0.5));
+        assert_eq!(lines(from_win32_hwheel(-30)), (-0.25, 0.0));
+    }
+
+    /// DOM page-mode deltas stay pages (the shared consumer owns the
+    /// page-to-pixel conversion), and an unknown `deltaMode` falls back to
+    /// pixels rather than dropping the event.
+    #[test]
+    fn web_pages_pass_through_and_unknown_modes_fall_back_to_pixels() {
+        assert!(matches!(
+            from_web(2, 0.0, 1.0),
+            ScrollDelta::PageDelta(x, y) if x == 0.0 && y == 1.0
+        ));
+        assert_eq!(pixels(from_web(7, 3.0, 4.0)), (3.0, 4.0));
+    }
+}


### PR DESCRIPTION
## What

The normalized wheel-delta contract (positive = content scrolls down/right; `PixelDelta` in logical pixels; `LineDelta` converted by the consumer at 53 logical px/line) was enforced only at the winit translation boundary. The web, Win32, and macOS backends passed raw platform values into the same shared consumers, so the same physical gesture scrolled in different directions and speeds per backend.

Closes #728

## How

**One shared table.** A new cfg-free module, `flui_platform::shared::scroll`, holds every backend's sign/unit decision as a pure function with a primary-source citation, so the math compiles — and its tests execute — on Linux even for backends whose callers only ever get clippy-linted. Every backend's translation boundary now routes through it. The contract itself is stated once, on the shared consumer (`flui_interaction::events` module docs + `ScrollEventData::delta_to_offset`), which owns the 53 px line height and 400 px page height.

**Per-backend decisions:**

| Backend | Raw sign | Decision | Citation |
|---|---|---|---|
| Win32 `WM_MOUSEWHEEL` | positive = rotated away from user (scroll up) | **negate** + `/WHEEL_DELTA` — was passed through un-negated, i.e. inverted scrolling | [WM_MOUSEWHEEL docs](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel) |
| Win32 `WM_MOUSEHWHEEL` | positive = tilted right (scroll right) | **new arm** (was dropped entirely); sign already matches the contract's right-positive x, so passthrough + `/WHEEL_DELTA` | [WM_MOUSEHWHEEL docs](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousehwheel) |
| macOS `scrollingDeltaX/Y` | positive = swipe up/left; the system applies natural scrolling before delivery | **negate both axes**; precise (trackpad) deltas are points = logical px, so `PixelDelta` with no scale conversion; non-precise stays `LineDelta` | [NSEvent.scrollingDeltaY](https://developer.apple.com/documentation/appkit/nsevent/scrollingdeltay); cross-checked against winit 0.30.13's macOS backend, which passes these through unchanged into a type documented as sign-inverse of this contract |
| web (DOM `WheelEvent`) | W3C convention — this contract IS the W3C one; CSS px = logical px | **passthrough**, now via the shared table so it is a stated decision with tests; `DOM_DELTA_PAGE` stays `PageDelta` (the shared consumer converts pages at 400 px/page); unknown `deltaMode` falls back to pixels | [W3C UI Events wheel section](https://w3c.github.io/uievents/#events-wheelevents) |
| winit | positive = content moves right/down (sign-inverse); `PixelDelta` physical px | **unchanged behavior**, now calls the shared helpers; its executing end-to-end boundary test is untouched | winit 0.30.13 `MouseScrollDelta` rustdoc |

Also fixed a misnomer in the consumer's comment: the 53 px/line factor is **logical** pixels, not "physical".

## Evidence — what executes vs what is lint-only

**Executes in CI (Linux):**
- `shared::scroll` contract-table tests (5 tests): one-gesture-one-delta across all four backends' vertical sign, horizontal right-positive across all four, pixel-deltas-are-logical (winit physical/2x → logical, AppKit points, CSS px), Win32 fractional detents, web page/unknown-mode handling. These exercise the exact functions the Win32/macOS/web boundaries call.
- `winit::events::wheel_deltas_are_normalized_and_logical` — the pre-existing end-to-end winit boundary test, still green through the refactor.
- The web module also compiles in CI's wasm-check (verified: `just wasm-check` exit 0, plus `cargo check -p flui-platform --target wasm32-unknown-unknown --features web` exit 0).

**Lint-only (no link, no tests — CI's `cross-typecheck` reality, per `flui-platform/AGENTS.md`):**
- The Win32 and macOS *callers* (`mouse_wheel_event`/`mouse_hwheel_event`, `convert_scroll_event`, the `WM_MOUSEHWHEEL` wndproc arm). Verified with the exact CI commands: `cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings` exit 0, same for `aarch64-apple-darwin` exit 0. No live Windows/macOS wheel input was exercised — the sign decisions rest on the cited platform documentation plus the executing helper tests, not on-device verification.

**Gate:** `just ci` exit 0 (fmt, inventory, runtime-conformance, port-check, clippy, nextest, doctests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM