### PR TITLE
feat(platform): winit pinch and rotation gestures produce PointerEvent::Gesture

### DIFF
--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -180,6 +180,28 @@ pub unsafe fn convert_ns_event(
                 Some(convert_scroll_event(ns_event, scale_factor, view_height))
             }
 
+            // Trackpad pinch/rotation — the native producer for the pan-zoom
+            // lane (ordinary macOS apps select THIS backend, not winit).
+            // `magnification` is the fraction the shared conversion expects;
+            // `rotation` is counterclockwise degrees, converted to the
+            // lane's clockwise radians in the same shared function the winit
+            // boundary uses, so the two backends cannot drift.
+            NSEventType::NSEventTypeMagnify => {
+                let magnification: f64 = msg_send![ns_event, magnification];
+                crate::shared::gestures::pinch(magnification).map(|gesture| {
+                    convert_gesture_event(ns_event, scale_factor, view_height, gesture)
+                })
+            }
+            NSEventType::NSEventTypeRotate => {
+                let degrees: f32 = msg_send![ns_event, rotation];
+                Some(convert_gesture_event(
+                    ns_event,
+                    scale_factor,
+                    view_height,
+                    crate::shared::gestures::rotation_ccw_degrees(degrees),
+                ))
+            }
+
             // Mouse enter/exit carry no useful position payload in the W3C
             // model — Enter/Leave only identify the pointer.
             NSEventType::NSMouseEntered => Some(PlatformInput::Pointer(PointerEvent::Enter(
@@ -440,6 +462,37 @@ unsafe fn convert_scroll_event(ns_event: id, scale_factor: f64, view_height: f64
             delta,
         }))
     }
+}
+
+/// Assemble a `PointerEvent::Gesture` around an already-converted
+/// [`PointerGesture`] at the event's own location, with the shared
+/// synthetic gesture identity (see `shared::gestures`).
+///
+/// # Safety
+///
+/// Caller guarantees `ns_event` validity; `pointer_state` reads only
+/// documented NSEvent getters.
+unsafe fn convert_gesture_event(
+    ns_event: id,
+    scale_factor: f64,
+    view_height: f64,
+    gesture: ui_events::pointer::PointerGesture,
+) -> PlatformInput {
+    // SAFETY: forwarded caller guarantee.
+    let state = unsafe { pointer_state(ns_event, scale_factor, view_height) };
+    PlatformInput::Pointer(PointerEvent::Gesture(
+        ui_events::pointer::PointerGestureEvent {
+            pointer: PointerInfo {
+                pointer_id: ui_events::pointer::PointerId::new(
+                    crate::shared::gestures::GESTURE_POINTER_ID,
+                ),
+                pointer_type: PointerType::Touch,
+                persistent_device_id: None,
+            },
+            gesture,
+            state,
+        },
+    ))
 }
 
 // ============================================================================

--- a/crates/flui-platform/src/platforms/winit/events.rs
+++ b/crates/flui-platform/src/platforms/winit/events.rs
@@ -308,12 +308,9 @@ pub fn trackpad_gesture_event(
     scale_factor: f64,
     modifiers: KeyboardModifiers,
 ) -> PlatformInput {
-    /// One shared identity for the gesture stream — see the function doc.
-    const GESTURE_POINTER_ID: u64 = u64::MAX;
-
     let event = PointerEvent::Gesture(ui_events::pointer::PointerGestureEvent {
         pointer: PointerInfo {
-            pointer_id: PointerId::new(GESTURE_POINTER_ID),
+            pointer_id: PointerId::new(crate::shared::gestures::GESTURE_POINTER_ID),
             pointer_type: PointerType::Touch,
             persistent_device_id: None,
         },

--- a/crates/flui-platform/src/platforms/winit/events.rs
+++ b/crates/flui-platform/src/platforms/winit/events.rs
@@ -279,6 +279,57 @@ pub fn touch_event(
     PlatformInput::Pointer(event)
 }
 
+/// Convert a winit trackpad pinch or rotation tick into a
+/// `PointerEvent::Gesture` — the producer side the pan-zoom lane never had
+/// (its consumer chain, `from_w3c_event` → `Listener::on_pointer_pan_zoom_update`,
+/// existed with zero producers on any backend).
+///
+/// Delta conventions, each converted AT THIS boundary:
+/// - winit `PinchGesture.delta` is a magnification fraction (positive =
+///   zoom in) — the exact semantics of `PointerGesture::Pinch`, passed
+///   through (NaN, which winit documents as possible, is dropped by the
+///   caller).
+/// - winit `RotationGesture.delta` is COUNTERCLOCKWISE degrees;
+///   `PointerGesture::Rotate` wants CLOCKWISE radians — negate and convert.
+///
+/// winit's `PanGesture` (iOS-only) has no `PointerGesture` counterpart and
+/// macOS trackpad pans already arrive as `MouseWheel` `PixelDelta` ticks;
+/// `DoubleTapGesture` carries no delta to translate. Both stay untranslated
+/// deliberately.
+///
+/// The synthetic gesture pointer: gestures arrive without a pointer id from
+/// winit; the whole tick stream shares one identity distinct from the mouse
+/// and any touch contact, typed `Touch` (a trackpad gesture is a touch-class
+/// input, and the binding's ephemeral no-contact dispatch keys on the id
+/// only).
+pub fn trackpad_gesture_event(
+    gesture: ui_events::pointer::PointerGesture,
+    position: winit::dpi::PhysicalPosition<f64>,
+    scale_factor: f64,
+    modifiers: KeyboardModifiers,
+) -> PlatformInput {
+    /// One shared identity for the gesture stream — see the function doc.
+    const GESTURE_POINTER_ID: u64 = u64::MAX;
+
+    let event = PointerEvent::Gesture(ui_events::pointer::PointerGestureEvent {
+        pointer: PointerInfo {
+            pointer_id: PointerId::new(GESTURE_POINTER_ID),
+            pointer_type: PointerType::Touch,
+            persistent_device_id: None,
+        },
+        gesture,
+        state: pointer_state(
+            position,
+            scale_factor,
+            0.0,
+            modifiers,
+            PointerButtons::default(),
+        ),
+    });
+
+    PlatformInput::Pointer(event)
+}
+
 /// Convert winit MouseWheel to W3C PointerEvent::Scroll
 pub fn mouse_wheel_event(
     delta: MouseScrollDelta,
@@ -792,6 +843,48 @@ mod pointer_translation_tests {
             panic!("expected Down");
         };
         assert_ne!(second.pointer.pointer_id, down.pointer.pointer_id);
+    }
+
+    /// A trackpad gesture tick becomes a `PointerEvent::Gesture` with one
+    /// stable synthetic identity that can never alias the mouse or a touch
+    /// contact, logical coordinates, and the delta passed through in the
+    /// lane's own convention.
+    #[test]
+    fn trackpad_gestures_produce_gesture_events_with_a_distinct_identity() {
+        use ui_events::pointer::PointerGesture;
+
+        let pinch = trackpad_gesture_event(
+            PointerGesture::Pinch(0.1),
+            winit::dpi::PhysicalPosition::new(200.0, 100.0),
+            2.0,
+            KeyboardModifiers::empty(),
+        );
+        let PlatformInput::Pointer(PointerEvent::Gesture(pinch)) = pinch else {
+            panic!("expected a gesture event, got {pinch:?}");
+        };
+        assert!(matches!(pinch.gesture, PointerGesture::Pinch(delta) if delta == 0.1));
+        assert_eq!(pinch.pointer.pointer_type, PointerType::Touch);
+        assert_ne!(
+            pinch.pointer.pointer_id,
+            Some(PointerId::PRIMARY),
+            "the gesture stream must not alias the mouse"
+        );
+        assert_eq!(pinch.state.position.x, 100.0, "positions are logical");
+
+        let rotate = trackpad_gesture_event(
+            PointerGesture::Rotate(-0.5),
+            winit::dpi::PhysicalPosition::new(0.0, 0.0),
+            1.0,
+            KeyboardModifiers::empty(),
+        );
+        let PlatformInput::Pointer(PointerEvent::Gesture(rotate)) = rotate else {
+            panic!("expected a gesture event, got {rotate:?}");
+        };
+        assert!(matches!(rotate.gesture, PointerGesture::Rotate(delta) if delta == -0.5));
+        assert_eq!(
+            rotate.pointer.pointer_id, pinch.pointer.pointer_id,
+            "one gesture stream, one identity"
+        );
     }
 }
 

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -1138,6 +1138,52 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_input(input);
                 }
             }
+            // NaN is documented as possible for the pinch delta; a NaN
+            // scale tick is meaningless to every consumer — the guard drops
+            // it without touching the rest of this handler.
+            WinitWindowEvent::PinchGesture { delta, .. } if !delta.is_nan() => {
+                let (modifiers, cursor_pos) = self.platform.with_state(|s| {
+                    (
+                        s.current_modifiers,
+                        s.cursor_positions
+                            .get(&platform_id)
+                            .copied()
+                            .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                    )
+                });
+                if let Some(ref win) = window {
+                    let input = winit_events::trackpad_gesture_event(
+                        ui_events::pointer::PointerGesture::Pinch(delta as f32),
+                        cursor_pos,
+                        win.scale_factor(),
+                        modifiers,
+                    );
+                    win.callbacks().dispatch_input(input);
+                }
+            }
+            WinitWindowEvent::RotationGesture { delta, .. } => {
+                let (modifiers, cursor_pos) = self.platform.with_state(|s| {
+                    (
+                        s.current_modifiers,
+                        s.cursor_positions
+                            .get(&platform_id)
+                            .copied()
+                            .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                    )
+                });
+                if let Some(ref win) = window {
+                    // winit: counterclockwise degrees; the lane's contract
+                    // is clockwise radians.
+                    let clockwise_radians = -delta.to_radians();
+                    let input = winit_events::trackpad_gesture_event(
+                        ui_events::pointer::PointerGesture::Rotate(clockwise_radians),
+                        cursor_pos,
+                        win.scale_factor(),
+                        modifiers,
+                    );
+                    win.callbacks().dispatch_input(input);
+                }
+            }
             WinitWindowEvent::Touch(touch) => {
                 let (modifiers, pointer_id) = self.platform.with_state(|s| {
                     let pointer_id = resolve_touch_pointer_id(

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -1138,10 +1138,14 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_input(input);
                 }
             }
-            // NaN is documented as possible for the pinch delta; a NaN
-            // scale tick is meaningless to every consumer — the guard drops
-            // it without touching the rest of this handler.
-            WinitWindowEvent::PinchGesture { delta, .. } if !delta.is_nan() => {
+            // NaN (documented possible) folds to None in the shared
+            // conversion; the guard drops the tick without touching the
+            // rest of this handler (the trailing wildcard arm covers it).
+            WinitWindowEvent::PinchGesture { delta, .. }
+                if crate::shared::gestures::pinch(delta).is_some() =>
+            {
+                let gesture = crate::shared::gestures::pinch(delta)
+                    .expect("BUG: the match guard just checked Some");
                 let (modifiers, cursor_pos) = self.platform.with_state(|s| {
                     (
                         s.current_modifiers,
@@ -1153,7 +1157,7 @@ impl ApplicationHandler for WinitApp {
                 });
                 if let Some(ref win) = window {
                     let input = winit_events::trackpad_gesture_event(
-                        ui_events::pointer::PointerGesture::Pinch(delta as f32),
+                        gesture,
                         cursor_pos,
                         win.scale_factor(),
                         modifiers,
@@ -1172,11 +1176,8 @@ impl ApplicationHandler for WinitApp {
                     )
                 });
                 if let Some(ref win) = window {
-                    // winit: counterclockwise degrees; the lane's contract
-                    // is clockwise radians.
-                    let clockwise_radians = -delta.to_radians();
                     let input = winit_events::trackpad_gesture_event(
-                        ui_events::pointer::PointerGesture::Rotate(clockwise_radians),
+                        crate::shared::gestures::rotation_ccw_degrees(delta),
                         cursor_pos,
                         win.scale_factor(),
                         modifiers,

--- a/crates/flui-platform/src/shared/gestures.rs
+++ b/crates/flui-platform/src/shared/gestures.rs
@@ -1,0 +1,58 @@
+//! The cross-backend trackpad-gesture contract, in pure functions.
+//!
+//! `PointerGesture`'s conventions — a pinch delta as a magnification
+//! FRACTION (`0.1` = grow 10%), a rotation delta in CLOCKWISE RADIANS —
+//! are normalized here, once, so the winit and AppKit boundaries cannot
+//! drift apart. Both platforms happen to report the same raw shapes
+//! (AppKit `magnification` is the fraction winit's `PinchGesture.delta`
+//! forwards; AppKit `rotation` is the counterclockwise degrees winit's
+//! `RotationGesture.delta` forwards), so each conversion lives in exactly
+//! one function with the callers' unit tests executing on Linux.
+
+use ui_events::pointer::PointerGesture;
+
+/// The synthetic pointer identity shared by every trackpad-gesture tick.
+///
+/// Gestures arrive without a pointer id from either platform; the stream
+/// gets one stable identity distinct from the mouse (`PointerId::PRIMARY`
+/// is 1) and from any touch contact (allocated upward from 2) — the
+/// binding's ephemeral no-contact dispatch keys on the id alone.
+pub const GESTURE_POINTER_ID: u64 = u64::MAX;
+
+/// A pinch tick from a platform magnification delta (the fraction both
+/// AppKit and winit report). `None` for a NaN delta — winit documents NaN
+/// as possible, and a NaN scale tick is meaningless to every consumer.
+pub fn pinch(magnification: f64) -> Option<PointerGesture> {
+    if magnification.is_nan() {
+        return None;
+    }
+    #[allow(clippy::cast_possible_truncation)] // a magnification fraction is far inside f32 range
+    Some(PointerGesture::Pinch(magnification as f32))
+}
+
+/// A rotation tick from the platforms' counterclockwise-degrees delta,
+/// converted to the contract's clockwise radians.
+pub fn rotation_ccw_degrees(degrees: f32) -> PointerGesture {
+    PointerGesture::Rotate(-degrees.to_radians())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pinch_passes_the_fraction_through_and_drops_nan() {
+        assert!(matches!(pinch(0.1), Some(PointerGesture::Pinch(d)) if d == 0.1));
+        assert!(matches!(pinch(-0.25), Some(PointerGesture::Pinch(d)) if d == -0.25));
+        assert!(pinch(f64::NAN).is_none(), "a NaN magnification is dropped");
+    }
+
+    #[test]
+    fn rotation_converts_ccw_degrees_to_cw_radians() {
+        // A 90° counterclockwise platform delta is a -π/2 clockwise delta.
+        let PointerGesture::Rotate(radians) = rotation_ccw_degrees(90.0) else {
+            panic!("expected Rotate");
+        };
+        assert!((radians + std::f32::consts::FRAC_PI_2).abs() < 1e-6);
+    }
+}

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -3,6 +3,7 @@
 //! Components shared between platform implementations to reduce code
 //! duplication.
 
+pub mod gestures;
 mod handlers;
 pub mod scroll;
 


### PR DESCRIPTION
## What

Closes #723 (P1 from the live-wire audit): `PointerEvent::Gesture` had a complete, tested consumer chain and zero producers on any backend — trackpad pinch/rotate was dead end-to-end.

## How

Winit's `PinchGesture`/`RotationGesture` arms (macOS/iOS per winit's own platform notes) translate into Gesture ticks at the tracked cursor position. Conventions converted at the boundary: the pinch magnification fraction passes through (winit's semantics match `PointerGesture::Pinch` exactly; a NaN delta — documented possible — is dropped by a match guard, with the wildcard arm covering the guarded case); rotation converts winit's counterclockwise degrees into the lane's clockwise radians. One synthetic pointer identity for the whole gesture stream — never aliasing the mouse (`PRIMARY`) or any touch contact. `PanGesture` (iOS-only; macOS trackpad pans already arrive as `PixelDelta` wheel ticks) and `DoubleTapGesture` (no delta) stay deliberately untranslated, stated in the translator doc.

## Evidence

- `trackpad_gestures_produce_gesture_events_with_a_distinct_identity` pins the translator: gesture payload pass-through, touch typing, non-aliasing shared identity, logical coordinates.
- Honest scope: the platform match arms are dispatch plumbing on the established pattern, exercised transitively; the gestures themselves only fire on macOS/iOS hardware, which has no executing CI anywhere (`cross-typecheck` lints only) — the translator is the Linux-testable half, and it is tested.
- flui-platform suite CI-style: 202/202. `just ci` green, log-verified (`JUST_CI_EXIT: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM