### PR TITLE
feat(app): live root MediaQuery — theme, size and DPI republish into the tree

### DIFF
--- a/crates/flui-app/src/app/media_query_root.rs
+++ b/crates/flui-app/src/app/media_query_root.rs
@@ -4,7 +4,8 @@
 //! Nothing used to install an ambient `MediaQuery` at all — the
 //! `platform_brightness` republish this crate's docs promised was
 //! unimplemented, and every `MediaQuery::maybe_of` consumer fell back to
-//! defaults. The realm now owns one [`MediaQuerySource`] per presentation:
+//! defaults. The realm now owns one [`MediaQuerySource`], scoped to its
+//! PRIMARY presentation (the tree `attach_root_widget` serves):
 //! the platform's resize path keeps `size`/`device_pixel_ratio` current,
 //! the appearance path keeps `platform_brightness` current, and the
 //! [`MediaQueryRoot`] wrapper re-publishes on every change through the

--- a/crates/flui-app/src/app/media_query_root.rs
+++ b/crates/flui-app/src/app/media_query_root.rs
@@ -1,0 +1,101 @@
+//! The realm-owned live source behind the root [`MediaQuery`], and the
+//! stateful wrapper that publishes it into the widget tree.
+//!
+//! Nothing used to install an ambient `MediaQuery` at all — the
+//! `platform_brightness` republish this crate's docs promised was
+//! unimplemented, and every `MediaQuery::maybe_of` consumer fell back to
+//! defaults. The realm now owns one [`MediaQuerySource`] per presentation:
+//! the platform's resize path keeps `size`/`device_pixel_ratio` current,
+//! the appearance path keeps `platform_brightness` current, and the
+//! [`MediaQueryRoot`] wrapper re-publishes on every change through the
+//! rebuild handle it registered at mount (ADR-0018: the capability is
+//! acquired in `init_state`, used later from the owner thread).
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use flui_view::prelude::*;
+use flui_view::{BoxedView, RebuildHandle};
+use flui_widgets::{MediaQuery, MediaQueryData};
+
+/// Owner-local shared cell for the root media-query data.
+///
+/// The realm mutates it from platform signals; the [`MediaQueryRoot`]
+/// element reads it during build. Deliberately `!Send` (`Rc`/`RefCell`):
+/// every write side runs on the realm's owner thread.
+#[derive(Default)]
+pub(crate) struct MediaQuerySource {
+    data: RefCell<MediaQueryData>,
+    rebuild: Cell<Option<RebuildHandle>>,
+}
+
+impl MediaQuerySource {
+    /// Mutate the published data and schedule the root republish.
+    ///
+    /// A mutation before the root wrapper has mounted (bootstrap ordering)
+    /// just updates the cell — the first build reads the fresh value, so
+    /// the missing handle loses nothing.
+    pub(crate) fn update(&self, mutate: impl FnOnce(&mut MediaQueryData)) {
+        mutate(&mut self.data.borrow_mut());
+        if let Some(handle) = self.rebuild.take() {
+            handle.schedule(flui_view::RebuildReason::StateChange);
+            // The handle is reusable; put it back for the next signal.
+            self.rebuild.set(Some(handle));
+        }
+    }
+
+    fn snapshot(&self) -> MediaQueryData {
+        self.data.borrow().clone()
+    }
+
+    fn install_rebuild_handle(&self, handle: RebuildHandle) {
+        self.rebuild.set(Some(handle));
+    }
+}
+
+/// Publishes the realm's [`MediaQuerySource`] as the root `MediaQuery`.
+#[derive(Clone)]
+pub(crate) struct MediaQueryRoot {
+    source: Rc<MediaQuerySource>,
+    child: BoxedView,
+}
+
+impl MediaQueryRoot {
+    pub(crate) fn new(source: Rc<MediaQuerySource>, child: BoxedView) -> Self {
+        Self { source, child }
+    }
+}
+
+impl flui_view::View for MediaQueryRoot {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateful(self)
+    }
+}
+
+pub(crate) struct MediaQueryRootState {
+    source: Rc<MediaQuerySource>,
+}
+
+impl flui_view::StatefulView for MediaQueryRoot {
+    type State = MediaQueryRootState;
+
+    fn create_state(&self) -> Self::State {
+        MediaQueryRootState {
+            source: Rc::clone(&self.source),
+        }
+    }
+}
+
+impl flui_view::ViewState<MediaQueryRoot> for MediaQueryRootState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.source.install_rebuild_handle(ctx.rebuild_handle());
+    }
+
+    fn did_update_view(&mut self, _old_view: &MediaQueryRoot, new_view: &MediaQueryRoot) {
+        self.source = Rc::clone(&new_view.source);
+    }
+
+    fn build(&self, view: &MediaQueryRoot, _ctx: &dyn BuildContext) -> impl IntoView {
+        MediaQuery::new(self.source.snapshot(), view.child.clone())
+    }
+}

--- a/crates/flui-app/src/app/mod.rs
+++ b/crates/flui-app/src/app/mod.rs
@@ -14,6 +14,7 @@ mod config;
 pub mod direct;
 pub(crate) mod hot_reload;
 pub(crate) mod logging;
+pub(crate) mod media_query_root;
 pub(crate) mod presentation;
 pub(crate) mod presentation_forest;
 pub mod runner;

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -831,10 +831,18 @@ impl PlatformToUi {
                     }
                 }
                 realm.set_device_pixel_ratio(scale_factor);
-                realm.media_query().update(|data| {
-                    data.size = size;
-                    data.device_pixel_ratio = scale_factor;
-                });
+                // The root MediaQuery lives in the PRIMARY presentation's
+                // tree; a secondary window's resize must not republish its
+                // size there (SharedRealm hosts several windows). The
+                // realm-wide ratio/surface handling above keeps its
+                // pre-existing behavior — only the media-query write is
+                // addressed.
+                if realm.is_primary_presentation(presentation_id) {
+                    realm.media_query().update(|data| {
+                        data.size = size;
+                        data.device_pixel_ratio = scale_factor;
+                    });
+                }
                 realm.request_redraw();
                 tracing::trace!(?size, scale_factor, "realm resize committed");
             }
@@ -889,10 +897,12 @@ impl PlatformToUi {
                         flui_types::platform::Brightness::Light
                     }
                 };
-                realm.media_query().update(|data| {
-                    data.platform_brightness = brightness;
-                });
-                realm.request_redraw();
+                if realm.is_primary_presentation(presentation_id) {
+                    realm.media_query().update(|data| {
+                        data.platform_brightness = brightness;
+                    });
+                    realm.request_redraw();
+                }
             }
             Self::WindowVisibility(visible) => {
                 // Presentation-level `FrameClock` gate — finer
@@ -9138,6 +9148,17 @@ where
         let _ = dispatch_platform_realm(
             realm_dispatch,
             RealmTask::Event(PlatformToUi::AppearanceChanged(window.appearance())),
+        );
+        // Seed the initial size and device-pixel ratio the same way: the
+        // source must not sit on defaults until the first live resize —
+        // on the web backend no resize observer exists, so a default
+        // would be permanent there.
+        let _ = dispatch_platform_realm(
+            realm_dispatch,
+            RealmTask::Event(PlatformToUi::Resized {
+                size: window.logical_size(),
+                scale_factor: window.scale_factor() as f32,
+            }),
         );
 
         // 9. Store the window in AppRuntime's redraw-poke slot — BEFORE

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -673,6 +673,11 @@ pub(super) enum PlatformToUi {
     // its `on_active_status_change` registration).
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     WindowVisibility(bool),
+    /// The OS light/dark appearance changed (winit's `ThemeChanged`, or the
+    /// equivalent per-backend signal). Republishes
+    /// `MediaQueryData::platform_brightness` through the root media query.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    AppearanceChanged(flui_platform::WindowAppearance),
     /// The pointer entered (`true`) or left (`false`) the window (winit's
     /// `CursorEntered`/`CursorLeft`, via
     /// `PlatformWindow::on_hover_status_change`). Leave sweeps the addressed
@@ -826,6 +831,10 @@ impl PlatformToUi {
                     }
                 }
                 realm.set_device_pixel_ratio(scale_factor);
+                realm.media_query().update(|data| {
+                    data.size = size;
+                    data.device_pixel_ratio = scale_factor;
+                });
                 realm.request_redraw();
                 tracing::trace!(?size, scale_factor, "realm resize committed");
             }
@@ -869,6 +878,21 @@ impl PlatformToUi {
             }
             Self::WindowHover(inside) => {
                 realm.handle_window_hover_addressed(presentation_id, inside);
+            }
+            Self::AppearanceChanged(appearance) => {
+                use flui_platform::WindowAppearance;
+                let brightness = match appearance {
+                    WindowAppearance::Dark | WindowAppearance::VibrantDark => {
+                        flui_types::platform::Brightness::Dark
+                    }
+                    WindowAppearance::Light | WindowAppearance::VibrantLight => {
+                        flui_types::platform::Brightness::Light
+                    }
+                };
+                realm.media_query().update(|data| {
+                    data.platform_brightness = brightness;
+                });
+                realm.request_redraw();
             }
             Self::WindowVisibility(visible) => {
                 // Presentation-level `FrameClock` gate — finer
@@ -9096,6 +9120,25 @@ where
                 RealmTask::Event(PlatformToUi::WindowHover(is_hovered)),
             );
         }));
+        // The platform callback carries no payload; query the window's
+        // current appearance at dispatch time. Weak: the callback lives
+        // inside the window's own handler table, and a strong capture
+        // would cycle it alive past close.
+        let appearance_window = Arc::downgrade(&window);
+        window.on_appearance_changed(Box::new(move || {
+            if let Some(win) = appearance_window.upgrade() {
+                let _ = dispatch_platform_realm(
+                    realm_dispatch,
+                    RealmTask::Event(PlatformToUi::AppearanceChanged(win.appearance())),
+                );
+            }
+        }));
+        // Seed the initial brightness — a user on a dark desktop must not
+        // start light until the first live theme flip.
+        let _ = dispatch_platform_realm(
+            realm_dispatch,
+            RealmTask::Event(PlatformToUi::AppearanceChanged(window.appearance())),
+        );
 
         // 9. Store the window in AppRuntime's redraw-poke slot — BEFORE
         // marking the lifecycle Resumed or requesting the initial redraw.

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -907,6 +907,12 @@ impl UiRealm {
     /// resolves — closing the last presentation is closing the REALM, and
     /// must route there instead (see that match arm's own doc).
     #[must_use]
+    /// Whether `id` addresses this realm's primary presentation — the one
+    /// whose widget tree hosts the root `MediaQuery`.
+    pub(crate) fn is_primary_presentation(&self, id: PresentationId) -> bool {
+        self.presentations.primary().id() == id
+    }
+
     pub(crate) fn is_sole_presentation(&self, id: PresentationId) -> bool {
         self.presentations.len() == 1 && self.presentations.get(id).is_some()
     }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -428,6 +428,10 @@ pub(crate) struct UiRealm {
     local_post_frame: LocalPostFrameLane,
     /// Owner-local interaction callback storage, activated with the realm scope.
     interaction_lane: InteractionLane,
+    /// The live source behind the root `MediaQuery` — the platform's resize
+    /// and appearance signals write it, the root wrapper republishes it.
+    /// Primary-presentation-scoped, like `attach_root_widget` itself.
+    media_query: std::rc::Rc<crate::app::media_query_root::MediaQuerySource>,
     /// This realm's cross-tree `GlobalKey` uniqueness domain (ADR-0043 §1),
     /// installed into every presentation's `BuildOwner` at assembly time
     /// (`PresentationState::new`). Retained here (not just handed off once)
@@ -816,6 +820,7 @@ impl UiRealm {
             realm_id,
             local_post_frame,
             interaction_lane,
+            media_query: std::rc::Rc::new(crate::app::media_query_root::MediaQuerySource::default()),
             global_key_scope,
             presentations: PresentationForest::single(presentation),
             focus_coordinator: FocusCoordinator::new(presentation_id),
@@ -1239,6 +1244,11 @@ impl UiRealm {
     ///
     /// Crate-private so platform input can only reach it through the entered
     /// realm dispatch path rather than exposing a second public owner seam.
+    /// The live root media-query source (see the field doc).
+    pub(crate) fn media_query(&self) -> &crate::app::media_query_root::MediaQuerySource {
+        &self.media_query
+    }
+
     pub(crate) fn gestures(&self) -> &GestureBinding {
         self.presentations.primary().gestures()
     }
@@ -1932,7 +1942,15 @@ impl UiRealm {
         // registry, and FocusRoot publishes this presentation's exact focus
         // tree. These wrappers have no render object, so the render root is
         // unchanged.
-        let focused = FocusRoot::new(view.clone());
+        // The root MediaQuery publishes the realm's live platform data
+        // (size, device pixel ratio, brightness) to the whole user subtree;
+        // the realm's resize/appearance arms write the shared source and the
+        // wrapper republishes.
+        let with_media_query = crate::app::media_query_root::MediaQueryRoot::new(
+            std::rc::Rc::clone(&self.media_query),
+            flui_view::view::ViewExt::boxed(view.clone()),
+        );
+        let focused = FocusRoot::new(with_media_query);
         let animated = VsyncScope::new(self.vsync(), focused);
         let wrapped = GestureArenaScope::new(self.gestures().arena().clone(), animated);
         self.presentations
@@ -2015,7 +2033,13 @@ impl UiRealm {
     where
         V: flui_view::View + Clone + 'static,
     {
-        let focused = FocusRoot::new(view.clone());
+        // Same root MediaQuery as the production attach path — the sized
+        // variant must not present a different ambient environment.
+        let with_media_query = crate::app::media_query_root::MediaQueryRoot::new(
+            std::rc::Rc::clone(&self.media_query),
+            flui_view::view::ViewExt::boxed(view.clone()),
+        );
+        let focused = FocusRoot::new(with_media_query);
         let animated = VsyncScope::new(self.vsync(), focused);
         let wrapped = GestureArenaScope::new(self.gestures().arena().clone(), animated);
         self.presentations
@@ -4119,6 +4143,68 @@ mod tests {
             wake_count.load(Ordering::Relaxed) >= 1,
             "request_redraw must fire the platform wake — flag-only requests \
              leave a parked event loop asleep and the screen frozen"
+        );
+    }
+
+    /// The realm installs a live root `MediaQuery`: the user's subtree can
+    /// read it from the very first build, and a platform appearance change
+    /// republishes the new brightness through the same root on the next
+    /// frame — the wire nothing used to consume.
+    #[test]
+    fn the_root_media_query_republishes_a_brightness_change() {
+        use std::cell::Cell;
+
+        #[derive(Clone)]
+        struct BrightnessProbe {
+            seen: std::rc::Rc<Cell<Option<flui_types::platform::Brightness>>>,
+        }
+        impl flui_view::View for BrightnessProbe {
+            fn create_element(&self) -> flui_view::element::ElementKind {
+                flui_view::element::ElementKind::stateless(self)
+            }
+        }
+        impl flui_view::StatelessView for BrightnessProbe {
+            fn build(&self, ctx: &dyn flui_view::BuildContext) -> impl flui_view::IntoView {
+                self.seen
+                    .set(Some(flui_widgets::MediaQuery::of(ctx).platform_brightness));
+                SizedBox::new(10.0, 10.0)
+            }
+        }
+
+        let seen = std::rc::Rc::new(Cell::new(None));
+        let realm = new_runtime(noop_wake()).expect("realm claims cleanly");
+        realm
+            .attach_root_widget_with_size(
+                &BrightnessProbe {
+                    seen: std::rc::Rc::clone(&seen),
+                },
+                10.0,
+                10.0,
+            )
+            .expect("mounts under the root MediaQuery");
+        let _ = realm.draw_frame(coexistence_constraints());
+        assert_eq!(
+            seen.get(),
+            Some(flui_types::platform::Brightness::Light),
+            "the first build reads the installed root MediaQuery (default light)"
+        );
+
+        // The appearance arm's write side: mutate the shared source and pump.
+        seen.set(None);
+        realm.media_query().update(|data| {
+            data.platform_brightness = flui_types::platform::Brightness::Dark;
+        });
+        assert!(
+            realm.presentations.primary().widgets().has_pending_builds(),
+            "the appearance write's externally-scheduled rebuild must count as \
+             dirty work — a frame gate blind to the external inbox skips the \
+             very frame the schedule woke"
+        );
+        let _ = realm.draw_frame(coexistence_constraints());
+        assert_eq!(
+            seen.get(),
+            Some(flui_types::platform::Brightness::Dark),
+            "an appearance change republishes through the root on the next frame"
         );
     }
 

--- a/crates/flui-platform/src/traits/window.rs
+++ b/crates/flui-platform/src/traits/window.rs
@@ -556,6 +556,18 @@ impl PlatformWindow for WinitWindow {
         )
     }
 
+    fn appearance(&self) -> WindowAppearance {
+        // The live winit theme, so an appearance-change consumer querying at
+        // dispatch time (and the bootstrap's initial seed) reads the REAL
+        // value — the trait default is a permanent `Light` that silently
+        // killed the whole dark-mode wire. `None` (winit cannot determine
+        // the theme on this platform) keeps the light default.
+        match self.window.theme() {
+            Some(winit::window::Theme::Dark) => WindowAppearance::Dark,
+            Some(winit::window::Theme::Light) | None => WindowAppearance::Light,
+        }
+    }
+
     fn scale_factor(&self) -> f64 {
         self.window.scale_factor()
     }

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -976,6 +976,12 @@ impl BuildOwner {
             || self.build_scope_queues.as_ref().is_some_and(|queues| {
                 !queues.root.is_empty() || queues.isolated.values().any(|bucket| !bucket.is_empty())
             })
+            // Externally scheduled rebuilds (RebuildHandle) land in a shared
+            // inbox that build_scope drains at frame START — so a pending
+            // entry IS dirty work, and a frame gate that ignored it skipped
+            // the very frame the handle's own frame-request hook woke: the
+            // schedule stalled until some unrelated dirty state arrived.
+            || !self.external_inbox.lock().is_empty()
     }
 
     /// Get the number of dirty elements.


### PR DESCRIPTION
## What

Closes #725 (from the live-wire audit) — and installs the root `MediaQuery` that never existed: appearance changes had no consumer, and the `platform_brightness` republish promised in flui-app's docs was unimplemented.

## How

- **`MediaQuerySource`** (realm-owned, owner-local): the resize path writes `size` + `device_pixel_ratio`; the new appearance path writes `platform_brightness` (winit `ThemeChanged` → `on_appearance_changed` → `PlatformToUi::AppearanceChanged`, with the initial value seeded at bootstrap so a dark desktop doesn't start light). Vibrant appearance variants map to their base brightness.
- **`MediaQueryRoot`** stateful wrapper in BOTH attach chains (production and the sized test variant — same ambient environment) republishes via the rebuild handle acquired in `init_state` (ADR-0018 shape).
- **Root-caused a pre-existing stall the test surfaced**: `BuildOwner::has_dirty_elements` never consulted the external rebuild inbox, so an externally scheduled rebuild (any `RebuildHandle`) whose frame-request woke the loop was then skipped by the woken frame's clean-tree gate — stalling until unrelated dirty work arrived. The inbox now counts as dirty work. This fixes the class for every external scheduler, not just this feature.

## Evidence

- `the_root_media_query_republishes_a_brightness_change`: first build reads the installed root (default light); the appearance write marks pending work (the assert that red-flagged the inbox-blind gate) and the next frame republishes Dark. Born-red at both stages: the first cut failed on "no MediaQuery ancestor" (root missing), then on the skipped frame (inbox-blind gate) — each failure drove its half of the fix.
- Full flui-view + flui-app + flui-widgets suites: 2783 green (the dirty-predicate change is load-bearing workspace-wide). `just ci` green, log-verified (`JUST_CI_EXIT: 0`).
- Honest scope: the winit `ThemeChanged` arm and registration are dispatch plumbing exercised transitively; brightness mapping and republish are pinned at the realm seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM