### PR TITLE
fix(platform): merge WM_CHAR text into Win32 key events and fill the code tables

### DIFF
--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -342,8 +342,14 @@ pub fn key_down_event(
     // SAFETY: see `pointer_state` above — same call, no precondition.
     let modifiers = unsafe { get_modifiers() };
     let fallback = keys::vk_to_key(vk, modifiers.contains(KeyboardModifiers::SHIFT));
-    let key = keys::merge_wm_char(fallback, translated_text);
     let code = keys::scancode_to_code(scan_code, extended);
+    let key = keys::key_for_keydown(
+        fallback,
+        translated_text,
+        modifiers.contains(KeyboardModifiers::ALT),
+        modifiers.contains(KeyboardModifiers::CONTROL),
+        code,
+    );
 
     PlatformInput::Keyboard(KeyboardEvent {
         state: KeyState::Down,

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -22,19 +22,14 @@ use ui_events::{
 use windows::Win32::{
     Foundation::{HWND, LPARAM, POINT, WPARAM},
     Graphics::Gdi::ScreenToClient,
-    UI::Input::KeyboardAndMouse::{
-        VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9, VK_A, VK_B,
-        VK_BACK, VK_C, VK_CONTROL, VK_D, VK_DELETE, VK_DOWN, VK_E, VK_END, VK_ESCAPE, VK_F, VK_F1,
-        VK_F2, VK_F3, VK_F4, VK_F5, VK_F6, VK_F7, VK_F8, VK_F9, VK_F10, VK_F11, VK_F12, VK_G, VK_H,
-        VK_HOME, VK_I, VK_INSERT, VK_J, VK_K, VK_L, VK_LCONTROL, VK_LEFT, VK_LMENU, VK_LSHIFT,
-        VK_LWIN, VK_M, VK_MENU, VK_N, VK_NEXT, VK_O, VK_P, VK_PRIOR, VK_Q, VK_R, VK_RCONTROL,
-        VK_RETURN, VK_RIGHT, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_S, VK_SHIFT, VK_SPACE, VK_T, VK_TAB,
-        VK_U, VK_UP, VK_V, VK_W, VK_X, VK_Y, VK_Z,
-    },
+    UI::Input::KeyboardAndMouse::{VK_CONTROL, VK_LWIN, VK_MENU, VK_RWIN, VK_SHIFT},
 };
 
 use super::util::{get_x_lparam, get_y_lparam, is_key_pressed};
-use crate::traits::{Key, PlatformInput, device_to_logical};
+use crate::{
+    shared::keys,
+    traits::{Key, PlatformInput, device_to_logical},
+};
 
 /// Process-start epoch for monotonic event timestamps.
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
@@ -58,93 +53,12 @@ fn primary_mouse_info() -> PointerInfo {
 // ============================================================================
 // Keyboard Event Conversion
 // ============================================================================
-
-/// Convert VK_* to keyboard-types Key
-fn vk_to_key(vk: VIRTUAL_KEY, _scan_code: u16) -> Key {
-    use keyboard_types::{Key as K, NamedKey};
-
-    match vk {
-        // Named keys
-        VK_RETURN => K::Named(NamedKey::Enter),
-        VK_TAB => K::Named(NamedKey::Tab),
-        VK_SPACE => K::Character(" ".into()),
-        VK_BACK => K::Named(NamedKey::Backspace),
-        VK_DELETE => K::Named(NamedKey::Delete),
-        VK_ESCAPE => K::Named(NamedKey::Escape),
-
-        VK_LEFT => K::Named(NamedKey::ArrowLeft),
-        VK_RIGHT => K::Named(NamedKey::ArrowRight),
-        VK_UP => K::Named(NamedKey::ArrowUp),
-        VK_DOWN => K::Named(NamedKey::ArrowDown),
-
-        VK_HOME => K::Named(NamedKey::Home),
-        VK_END => K::Named(NamedKey::End),
-        VK_PRIOR => K::Named(NamedKey::PageUp),
-        VK_NEXT => K::Named(NamedKey::PageDown),
-        VK_INSERT => K::Named(NamedKey::Insert),
-
-        VK_F1 => K::Named(NamedKey::F1),
-        VK_F2 => K::Named(NamedKey::F2),
-        VK_F3 => K::Named(NamedKey::F3),
-        VK_F4 => K::Named(NamedKey::F4),
-        VK_F5 => K::Named(NamedKey::F5),
-        VK_F6 => K::Named(NamedKey::F6),
-        VK_F7 => K::Named(NamedKey::F7),
-        VK_F8 => K::Named(NamedKey::F8),
-        VK_F9 => K::Named(NamedKey::F9),
-        VK_F10 => K::Named(NamedKey::F10),
-        VK_F11 => K::Named(NamedKey::F11),
-        VK_F12 => K::Named(NamedKey::F12),
-
-        // Modifiers
-        VK_LSHIFT | VK_RSHIFT => K::Named(NamedKey::Shift),
-        VK_LCONTROL | VK_RCONTROL => K::Named(NamedKey::Control),
-        VK_LMENU | VK_RMENU => K::Named(NamedKey::Alt),
-        VK_LWIN | VK_RWIN => K::Named(NamedKey::Meta),
-
-        // Letters
-        VK_A => K::Character("a".into()),
-        VK_B => K::Character("b".into()),
-        VK_C => K::Character("c".into()),
-        VK_D => K::Character("d".into()),
-        VK_E => K::Character("e".into()),
-        VK_F => K::Character("f".into()),
-        VK_G => K::Character("g".into()),
-        VK_H => K::Character("h".into()),
-        VK_I => K::Character("i".into()),
-        VK_J => K::Character("j".into()),
-        VK_K => K::Character("k".into()),
-        VK_L => K::Character("l".into()),
-        VK_M => K::Character("m".into()),
-        VK_N => K::Character("n".into()),
-        VK_O => K::Character("o".into()),
-        VK_P => K::Character("p".into()),
-        VK_Q => K::Character("q".into()),
-        VK_R => K::Character("r".into()),
-        VK_S => K::Character("s".into()),
-        VK_T => K::Character("t".into()),
-        VK_U => K::Character("u".into()),
-        VK_V => K::Character("v".into()),
-        VK_W => K::Character("w".into()),
-        VK_X => K::Character("x".into()),
-        VK_Y => K::Character("y".into()),
-        VK_Z => K::Character("z".into()),
-
-        // Numbers
-        VK_0 => K::Character("0".into()),
-        VK_1 => K::Character("1".into()),
-        VK_2 => K::Character("2".into()),
-        VK_3 => K::Character("3".into()),
-        VK_4 => K::Character("4".into()),
-        VK_5 => K::Character("5".into()),
-        VK_6 => K::Character("6".into()),
-        VK_7 => K::Character("7".into()),
-        VK_8 => K::Character("8".into()),
-        VK_9 => K::Character("9".into()),
-
-        _ => K::Named(NamedKey::Unidentified),
-    }
-}
+//
+// The translation decisions themselves (vk -> Key fallback, scancode -> Code,
+// the WM_CHAR merge) are pure functions in `crate::shared::keys`, where their
+// tests execute on every host; this file only unpacks the Win32 message
+// parameters and feeds them through. The WM_CHAR pairing model is documented
+// on that module.
 
 /// Get current modifiers state
 ///
@@ -410,39 +324,76 @@ pub fn mouse_hwheel_event(
 // Keyboard events (simple wrappers)
 // ============================================================================
 
-/// Convert WM_KEYDOWN to W3C KeyboardEvent
-pub fn key_down_event(wparam: WPARAM, lparam: LPARAM) -> PlatformInput {
-    let vk = VIRTUAL_KEY(wparam.0 as u16);
-    let scan_code = ((lparam.0 >> 16) & 0xFF) as u16;
-    let is_repeat = (lparam.0 & (1 << 30)) != 0;
+/// Convert WM_KEYDOWN to W3C KeyboardEvent.
+///
+/// `translated_text` is the drained `WM_CHAR` burst for this keydown (see
+/// `window_proc`'s `WM_KEYDOWN` arm and `crate::shared::keys`'s module doc
+/// for the pairing model); when present and typeable it becomes the event's
+/// `Key::Character`, otherwise the layout-independent virtual-key fallback
+/// applies.
+pub fn key_down_event(
+    wparam: WPARAM,
+    lparam: LPARAM,
+    translated_text: Option<String>,
+) -> PlatformInput {
+    let vk = wparam.0 as u16;
+    let (scan_code, extended, is_repeat) = keys::parse_key_lparam(lparam.0);
 
     // SAFETY: see `pointer_state` above — same call, no precondition.
     let modifiers = unsafe { get_modifiers() };
-    let key = vk_to_key(vk, scan_code);
+    let fallback = keys::vk_to_key(vk, modifiers.contains(KeyboardModifiers::SHIFT));
+    let key = keys::merge_wm_char(fallback, translated_text);
+    let code = keys::scancode_to_code(scan_code, extended);
 
     PlatformInput::Keyboard(KeyboardEvent {
         state: KeyState::Down,
         key,
-        code: Code::Unidentified,
-        location: Location::Standard,
+        code,
+        location: keys::location_for_code(code),
         modifiers,
         repeat: is_repeat,
         is_composing: false,
     })
 }
 
-/// Convert WM_KEYUP to W3C KeyboardEvent
+/// Convert WM_KEYUP to W3C KeyboardEvent.
+///
+/// No `WM_CHAR` pairs with a keyup, so the key is always the virtual-key
+/// fallback — for a letter that is its shift-respecting character, for OEM
+/// punctuation the US-layout position. Consumers that type text act on
+/// `KeyState::Down` only, so this asymmetry never reaches a text field.
 pub fn key_up_event(wparam: WPARAM, lparam: LPARAM) -> PlatformInput {
-    let vk = VIRTUAL_KEY(wparam.0 as u16);
-    let scan_code = ((lparam.0 >> 16) & 0xFF) as u16;
+    let vk = wparam.0 as u16;
+    let (scan_code, extended, _) = keys::parse_key_lparam(lparam.0);
 
     // SAFETY: see `pointer_state` above — same call, no precondition.
     let modifiers = unsafe { get_modifiers() };
-    let key = vk_to_key(vk, scan_code);
+    let key = keys::vk_to_key(vk, modifiers.contains(KeyboardModifiers::SHIFT));
+    let code = keys::scancode_to_code(scan_code, extended);
 
     PlatformInput::Keyboard(KeyboardEvent {
         state: KeyState::Up,
         key,
+        code,
+        location: keys::location_for_code(code),
+        modifiers,
+        repeat: false,
+        is_composing: false,
+    })
+}
+
+/// Build the KeyboardEvent for an out-of-band `WM_CHAR` — one that reached
+/// `window_proc` instead of being drained by a `WM_KEYDOWN` (Alt+numpad
+/// composition, or a directly-sent message). There is no owning physical
+/// key, so it is dispatched as a key-down with `Code::Unidentified` and no
+/// paired key-up; the text lane consumes `Key::Character` on key-down only.
+pub fn stray_char_event(text: String) -> PlatformInput {
+    // SAFETY: see `pointer_state` above — same call, no precondition.
+    let modifiers = unsafe { get_modifiers() };
+
+    PlatformInput::Keyboard(KeyboardEvent {
+        state: KeyState::Down,
+        key: Key::Character(text),
         code: Code::Unidentified,
         location: Location::Standard,
         modifiers,
@@ -451,22 +402,30 @@ pub fn key_up_event(wparam: WPARAM, lparam: LPARAM) -> PlatformInput {
     })
 }
 
-/// Convert WM_CHAR to a character
-pub fn char_from_wparam(wparam: WPARAM) -> Option<char> {
-    char::from_u32(wparam.0 as u32)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::NamedKey;
 
+    /// The Win32 wire assembles its keyboard events from the shared,
+    /// host-testable tables plus the live modifier query: a WM_KEYDOWN for
+    /// VK_A (scancode 0x1E) with the translated text "A" merged in must
+    /// carry the shifted character AND the physical-key code — this is the
+    /// wire that used to hardcode `Code::Unidentified` and case-fold every
+    /// character.
     #[test]
-    fn test_vk_to_key() {
-        assert!(matches!(vk_to_key(VK_A, 0), Key::Character(_)));
-        assert_eq!(vk_to_key(VK_RETURN, 0), Key::Named(NamedKey::Enter));
-        assert_eq!(vk_to_key(VK_LEFT, 0), Key::Named(NamedKey::ArrowLeft));
-        assert_eq!(vk_to_key(VK_F1, 0), Key::Named(NamedKey::F1));
+    fn test_key_down_event_carries_text_and_code() {
+        let lparam = LPARAM(0x1E << 16); // scancode 0x1E, not extended
+        let event = key_down_event(WPARAM(0x41), lparam, Some("A".to_string()));
+
+        if let PlatformInput::Keyboard(kb) = event {
+            assert_eq!(kb.state, KeyState::Down);
+            assert_eq!(kb.key, Key::Character("A".to_string()));
+            assert_eq!(kb.code, Code::KeyA);
+            assert_eq!(kb.location, Location::Standard);
+            assert!(!kb.repeat);
+        } else {
+            panic!("Expected Keyboard event");
+        }
     }
 
     #[test]

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -17,14 +17,15 @@ use windows::{
             WindowsAndMessaging::{
                 CS_HREDRAW, CS_OWNDC, CS_VREDRAW, CreateWindowExW, DefWindowProcW, DestroyWindow,
                 DispatchMessageW, GWLP_USERDATA, GetForegroundWindow, GetMessageW,
-                GetWindowLongPtrW, HICON, HTCLIENT, HWND_MESSAGE, IDC_ARROW, MSG, PostQuitMessage,
-                RegisterClassW, SW_SHOWNORMAL, SWP_NOACTIVATE, SWP_NOZORDER, SetForegroundWindow,
-                SetWindowLongPtrW, SetWindowPos, TranslateMessage, WINDOW_EX_STYLE, WINDOW_STYLE,
-                WM_CHAR, WM_CLOSE, WM_CREATE, WM_DESTROY, WM_DPICHANGED, WM_ERASEBKGND,
-                WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN,
-                WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE,
-                WM_MOUSEWHEEL, WM_MOVE, WM_PAINT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR,
-                WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WNDCLASSW,
+                GetWindowLongPtrW, HICON, HTCLIENT, HWND_MESSAGE, IDC_ARROW, MSG, PM_REMOVE,
+                PeekMessageW, PostQuitMessage, RegisterClassW, SW_SHOWNORMAL, SWP_NOACTIVATE,
+                SWP_NOZORDER, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
+                TranslateMessage, WINDOW_EX_STYLE, WINDOW_STYLE, WM_CHAR, WM_CLOSE, WM_CREATE,
+                WM_DESTROY, WM_DPICHANGED, WM_ERASEBKGND, WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP,
+                WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP,
+                WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_MOVE, WM_PAINT, WM_RBUTTONDOWN,
+                WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN,
+                WM_SYSKEYUP, WNDCLASSW,
             },
         },
     },
@@ -87,6 +88,12 @@ pub(super) struct WindowContext {
     /// Stored here instead of in `WindowMode` to keep the cross-platform enum
     /// free of platform-specific fields.
     pub restore_style: std::cell::Cell<u32>,
+    /// High half of a UTF-16 surrogate pair from an out-of-band `WM_CHAR`,
+    /// held until its low half arrives in the next message (Windows splits
+    /// astral-plane characters across two `WM_CHAR`s). Only the stray-char
+    /// path in `window_proc` uses this; the `WM_KEYDOWN` drain sees a whole
+    /// burst at once and never needs cross-message state.
+    pub pending_high_surrogate: std::cell::Cell<Option<u16>>,
 }
 
 impl WindowContext {
@@ -923,9 +930,19 @@ impl WindowsPlatform {
                         // Track modifiers (T035)
                         ctx.modifiers.set(current_modifiers());
 
+                        // Merge the fully-translated character(s) for this
+                        // keystroke into the keydown. The message loop runs
+                        // `TranslateMessage` before `DispatchMessageW` (see
+                        // `run`), so the WM_CHAR burst for this keydown —
+                        // shift/caps/AltGr applied, dead keys resolved — is
+                        // already in the queue and is drained synchronously
+                        // here. Pairing model and merge rules:
+                        // `crate::shared::keys` module doc.
+                        let translated = drain_translated_chars(hwnd);
+
                         // Dispatch keyboard event via per-window callback
                         use super::events::key_down_event;
-                        let event = key_down_event(wparam, lparam);
+                        let event = key_down_event(wparam, lparam, translated);
                         ctx.callbacks.dispatch_input(event);
                     }
 
@@ -945,8 +962,27 @@ impl WindowsPlatform {
                 }
 
                 WM_CHAR => {
-                    // WM_CHAR is handled by the framework via KeyboardEvent
-                    // No per-window callback dispatch needed here
+                    // Normally unreachable: the WM_KEYDOWN arm drains the
+                    // paired WM_CHAR burst before it would be dispatched
+                    // here. What remains is an out-of-band character with no
+                    // owning keydown — Alt+numpad composition (queued by
+                    // TranslateMessage of the Alt KEYUP) or a directly-sent
+                    // message — dispatched as its own key-down instead of
+                    // being discarded, so the text lane still receives it.
+                    // Astral-plane characters arrive as two WM_CHARs; the
+                    // high surrogate is parked in the context until its low
+                    // half arrives.
+                    if let Some(ctx) = ctx {
+                        let (pending, text) = crate::shared::keys::assemble_stray_wm_char(
+                            ctx.pending_high_surrogate.get(),
+                            wparam.0 as u16,
+                        );
+                        ctx.pending_high_surrogate.set(pending);
+                        if let Some(text) = text {
+                            use super::events::stray_char_event;
+                            ctx.callbacks.dispatch_input(stray_char_event(text));
+                        }
+                    }
                     LRESULT(0)
                 }
 
@@ -1600,6 +1636,37 @@ fn current_modifiers() -> keyboard_types::Modifiers {
         }
         mods
     }
+}
+
+/// Drain the `WM_CHAR` burst `TranslateMessage` queued for the keydown
+/// currently being handled, and decode it into typeable text.
+///
+/// Called from `window_proc`'s `WM_KEYDOWN`/`WM_SYSKEYDOWN` arm. The burst
+/// is complete at that point — the message loop runs `TranslateMessage`
+/// before `DispatchMessageW`, so every `WM_CHAR` belonging to this keystroke
+/// (two of them for an astral-plane character) is already posted. Draining
+/// filters exactly `WM_CHAR` for this window: `WM_SYSCHAR` is deliberately
+/// left queued so Alt+mnemonic accelerators still flow to `DefWindowProcW`,
+/// and `WM_DEADCHAR` is left to expire so dead-key state stays Windows'
+/// business. Returns `None` for keystrokes with no typeable translation
+/// (navigation keys, Ctrl chords — see `shared::keys::wm_char_text`).
+fn drain_translated_chars(hwnd: HWND) -> Option<String> {
+    let mut units: Vec<u16> = Vec::new();
+    let mut msg = MSG::default();
+
+    // SAFETY: `msg` is a live, writable local and `PeekMessageW` writes
+    // nothing else. `PM_REMOVE` only ever removes messages from this
+    // thread's own queue (the wndproc runs on the queue's owning thread).
+    // Note `PeekMessageW` may deliver pending nonqueued (sent) messages,
+    // re-entering `window_proc` — the same re-entrancy any modal Win32 API
+    // call permits, and `window_proc` holds no lock across this call.
+    unsafe {
+        while PeekMessageW(&raw mut msg, Some(hwnd), WM_CHAR, WM_CHAR, PM_REMOVE).as_bool() {
+            units.push(msg.wParam.0 as u16);
+        }
+    }
+
+    crate::shared::keys::wm_char_text(&units)
 }
 
 // Windows platform capabilities

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -239,6 +239,7 @@ impl WindowsWindow {
                 modifiers: std::cell::Cell::new(keyboard_types::Modifiers::empty()),
                 cursor: std::cell::Cell::new(CursorIcon::default()),
                 restore_style: std::cell::Cell::new(0),
+                pending_high_surrogate: std::cell::Cell::new(None),
             });
             let context_ptr = Box::into_raw(context);
             SetWindowLongPtrW(hwnd, GWLP_USERDATA, context_ptr as isize);

--- a/crates/flui-platform/src/shared/keys.rs
+++ b/crates/flui-platform/src/shared/keys.rs
@@ -1,0 +1,780 @@
+//! Win32 keyboard translation decisions.
+//!
+//! Everything the Win32 backend decides about a keystroke — which `Key` a
+//! virtual-key code falls back to, which W3C `Code` a scancode names, whether
+//! a `WM_CHAR` burst is typeable text, and how that text merges into the
+//! key-down event — lives here as pure functions over raw integers.
+//!
+//! This module is deliberately free of `cfg` gates and platform types so the
+//! per-decision tables compile — and their tests execute — on any host, even
+//! though the Win32 caller (`platforms/windows`) itself is only ever
+//! clippy-linted in CI, never linked or run.
+//!
+//! # The WM_CHAR pairing model
+//!
+//! Win32 splits one keystroke across two wire messages: `WM_KEYDOWN` carries
+//! the key identity (virtual key + scancode), and `TranslateMessage` posts a
+//! follow-up `WM_CHAR` carrying the fully-translated character — shift, caps
+//! lock, AltGr, and dead-key composition applied, with characters outside the
+//! BMP split into two `WM_CHAR`s (a UTF-16 surrogate pair). Because the
+//! message loop runs `TranslateMessage` *before* `DispatchMessageW`, the
+//! `WM_CHAR` burst for a keydown is already in the thread queue when the
+//! window procedure sees the `WM_KEYDOWN` — so the backend drains it
+//! synchronously and merges it into the keydown's `key` via
+//! [`merge_wm_char`], producing ONE `KeyboardEvent` per physical press. That
+//! is the contract the shared consumers are built on: text is typed from
+//! `Key::Character` on a `KeyState::Down` event (`flui-widgets`'
+//! `EditableText` key handler), so dispatching the character as a second,
+//! separate event would double-type every key the fallback table already
+//! names. The winit Windows backend performs the same merge with its own
+//! queue peek (winit 0.30 `platform_impl/windows/keyboard.rs`).
+//!
+//! A `WM_CHAR` with no owning keydown still exists — Alt+numpad composition
+//! is queued by `TranslateMessage` of the Alt *keyup* — and is assembled by
+//! [`assemble_stray_wm_char`] into its own event instead of being dropped.
+
+use keyboard_types::{Code, Key, Location, NamedKey};
+
+// Virtual-key codes, from `winuser.h`. Raw `u16` rather than the `windows`
+// crate's `VIRTUAL_KEY` newtype so this module compiles on every host.
+mod vk {
+    pub const BACK: u16 = 0x08;
+    pub const TAB: u16 = 0x09;
+    pub const RETURN: u16 = 0x0D;
+    pub const SHIFT: u16 = 0x10;
+    pub const CONTROL: u16 = 0x11;
+    pub const MENU: u16 = 0x12;
+    pub const PAUSE: u16 = 0x13;
+    pub const CAPITAL: u16 = 0x14;
+    pub const ESCAPE: u16 = 0x1B;
+    pub const SPACE: u16 = 0x20;
+    pub const PRIOR: u16 = 0x21;
+    pub const NEXT: u16 = 0x22;
+    pub const END: u16 = 0x23;
+    pub const HOME: u16 = 0x24;
+    pub const LEFT: u16 = 0x25;
+    pub const UP: u16 = 0x26;
+    pub const RIGHT: u16 = 0x27;
+    pub const DOWN: u16 = 0x28;
+    pub const SNAPSHOT: u16 = 0x2C;
+    pub const INSERT: u16 = 0x2D;
+    pub const DELETE: u16 = 0x2E;
+    pub const KEY_0: u16 = 0x30;
+    pub const KEY_9: u16 = 0x39;
+    pub const KEY_A: u16 = 0x41;
+    pub const KEY_Z: u16 = 0x5A;
+    pub const LWIN: u16 = 0x5B;
+    pub const RWIN: u16 = 0x5C;
+    pub const APPS: u16 = 0x5D;
+    pub const NUMPAD0: u16 = 0x60;
+    pub const NUMPAD9: u16 = 0x69;
+    pub const MULTIPLY: u16 = 0x6A;
+    pub const ADD: u16 = 0x6B;
+    pub const SUBTRACT: u16 = 0x6D;
+    pub const DECIMAL: u16 = 0x6E;
+    pub const DIVIDE: u16 = 0x6F;
+    pub const F1: u16 = 0x70;
+    pub const F12: u16 = 0x7B;
+    pub const NUMLOCK: u16 = 0x90;
+    pub const SCROLL: u16 = 0x91;
+    pub const LSHIFT: u16 = 0xA0;
+    pub const RSHIFT: u16 = 0xA1;
+    pub const LCONTROL: u16 = 0xA2;
+    pub const RCONTROL: u16 = 0xA3;
+    pub const LMENU: u16 = 0xA4;
+    pub const RMENU: u16 = 0xA5;
+    pub const OEM_1: u16 = 0xBA;
+    pub const OEM_PLUS: u16 = 0xBB;
+    pub const OEM_COMMA: u16 = 0xBC;
+    pub const OEM_MINUS: u16 = 0xBD;
+    pub const OEM_PERIOD: u16 = 0xBE;
+    pub const OEM_2: u16 = 0xBF;
+    pub const OEM_3: u16 = 0xC0;
+    pub const OEM_4: u16 = 0xDB;
+    pub const OEM_5: u16 = 0xDC;
+    pub const OEM_6: u16 = 0xDD;
+    pub const OEM_7: u16 = 0xDE;
+    pub const OEM_102: u16 = 0xE2;
+}
+
+/// Split a `WM_KEYDOWN`/`WM_KEYUP` `lParam` into the fields the translation
+/// needs: the 8-bit scancode (bits 16–23), the extended-key flag (bit 24,
+/// the `E0` prefix that distinguishes e.g. arrow keys from the numpad), and
+/// the previous-key-state repeat flag (bit 30, meaningful on keydown only).
+///
+/// Layout per the `WM_KEYDOWN` docs:
+/// <https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-keydown>
+pub fn parse_key_lparam(lparam: isize) -> (u16, bool, bool) {
+    let scancode = ((lparam >> 16) & 0xFF) as u16;
+    let extended = (lparam >> 24) & 1 == 1;
+    let repeat = (lparam >> 30) & 1 == 1;
+    (scancode, extended, repeat)
+}
+
+/// The layout-independent `Key` a virtual-key code falls back to when no
+/// `WM_CHAR` text is available for the event — key-ups, and chords whose
+/// translation is a control character (Ctrl+S delivers `WM_CHAR` `0x13`,
+/// which [`wm_char_text`] rejects, so shortcut matching still sees `"s"`).
+///
+/// `shift` upcases the letter fallbacks so a Ctrl+Shift+S chord reports
+/// `"S"`, matching the W3C `key` value and the winit backend's
+/// `logical_key`. Punctuation (`OEM_*`) uses the US-layout positions — the
+/// only layout-independent choice available without the live keyboard
+/// layout; a real typed character never takes this path because the
+/// `WM_CHAR` merge wins.
+pub fn vk_to_key(vk_code: u16, shift: bool) -> Key {
+    use Key as K;
+
+    match vk_code {
+        vk::RETURN => K::Named(NamedKey::Enter),
+        vk::TAB => K::Named(NamedKey::Tab),
+        vk::SPACE => K::Character(" ".into()),
+        vk::BACK => K::Named(NamedKey::Backspace),
+        vk::DELETE => K::Named(NamedKey::Delete),
+        vk::ESCAPE => K::Named(NamedKey::Escape),
+
+        vk::LEFT => K::Named(NamedKey::ArrowLeft),
+        vk::RIGHT => K::Named(NamedKey::ArrowRight),
+        vk::UP => K::Named(NamedKey::ArrowUp),
+        vk::DOWN => K::Named(NamedKey::ArrowDown),
+
+        vk::HOME => K::Named(NamedKey::Home),
+        vk::END => K::Named(NamedKey::End),
+        vk::PRIOR => K::Named(NamedKey::PageUp),
+        vk::NEXT => K::Named(NamedKey::PageDown),
+        vk::INSERT => K::Named(NamedKey::Insert),
+
+        vk::CAPITAL => K::Named(NamedKey::CapsLock),
+        vk::NUMLOCK => K::Named(NamedKey::NumLock),
+        vk::SCROLL => K::Named(NamedKey::ScrollLock),
+        vk::SNAPSHOT => K::Named(NamedKey::PrintScreen),
+        vk::PAUSE => K::Named(NamedKey::Pause),
+        vk::APPS => K::Named(NamedKey::ContextMenu),
+
+        // WM_KEYDOWN delivers the GENERIC modifier VKs (VK_SHIFT etc.);
+        // the left/right VKs only appear via GetKeyState-style queries,
+        // but both spellings map to the same W3C `key` value anyway —
+        // sidedness is the `code`'s job.
+        vk::SHIFT | vk::LSHIFT | vk::RSHIFT => K::Named(NamedKey::Shift),
+        vk::CONTROL | vk::LCONTROL | vk::RCONTROL => K::Named(NamedKey::Control),
+        vk::MENU | vk::LMENU | vk::RMENU => K::Named(NamedKey::Alt),
+        vk::LWIN | vk::RWIN => K::Named(NamedKey::Meta),
+
+        // VK_A..=VK_Z are the ASCII uppercase letters.
+        c @ vk::KEY_A..=vk::KEY_Z => {
+            let ch = if shift {
+                c as u8 as char
+            } else {
+                (c as u8 as char).to_ascii_lowercase()
+            };
+            K::Character(ch.to_string())
+        }
+        // VK_0..=VK_9 are the ASCII digits. Their shifted values are
+        // layout-dependent, so no `shift` handling: the WM_CHAR merge is
+        // what delivers `!`/`@`/… on a real press.
+        c @ vk::KEY_0..=vk::KEY_9 => K::Character((c as u8 as char).to_string()),
+
+        // Numpad digits and operators (delivered with NumLock on).
+        c @ vk::NUMPAD0..=vk::NUMPAD9 => {
+            K::Character(((b'0' + (c - vk::NUMPAD0) as u8) as char).to_string())
+        }
+        vk::MULTIPLY => K::Character("*".into()),
+        vk::ADD => K::Character("+".into()),
+        vk::SUBTRACT => K::Character("-".into()),
+        vk::DECIMAL => K::Character(".".into()),
+        vk::DIVIDE => K::Character("/".into()),
+
+        c @ vk::F1..=vk::F12 => {
+            let named = [
+                NamedKey::F1,
+                NamedKey::F2,
+                NamedKey::F3,
+                NamedKey::F4,
+                NamedKey::F5,
+                NamedKey::F6,
+                NamedKey::F7,
+                NamedKey::F8,
+                NamedKey::F9,
+                NamedKey::F10,
+                NamedKey::F11,
+                NamedKey::F12,
+            ][(c - vk::F1) as usize];
+            K::Named(named)
+        }
+
+        // OEM punctuation, US-layout positions (unshifted).
+        vk::OEM_1 => K::Character(";".into()),
+        vk::OEM_PLUS => K::Character("=".into()),
+        vk::OEM_COMMA => K::Character(",".into()),
+        vk::OEM_MINUS => K::Character("-".into()),
+        vk::OEM_PERIOD => K::Character(".".into()),
+        vk::OEM_2 => K::Character("/".into()),
+        vk::OEM_3 => K::Character("`".into()),
+        vk::OEM_4 => K::Character("[".into()),
+        vk::OEM_5 | vk::OEM_102 => K::Character("\\".into()),
+        vk::OEM_6 => K::Character("]".into()),
+        vk::OEM_7 => K::Character("'".into()),
+
+        _ => K::Named(NamedKey::Unidentified),
+    }
+}
+
+/// Map a Win32 Set-1 make scancode (+ the lParam extended flag) to the W3C
+/// `code` value naming the physical key.
+///
+/// The table follows the W3C registry
+/// (<https://www.w3.org/TR/uievents-code/>) as implemented by the winit
+/// Windows backend and Firefox's `NativeKeyToDOMCodeName.h`, including the
+/// legacy quirks those sources agree on: `Pause` reports `0x45`
+/// (`0xE046` when Ctrl is held), `NumLock` reports the *extended* `0xE045`,
+/// and `PrintScreen` reports `0xE037` (`0x54` when Alt is held).
+pub fn scancode_to_code(scancode: u16, extended: bool) -> Code {
+    let ext_scancode = if extended {
+        0xE000 | u32::from(scancode)
+    } else {
+        u32::from(scancode)
+    };
+
+    match ext_scancode {
+        0x0001 => Code::Escape,
+        0x0002 => Code::Digit1,
+        0x0003 => Code::Digit2,
+        0x0004 => Code::Digit3,
+        0x0005 => Code::Digit4,
+        0x0006 => Code::Digit5,
+        0x0007 => Code::Digit6,
+        0x0008 => Code::Digit7,
+        0x0009 => Code::Digit8,
+        0x000A => Code::Digit9,
+        0x000B => Code::Digit0,
+        0x000C => Code::Minus,
+        0x000D => Code::Equal,
+        0x000E => Code::Backspace,
+        0x000F => Code::Tab,
+        0x0010 => Code::KeyQ,
+        0x0011 => Code::KeyW,
+        0x0012 => Code::KeyE,
+        0x0013 => Code::KeyR,
+        0x0014 => Code::KeyT,
+        0x0015 => Code::KeyY,
+        0x0016 => Code::KeyU,
+        0x0017 => Code::KeyI,
+        0x0018 => Code::KeyO,
+        0x0019 => Code::KeyP,
+        0x001A => Code::BracketLeft,
+        0x001B => Code::BracketRight,
+        0x001C => Code::Enter,
+        0x001D => Code::ControlLeft,
+        0x001E => Code::KeyA,
+        0x001F => Code::KeyS,
+        0x0020 => Code::KeyD,
+        0x0021 => Code::KeyF,
+        0x0022 => Code::KeyG,
+        0x0023 => Code::KeyH,
+        0x0024 => Code::KeyJ,
+        0x0025 => Code::KeyK,
+        0x0026 => Code::KeyL,
+        0x0027 => Code::Semicolon,
+        0x0028 => Code::Quote,
+        0x0029 => Code::Backquote,
+        0x002A => Code::ShiftLeft,
+        0x002B => Code::Backslash,
+        0x002C => Code::KeyZ,
+        0x002D => Code::KeyX,
+        0x002E => Code::KeyC,
+        0x002F => Code::KeyV,
+        0x0030 => Code::KeyB,
+        0x0031 => Code::KeyN,
+        0x0032 => Code::KeyM,
+        0x0033 => Code::Comma,
+        0x0034 => Code::Period,
+        0x0035 => Code::Slash,
+        0x0036 => Code::ShiftRight,
+        0x0037 => Code::NumpadMultiply,
+        0x0038 => Code::AltLeft,
+        0x0039 => Code::Space,
+        0x003A => Code::CapsLock,
+        0x003B => Code::F1,
+        0x003C => Code::F2,
+        0x003D => Code::F3,
+        0x003E => Code::F4,
+        0x003F => Code::F5,
+        0x0040 => Code::F6,
+        0x0041 => Code::F7,
+        0x0042 => Code::F8,
+        0x0043 => Code::F9,
+        0x0044 => Code::F10,
+        // 0xE046 is the make code the same key reports while Ctrl is held
+        // (Ctrl+Pause = Break).
+        0x0045 | 0xE046 => Code::Pause,
+        0x0046 => Code::ScrollLock,
+        0x0047 => Code::Numpad7,
+        0x0048 => Code::Numpad8,
+        0x0049 => Code::Numpad9,
+        0x004A => Code::NumpadSubtract,
+        0x004B => Code::Numpad4,
+        0x004C => Code::Numpad5,
+        0x004D => Code::Numpad6,
+        0x004E => Code::NumpadAdd,
+        0x004F => Code::Numpad1,
+        0x0050 => Code::Numpad2,
+        0x0051 => Code::Numpad3,
+        0x0052 => Code::Numpad0,
+        0x0053 => Code::NumpadDecimal,
+        // 0x54 is the make code the same key reports while Alt is held
+        // (Alt+PrintScreen = SysRq); 0xE037 is the ordinary press.
+        0x0054 | 0xE037 => Code::PrintScreen,
+        0x0056 => Code::IntlBackslash,
+        0x0057 => Code::F11,
+        0x0058 => Code::F12,
+        0x0059 => Code::NumpadEqual,
+        0x0064 => Code::F13,
+        0x0065 => Code::F14,
+        0x0066 => Code::F15,
+        0x0067 => Code::F16,
+        0x0068 => Code::F17,
+        0x0069 => Code::F18,
+        0x006A => Code::F19,
+        0x006B => Code::F20,
+        0x006C => Code::F21,
+        0x006D => Code::F22,
+        0x006E => Code::F23,
+        0x0070 => Code::KanaMode,
+        0x0071 => Code::Lang2,
+        0x0072 => Code::Lang1,
+        0x0073 => Code::IntlRo,
+        0x0076 => Code::F24,
+        0x0079 => Code::Convert,
+        0x007B => Code::NonConvert,
+        0x007D => Code::IntlYen,
+        0x007E => Code::NumpadComma,
+
+        0xE010 => Code::MediaTrackPrevious,
+        0xE019 => Code::MediaTrackNext,
+        0xE01C => Code::NumpadEnter,
+        0xE01D => Code::ControlRight,
+        0xE020 => Code::AudioVolumeMute,
+        0xE021 => Code::LaunchApp2,
+        0xE022 => Code::MediaPlayPause,
+        0xE024 => Code::MediaStop,
+        0xE02E => Code::AudioVolumeDown,
+        0xE030 => Code::AudioVolumeUp,
+        0xE032 => Code::BrowserHome,
+        0xE035 => Code::NumpadDivide,
+        0xE038 => Code::AltRight,
+        0xE045 => Code::NumLock,
+        0xE047 => Code::Home,
+        0xE048 => Code::ArrowUp,
+        0xE049 => Code::PageUp,
+        0xE04B => Code::ArrowLeft,
+        0xE04D => Code::ArrowRight,
+        0xE04F => Code::End,
+        0xE050 => Code::ArrowDown,
+        0xE051 => Code::PageDown,
+        0xE052 => Code::Insert,
+        0xE053 => Code::Delete,
+        0xE05B => Code::MetaLeft,
+        0xE05C => Code::MetaRight,
+        0xE05D => Code::ContextMenu,
+        0xE05E => Code::Power,
+        0xE065 => Code::BrowserSearch,
+        0xE066 => Code::BrowserFavorites,
+        0xE067 => Code::BrowserRefresh,
+        0xE068 => Code::BrowserStop,
+        0xE069 => Code::BrowserForward,
+        0xE06A => Code::BrowserBack,
+        0xE06B => Code::LaunchApp1,
+        0xE06C => Code::LaunchMail,
+        0xE06D => Code::MediaSelect,
+
+        _ => Code::Unidentified,
+    }
+}
+
+/// The W3C `location` a `code` implies: numpad keys report `Numpad`, sided
+/// modifiers report their side, everything else is `Standard`. Mirrors the
+/// winit backend's location derivation so the two Windows wires agree.
+pub fn location_for_code(code: Code) -> Location {
+    match code {
+        Code::ShiftLeft | Code::ControlLeft | Code::AltLeft | Code::MetaLeft => Location::Left,
+        Code::ShiftRight | Code::ControlRight | Code::AltRight | Code::MetaRight => Location::Right,
+        Code::Numpad0
+        | Code::Numpad1
+        | Code::Numpad2
+        | Code::Numpad3
+        | Code::Numpad4
+        | Code::Numpad5
+        | Code::Numpad6
+        | Code::Numpad7
+        | Code::Numpad8
+        | Code::Numpad9
+        | Code::NumpadEnter
+        | Code::NumpadAdd
+        | Code::NumpadSubtract
+        | Code::NumpadMultiply
+        | Code::NumpadDivide
+        | Code::NumpadDecimal
+        | Code::NumpadComma
+        | Code::NumpadEqual
+        | Code::NumLock => Location::Numpad,
+        _ => Location::Standard,
+    }
+}
+
+/// Decode a keydown's `WM_CHAR` burst (the UTF-16 code units of every
+/// `WM_CHAR` `TranslateMessage` queued for it, in order) into typeable text.
+///
+/// Returns `None` — meaning "keep the virtual-key fallback" — when the burst
+/// is empty (no translation: arrows, F-keys, dead-key presses), is not valid
+/// UTF-16 (a stranded surrogate half), or contains any control character:
+/// Ctrl+letter chords translate to C0 codes (Ctrl+S → `0x13`), and Enter /
+/// Tab / Backspace / Escape translate to `\r` / `\t` / `0x08` / `0x1B`,
+/// none of which are text — the named-key or letter fallback is the right
+/// event for all of them.
+pub fn wm_char_text(units: &[u16]) -> Option<String> {
+    if units.is_empty() {
+        return None;
+    }
+    let text = String::from_utf16(units).ok()?;
+    if text.chars().any(char::is_control) {
+        return None;
+    }
+    Some(text)
+}
+
+/// The merge decision itself: translated `WM_CHAR` text wins over the
+/// case-folded virtual-key fallback; absent (or rejected) text keeps the
+/// fallback. This one line is why Shift+A types `A` while Ctrl+S still
+/// matches a `"s"` shortcut.
+pub fn merge_wm_char(fallback: Key, text: Option<String>) -> Key {
+    match text {
+        Some(text) => Key::Character(text),
+        None => fallback,
+    }
+}
+
+/// Fold one out-of-band `WM_CHAR` code unit (no owning keydown — Alt+numpad
+/// composition, or a directly-sent message) into at most one completed text.
+///
+/// Returns `(pending_high_surrogate, completed_text)`: a high surrogate is
+/// held for the low half that follows in the next message; everything else
+/// completes immediately, through the same typeability filter as
+/// [`wm_char_text`]. A malformed sequence (lone or mismatched half) yields
+/// neither state nor text.
+pub fn assemble_stray_wm_char(
+    pending_high: Option<u16>,
+    unit: u16,
+) -> (Option<u16>, Option<String>) {
+    if (0xD800..=0xDBFF).contains(&unit) {
+        // Start of a surrogate pair: hold it (a preceding unpaired high
+        // surrogate is malformed and dropped).
+        (Some(unit), None)
+    } else if (0xDC00..=0xDFFF).contains(&unit) {
+        match pending_high {
+            // Completion of a held pair.
+            Some(high) => (None, wm_char_text(&[high, unit])),
+            // A low half with nothing held is malformed.
+            None => (None, None),
+        }
+    } else {
+        // A plain BMP unit; any held high surrogate was left unpaired.
+        (None, wm_char_text(&[unit]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch(s: &str) -> Key {
+        Key::Character(s.into())
+    }
+
+    fn utf16(s: &str) -> Vec<u16> {
+        s.encode_utf16().collect()
+    }
+
+    /// The bug this module exists for: `vk_to_key` case-folds, so without
+    /// the WM_CHAR merge a shifted press is untypeable. The translated
+    /// character — whatever produced it (Shift, CapsLock, AltGr, a dead
+    /// key) — must win over the fallback.
+    #[test]
+    fn translated_wm_char_text_wins_over_the_case_folded_fallback() {
+        // Shift+A: keydown VK_A falls back to "a", WM_CHAR delivers "A".
+        assert_eq!(
+            merge_wm_char(vk_to_key(0x41, false), wm_char_text(&utf16("A"))),
+            ch("A")
+        );
+        // AltGr on a German layout: VK_Q's fallback is "q", WM_CHAR "@".
+        assert_eq!(
+            merge_wm_char(vk_to_key(0x51, false), wm_char_text(&utf16("@"))),
+            ch("@")
+        );
+        // Dead-key composition: the composed char rides the FOLLOWING
+        // keydown (VK_E), whose fallback is "e".
+        assert_eq!(
+            merge_wm_char(vk_to_key(0x45, false), wm_char_text(&utf16("é"))),
+            ch("é")
+        );
+    }
+
+    /// Ctrl chords translate to C0 control codes; treating those as text
+    /// would both type garbage and hide the letter from shortcut matching.
+    /// The burst is rejected wholesale and the fallback survives.
+    #[test]
+    fn control_character_bursts_keep_the_vk_fallback() {
+        // Ctrl+S delivers WM_CHAR 0x13.
+        assert_eq!(wm_char_text(&[0x13]), None);
+        assert_eq!(merge_wm_char(vk_to_key(0x53, false), None), ch("s"));
+        // Ctrl+Shift+S: same rejection, but the fallback respects shift.
+        assert_eq!(merge_wm_char(vk_to_key(0x53, true), None), ch("S"));
+        // Enter, Tab, Backspace, Escape all translate to control chars;
+        // their named keys must survive the merge.
+        for (unit, vk_code, key) in [
+            (0x0D_u16, 0x0D_u16, NamedKey::Enter),
+            (0x09, 0x09, NamedKey::Tab),
+            (0x08, 0x08, NamedKey::Backspace),
+            (0x1B, 0x1B, NamedKey::Escape),
+        ] {
+            assert_eq!(wm_char_text(&[unit]), None, "unit {unit:#x} is control");
+            assert_eq!(
+                merge_wm_char(vk_to_key(vk_code, false), wm_char_text(&[unit])),
+                Key::Named(key)
+            );
+        }
+        // Space is NOT a control character: it is real text.
+        assert_eq!(wm_char_text(&[0x20]).as_deref(), Some(" "));
+    }
+
+    /// Characters outside the BMP arrive as two WM_CHARs (a surrogate
+    /// pair); the drained burst must reassemble them, and a stranded half
+    /// must reject rather than panic or replace.
+    #[test]
+    fn surrogate_pairs_reassemble_and_stranded_halves_reject() {
+        assert_eq!(wm_char_text(&[0xD83D, 0xDE00]).as_deref(), Some("😀"));
+        assert_eq!(wm_char_text(&[0xD83D]), None);
+        assert_eq!(wm_char_text(&[]), None);
+    }
+
+    /// The out-of-band WM_CHAR path (Alt+numpad composition) assembles one
+    /// unit at a time across messages.
+    #[test]
+    fn stray_wm_chars_assemble_across_messages() {
+        // BMP character completes immediately.
+        assert_eq!(
+            assemble_stray_wm_char(None, 0x00FC),
+            (None, Some("ü".into()))
+        );
+        // Surrogate pair across two messages.
+        let (pending, none) = assemble_stray_wm_char(None, 0xD83D);
+        assert_eq!((pending, none), (Some(0xD83D), None));
+        assert_eq!(
+            assemble_stray_wm_char(pending, 0xDE00),
+            (None, Some("😀".into()))
+        );
+        // Control unit: rejected, no state kept.
+        assert_eq!(assemble_stray_wm_char(None, 0x0008), (None, None));
+        // Lone low half is malformed.
+        assert_eq!(assemble_stray_wm_char(None, 0xDE00), (None, None));
+        // A second high surrogate replaces an unpaired one.
+        assert_eq!(
+            assemble_stray_wm_char(Some(0xD83D), 0xD83E),
+            (Some(0xD83E), None)
+        );
+    }
+
+    /// The named-key half of the VK fallback table, including the keys the
+    /// winit backend names that this table used to drop to `Unidentified`.
+    #[test]
+    fn vk_fallback_names_the_standard_named_keys() {
+        for (vk_code, key) in [
+            (0x0D_u16, NamedKey::Enter),
+            (0x25, NamedKey::ArrowLeft),
+            (0x70, NamedKey::F1),
+            (0x7B, NamedKey::F12),
+            (0x14, NamedKey::CapsLock),
+            (0x90, NamedKey::NumLock),
+            (0x91, NamedKey::ScrollLock),
+            (0x2C, NamedKey::PrintScreen),
+            (0x13, NamedKey::Pause),
+            (0x5D, NamedKey::ContextMenu),
+            // The generic modifier VKs WM_KEYDOWN actually delivers.
+            (0x10, NamedKey::Shift),
+            (0x11, NamedKey::Control),
+            (0x12, NamedKey::Alt),
+            (0x5B, NamedKey::Meta),
+        ] {
+            assert_eq!(
+                vk_to_key(vk_code, false),
+                Key::Named(key),
+                "vk {vk_code:#x}"
+            );
+        }
+    }
+
+    /// The character half of the VK fallback table: numpad and US-layout
+    /// OEM punctuation no longer fall to `Unidentified`.
+    #[test]
+    fn vk_fallback_covers_numpad_and_oem_punctuation() {
+        assert_eq!(vk_to_key(0x60, false), ch("0")); // VK_NUMPAD0
+        assert_eq!(vk_to_key(0x69, false), ch("9")); // VK_NUMPAD9
+        assert_eq!(vk_to_key(0x6A, false), ch("*"));
+        assert_eq!(vk_to_key(0x6B, false), ch("+"));
+        assert_eq!(vk_to_key(0x6D, false), ch("-"));
+        assert_eq!(vk_to_key(0x6E, false), ch("."));
+        assert_eq!(vk_to_key(0x6F, false), ch("/"));
+        assert_eq!(vk_to_key(0xBA, false), ch(";")); // VK_OEM_1
+        assert_eq!(vk_to_key(0xBB, false), ch("="));
+        assert_eq!(vk_to_key(0xBC, false), ch(","));
+        assert_eq!(vk_to_key(0xBD, false), ch("-"));
+        assert_eq!(vk_to_key(0xBE, false), ch("."));
+        assert_eq!(vk_to_key(0xBF, false), ch("/"));
+        assert_eq!(vk_to_key(0xC0, false), ch("`"));
+        assert_eq!(vk_to_key(0xDB, false), ch("["));
+        assert_eq!(vk_to_key(0xDC, false), ch("\\"));
+        assert_eq!(vk_to_key(0xDD, false), ch("]"));
+        assert_eq!(vk_to_key(0xDE, false), ch("'"));
+        assert_eq!(vk_to_key(0xE2, false), ch("\\")); // VK_OEM_102
+        // Digits ignore shift (shifted values are layout-dependent).
+        assert_eq!(vk_to_key(0x31, true), ch("1"));
+    }
+
+    /// The scancode quirk keys, exactly as the W3C registry / winit /
+    /// Firefox agree on them: Pause is the NON-extended 0x45, NumLock the
+    /// EXTENDED 0x45, and PrintScreen has an Alt-variant make code.
+    #[test]
+    fn scancode_quirk_keys_resolve_correctly() {
+        assert_eq!(scancode_to_code(0x45, false), Code::Pause);
+        assert_eq!(scancode_to_code(0x45, true), Code::NumLock);
+        assert_eq!(scancode_to_code(0x46, true), Code::Pause); // Ctrl+Pause
+        assert_eq!(scancode_to_code(0x37, true), Code::PrintScreen);
+        assert_eq!(scancode_to_code(0x54, false), Code::PrintScreen); // Alt+PrtSc
+    }
+
+    /// The extended bit is what separates the editing/arrow cluster from
+    /// the numpad, and the right-hand modifiers from the left.
+    #[test]
+    fn extended_bit_separates_numpad_from_navigation() {
+        assert_eq!(scancode_to_code(0x1C, false), Code::Enter);
+        assert_eq!(scancode_to_code(0x1C, true), Code::NumpadEnter);
+        assert_eq!(scancode_to_code(0x35, false), Code::Slash);
+        assert_eq!(scancode_to_code(0x35, true), Code::NumpadDivide);
+        assert_eq!(scancode_to_code(0x48, false), Code::Numpad8);
+        assert_eq!(scancode_to_code(0x48, true), Code::ArrowUp);
+        assert_eq!(scancode_to_code(0x53, false), Code::NumpadDecimal);
+        assert_eq!(scancode_to_code(0x53, true), Code::Delete);
+        assert_eq!(scancode_to_code(0x1D, false), Code::ControlLeft);
+        assert_eq!(scancode_to_code(0x1D, true), Code::ControlRight);
+        assert_eq!(scancode_to_code(0x38, false), Code::AltLeft);
+        assert_eq!(scancode_to_code(0x38, true), Code::AltRight);
+    }
+
+    /// Everything the winit backend's `Code` table can produce, this table
+    /// produces from the corresponding Win32 scancode — the two Windows
+    /// wires must agree on physical-key identity.
+    #[test]
+    fn covers_every_code_the_winit_backend_produces() {
+        let winit_backend_codes: &[(u16, bool, Code)] = &[
+            (0x1E, false, Code::KeyA),
+            (0x30, false, Code::KeyB),
+            (0x2E, false, Code::KeyC),
+            (0x20, false, Code::KeyD),
+            (0x12, false, Code::KeyE),
+            (0x21, false, Code::KeyF),
+            (0x22, false, Code::KeyG),
+            (0x23, false, Code::KeyH),
+            (0x17, false, Code::KeyI),
+            (0x24, false, Code::KeyJ),
+            (0x25, false, Code::KeyK),
+            (0x26, false, Code::KeyL),
+            (0x32, false, Code::KeyM),
+            (0x31, false, Code::KeyN),
+            (0x18, false, Code::KeyO),
+            (0x19, false, Code::KeyP),
+            (0x10, false, Code::KeyQ),
+            (0x13, false, Code::KeyR),
+            (0x1F, false, Code::KeyS),
+            (0x14, false, Code::KeyT),
+            (0x16, false, Code::KeyU),
+            (0x2F, false, Code::KeyV),
+            (0x11, false, Code::KeyW),
+            (0x2D, false, Code::KeyX),
+            (0x15, false, Code::KeyY),
+            (0x2C, false, Code::KeyZ),
+            (0x0B, false, Code::Digit0),
+            (0x02, false, Code::Digit1),
+            (0x03, false, Code::Digit2),
+            (0x04, false, Code::Digit3),
+            (0x05, false, Code::Digit4),
+            (0x06, false, Code::Digit5),
+            (0x07, false, Code::Digit6),
+            (0x08, false, Code::Digit7),
+            (0x09, false, Code::Digit8),
+            (0x0A, false, Code::Digit9),
+            (0x1C, false, Code::Enter),
+            (0x01, false, Code::Escape),
+            (0x0E, false, Code::Backspace),
+            (0x0F, false, Code::Tab),
+            (0x39, false, Code::Space),
+            (0x2A, false, Code::ShiftLeft),
+            (0x36, false, Code::ShiftRight),
+            (0x1D, false, Code::ControlLeft),
+            (0x1D, true, Code::ControlRight),
+            (0x38, false, Code::AltLeft),
+            (0x38, true, Code::AltRight),
+            (0x5B, true, Code::MetaLeft),
+            (0x5C, true, Code::MetaRight),
+            (0x4B, true, Code::ArrowLeft),
+            (0x4D, true, Code::ArrowRight),
+            (0x48, true, Code::ArrowUp),
+            (0x50, true, Code::ArrowDown),
+            (0x47, true, Code::Home),
+            (0x4F, true, Code::End),
+            (0x49, true, Code::PageUp),
+            (0x51, true, Code::PageDown),
+            (0x52, true, Code::Insert),
+            (0x53, true, Code::Delete),
+            (0x3B, false, Code::F1),
+            (0x3C, false, Code::F2),
+            (0x3D, false, Code::F3),
+            (0x3E, false, Code::F4),
+            (0x3F, false, Code::F5),
+            (0x40, false, Code::F6),
+            (0x41, false, Code::F7),
+            (0x42, false, Code::F8),
+            (0x43, false, Code::F9),
+            (0x44, false, Code::F10),
+            (0x57, false, Code::F11),
+            (0x58, false, Code::F12),
+        ];
+        for &(scancode, extended, code) in winit_backend_codes {
+            assert_eq!(
+                scancode_to_code(scancode, extended),
+                code,
+                "scancode {scancode:#04x} extended={extended}"
+            );
+        }
+    }
+
+    #[test]
+    fn location_reports_numpad_and_sidedness() {
+        assert_eq!(location_for_code(Code::Numpad5), Location::Numpad);
+        assert_eq!(location_for_code(Code::NumpadEnter), Location::Numpad);
+        assert_eq!(location_for_code(Code::ShiftLeft), Location::Left);
+        assert_eq!(location_for_code(Code::ControlRight), Location::Right);
+        assert_eq!(location_for_code(Code::KeyA), Location::Standard);
+        assert_eq!(location_for_code(Code::Enter), Location::Standard);
+    }
+
+    /// The lParam bit layout: scancode in bits 16–23, extended flag bit 24,
+    /// repeat flag bit 30.
+    #[test]
+    fn key_lparam_fields_unpack() {
+        // VK_UP: scancode 0x48, extended, first press.
+        let lparam = (0x48_isize << 16) | (1 << 24);
+        assert_eq!(parse_key_lparam(lparam), (0x48, true, false));
+        // Held 'a': scancode 0x1E, not extended, repeat.
+        let lparam = (0x1E_isize << 16) | (1 << 30);
+        assert_eq!(parse_key_lparam(lparam), (0x1E, false, true));
+    }
+}

--- a/crates/flui-platform/src/shared/keys.rs
+++ b/crates/flui-platform/src/shared/keys.rs
@@ -453,6 +453,47 @@ pub fn merge_wm_char(fallback: Key, text: Option<String>) -> Key {
     }
 }
 
+/// The complete `key` decision for a Win32 keydown: the [`merge_wm_char`]
+/// merge, plus the Alt+numpad composition guard.
+///
+/// While Alt is held without Ctrl, a numpad-digit keydown that produced no
+/// `WM_CHAR` is a step of Windows' Alt+numpad character entry, not a
+/// keystroke of its own: the digits type nothing (their character arrives
+/// composed, as an out-of-band `WM_CHAR` on Alt release — see
+/// [`assemble_stray_wm_char`]), so surfacing the digit fallback would type
+/// `65` before Alt+65's `A`, and — because NumLock-off composition reports
+/// the navigation VKs on the same physical keys — surfacing a `Home`/arrow
+/// fallback would fire caret movement mid-composition. Such a keydown
+/// reports `Unidentified` instead. The guard is keyed on the physical
+/// numpad cluster (`Code::Numpad0..=Numpad9`), which is NumLock-invariant;
+/// Ctrl+Alt is excluded because that chord is AltGr, whose translated text
+/// arrives on the keydown itself and must keep winning.
+pub fn key_for_keydown(
+    fallback: Key,
+    text: Option<String>,
+    alt: bool,
+    ctrl: bool,
+    code: Code,
+) -> Key {
+    let numpad_digit = matches!(
+        code,
+        Code::Numpad0
+            | Code::Numpad1
+            | Code::Numpad2
+            | Code::Numpad3
+            | Code::Numpad4
+            | Code::Numpad5
+            | Code::Numpad6
+            | Code::Numpad7
+            | Code::Numpad8
+            | Code::Numpad9
+    );
+    if alt && !ctrl && text.is_none() && numpad_digit {
+        return Key::Named(NamedKey::Unidentified);
+    }
+    merge_wm_char(fallback, text)
+}
+
 /// Fold one out-of-band `WM_CHAR` code unit (no owning keydown — Alt+numpad
 /// composition, or a directly-sent message) into at most one completed text.
 ///
@@ -554,6 +595,49 @@ mod tests {
         assert_eq!(wm_char_text(&[0xD83D, 0xDE00]).as_deref(), Some("😀"));
         assert_eq!(wm_char_text(&[0xD83D]), None);
         assert_eq!(wm_char_text(&[]), None);
+    }
+
+    /// Alt+numpad character entry: while Alt (without Ctrl) is held, the
+    /// intermediate numpad keydowns are composition input, not keystrokes —
+    /// they produce no WM_CHAR of their own, and the composed character
+    /// arrives as an out-of-band WM_CHAR on Alt release. Letting the digit
+    /// fallbacks through would make Alt+6 5 type "65" into a text field
+    /// (and, with NumLock off, fire Home/End/arrow editing actions mid-
+    /// composition) before the composed character lands, so a numpad-
+    /// cluster keydown under plain Alt with no translated text must not
+    /// surface a typeable or editing key at all.
+    #[test]
+    fn alt_numpad_composition_steps_do_not_surface_keys() {
+        // NumLock on: VK_NUMPAD6, scancode 0x4D non-extended → Numpad6.
+        let fallback = vk_to_key(0x66, false); // VK_NUMPAD6 → "6"
+        assert_eq!(
+            key_for_keydown(fallback, None, true, false, Code::Numpad6),
+            Key::Named(NamedKey::Unidentified),
+            "an Alt+numpad digit with no translation is a composition step"
+        );
+        // NumLock off: the same physical key reports VK_HOME → Named(Home);
+        // Code is still Numpad7, and a Home fallback would move the caret.
+        assert_eq!(
+            key_for_keydown(Key::Named(NamedKey::Home), None, true, false, Code::Numpad7),
+            Key::Named(NamedKey::Unidentified),
+            "NumLock-off composition digits must not surface editing keys"
+        );
+        // AltGr (Ctrl+Alt) is NOT composition: translated text still wins.
+        assert_eq!(
+            key_for_keydown(ch("q"), Some("@".into()), true, true, Code::KeyQ),
+            ch("@")
+        );
+        // A numpad digit without Alt types normally.
+        assert_eq!(
+            key_for_keydown(ch("6"), Some("6".into()), false, false, Code::Numpad6),
+            ch("6")
+        );
+        // Alt over a NON-numpad key keeps its fallback (mnemonic/shortcut
+        // identity, same as the winit wire's logical_key).
+        assert_eq!(
+            key_for_keydown(ch("s"), None, true, false, Code::KeyS),
+            ch("s")
+        );
     }
 
     /// The out-of-band WM_CHAR path (Alt+numpad composition) assembles one

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -4,6 +4,7 @@
 //! duplication.
 
 mod handlers;
+pub mod keys;
 pub mod scroll;
 
 pub use handlers::{PlatformHandlers, WindowCallbacks};


### PR DESCRIPTION
## What

The Win32 keyboard wire had three of the four defects from the live-wire audit in #733:

- `vk_to_key` always lowercased, so `Key::Character` never carried a shifted/AltGr/dead-key character;
- `WM_CHAR` — the message that carries the fully-translated character — was discarded in `window_proc`;
- every keyboard event shipped `Code::Unidentified` and `Location::Standard` (the scancode was extracted and then ignored).

Together: shifted characters were untypeable through the Win32 wire, and physical-key identity (shortcut positions, numpad vs. navigation cluster) was invisible to consumers.

Part of #733 — the Win32 half; the macOS `Code::Unidentified` half and the winit `is_synthetic` bit are tracked in the same issue. Both live in files an open PR touches, so they are deliberately not in this diff.

## How

**The WM_CHAR pairing model (stated in `shared::keys`' module doc).** Win32 splits one keystroke across `WM_KEYDOWN` (key identity) and the `WM_CHAR` that `TranslateMessage` posts (translated character — shift, caps, AltGr, dead-key composition, surrogate-pair splitting). Because the message loop runs `TranslateMessage` *before* `DispatchMessageW`, the `WM_CHAR` burst for a keydown is already in the thread queue when `window_proc` sees the `WM_KEYDOWN` — so the keydown arm drains exactly `WM_CHAR` for its window synchronously (`PeekMessageW`/`PM_REMOVE`) and merges the text into the keydown's `key`, producing **one `KeyboardEvent` per physical press**. That pairing (merge, not a second event) is what FLUI's consumer contract requires: `EditableText` types from `Key::Character` on `KeyState::Down`, so a separate character event would double-type every key the fallback table already names. It is the same merge the winit Windows backend performs with its own queue peek (winit 0.30 `platform_impl/windows/keyboard.rs`).

Merge rules, each pinned by an executing test:
- translated text wins over the case-folded fallback (Shift+A → `"A"`, AltGr `@`, dead-key `é`);
- control-character bursts reject wholesale, so Ctrl+S still matches an `"s"` shortcut and Enter/Tab/Backspace/Escape keep their named keys;
- `WM_SYSCHAR` is deliberately left queued (Alt-mnemonics keep flowing to `DefWindowProcW`), `WM_DEADCHAR` is left to Windows;
- an out-of-band `WM_CHAR` with no owning keydown (Alt+numpad composition arrives via the Alt *keyup*'s translation) is assembled — surrogate halves parked in the window context across messages — and dispatched as its own key-down instead of being discarded.

**Table fills:**
- `scancode_to_code`: full Set-1 + extended (`E0`) table per the W3C uievents-code registry as implemented by winit/Firefox, including the quirk keys (`Pause` = non-extended `0x45` / `0xE046` under Ctrl; `NumLock` = *extended* `0x45`; `PrintScreen` = `0xE037` / `0x54` under Alt), the numpad/navigation split on the extended bit, F13–F24, and the browser/media block.
- `vk_to_key`: now shift-aware for letters (Ctrl+Shift+S reports `"S"`), and covers the named keys the winit backend names (CapsLock, NumLock, ScrollLock, PrintScreen, Pause, ContextMenu), the generic modifier VKs `WM_KEYDOWN` actually delivers (`VK_SHIFT`, not just `VK_LSHIFT`), the numpad, and US-layout OEM punctuation.
- `location_for_code`: numpad/left/right derivation, mirroring the winit backend so the two Windows wires agree.

## Evidence — what executes vs what is clippy-only

**Executes in CI (Linux):** everything decision-shaped, following the `shared::scroll` precedent — the new cfg-free `flui_platform::shared::keys` module holds the WM_CHAR merge (`wm_char_text`, `merge_wm_char`, `assemble_stray_wm_char`), both tables, the location derivation, and the lParam field split, with 11 tests covering the shifted/AltGr/dead-key merges, control-char rejection, surrogate reassembly (drained and stray paths), the quirk scancodes, the extended-bit splits, a winit-backend code-parity table, and the named/numpad/OEM VK fills. `cargo nextest run -p flui-platform keys`: 11/11 pass.

**Lint-only (no link, no tests — CI's `cross-typecheck` reality per `flui-platform/AGENTS.md`):** the Win32 message-loop plumbing — `window_proc`'s `WM_KEYDOWN` drain (`drain_translated_chars`) and stray-`WM_CHAR` arm, the `pending_high_surrogate` cell on `WindowContext`, and the `key_down_event`/`key_up_event`/`stray_char_event` assembly in `windows/events.rs`. Verified with the exact CI command: `cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings` exit 0. No live Windows keystroke was exercised — the pairing model rests on the documented `TranslateMessage`→`DispatchMessageW` ordering of this backend's own message loop plus the executing merge tests, not on-device verification.

**Gate:** `just ci` exit 0 (fmt, inventory, runtime-conformance, port-check, clippy, nextest, doctests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM