### PR TITLE
fix(platform,interaction): one pointer field contract on both wires

### DIFF
--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -1,5 +1,23 @@
 //! Event types for user interactions.
 //!
+//! # The pointer field contract (one contract, both wires)
+//!
+//! Every live translation and every synthetic constructor stamps the same
+//! values, so a recognizer developed against either wire meets the other
+//! unchanged:
+//!
+//! - `time` — **nanoseconds**, monotonic, process-start base (upstream
+//!   ui-events documents the unit; the base only has to agree per device).
+//! - `buttons` — the set held at the instant, transition included on Down /
+//!   excluded on Up; a Move with an empty set IS a hover.
+//! - `pressure` — `0.5` while any button/contact is active on hardware
+//!   without a pressure sensor (the W3C default), `0.0` otherwise; real
+//!   sensors (touch force, pen) report their normalized value.
+//! - `count` — click/tap count: `1` on Down/Up, `0` on motion, hover,
+//!   scroll and gesture states.
+//! - Events that arrive before any position is known are DROPPED at the
+//!   platform boundary, never delivered at a made-up origin.
+//!
 //! This module provides standardized event types following W3C specifications:
 //!
 //! - **Pointer events** - Mouse, touch, pen input via [`ui_events`]
@@ -592,7 +610,10 @@ pub fn make_down_event_for_id(
                 height: 1.0,
             },
             orientation: PointerOrientation::default(),
-            pressure: 1.0,
+            // The W3C default for active-button hardware with no pressure
+            // sensor — the value every live translation stamps; a synthetic
+            // 1.0 here let tests pass against a contract no real wire meets.
+            pressure: 0.5,
             tangential_pressure: 0.0,
             scale_factor: 1.0,
         },
@@ -683,7 +704,10 @@ pub fn make_move_event_for_id(
                 height: 1.0,
             },
             orientation: PointerOrientation::default(),
-            pressure: 1.0,
+            // The W3C default for active-button hardware with no pressure
+            // sensor — the value every live translation stamps; a synthetic
+            // 1.0 here let tests pass against a contract no real wire meets.
+            pressure: 0.5,
             tangential_pressure: 0.0,
             scale_factor: 1.0,
         },
@@ -760,7 +784,10 @@ pub fn make_down_event_for_id_with_button(
                 height: 1.0,
             },
             orientation: PointerOrientation::default(),
-            pressure: 1.0,
+            // The W3C default for active-button hardware with no pressure
+            // sensor — the value every live translation stamps; a synthetic
+            // 1.0 here let tests pass against a contract no real wire meets.
+            pressure: 0.5,
             tangential_pressure: 0.0,
             scale_factor: 1.0,
         },
@@ -854,7 +881,10 @@ pub fn make_move_event_with_button(
                 height: 1.0,
             },
             orientation: PointerOrientation::default(),
-            pressure: 1.0,
+            // The W3C default for active-button hardware with no pressure
+            // sensor — the value every live translation stamps; a synthetic
+            // 1.0 here let tests pass against a contract no real wire meets.
+            pressure: 0.5,
             tangential_pressure: 0.0,
             scale_factor: 1.0,
         },

--- a/crates/flui-platform/src/platforms/android/input.rs
+++ b/crates/flui-platform/src/platforms/android/input.rs
@@ -52,6 +52,7 @@ pub fn convert_motion_event(
                 scale_factor,
                 modifiers,
                 contact_buttons(),
+                1,
             );
 
             vec![PlatformInput::Pointer(PointerEvent::Down(
@@ -73,6 +74,7 @@ pub fn convert_motion_event(
                 scale_factor,
                 modifiers,
                 PointerButtons::default(),
+                1,
             );
 
             vec![PlatformInput::Pointer(PointerEvent::Up(
@@ -96,6 +98,7 @@ pub fn convert_motion_event(
                         scale_factor,
                         modifiers,
                         contact_buttons(),
+                        0,
                     );
 
                     PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
@@ -145,6 +148,7 @@ pub fn convert_motion_event(
                         scale_factor,
                         modifiers,
                         PointerButtons::default(),
+                        0,
                     );
 
                     PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
@@ -245,12 +249,16 @@ fn make_pointer_info(pointer: &android_activity::input::Pointer<'_>) -> PointerI
 /// Android does not report a button mask for touch, but its `MotionAction`
 /// already states the answer: the `Down`/`Move` actions are contact, the
 /// `Hover*` actions are not, and `Up` is the release itself.
+/// `count` is the W3C click/tap count — `1` on Down/Up transitions, `0`
+/// on motion and hover (the cross-wire contract in flui-interaction's
+/// module doc).
 fn make_pointer_state(
     pointer: &android_activity::input::Pointer<'_>,
     time_ns: u64,
     scale_factor: f64,
     modifiers: Modifiers,
     buttons: PointerButtons,
+    count: u8,
 ) -> PointerState {
     // Android reports coordinates in physical (device) pixels
     let x = pointer.x() as f64;
@@ -278,7 +286,7 @@ fn make_pointer_state(
         position: PhysicalPosition::new(x, y),
         buttons,
         modifiers,
-        count: 1,
+        count,
         contact_geometry: contact,
         orientation: PointerOrientation::default(),
         pressure,

--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -354,7 +354,16 @@ fn key_code_to_key(key_code: u16) -> Option<Key> {
 /// # Safety
 ///
 /// `ns_event` must be a valid, live `NSEvent*` of a mouse event.
-unsafe fn pointer_state(ns_event: id, scale_factor: f64, view_height: f64) -> PointerState {
+/// `count` is the W3C click count — `1` on Down/Up transitions, `0`
+/// elsewhere; `pressure` follows the sensor-less rule (`0.5` while any
+/// button is held per the live `pressedMouseButtons` state, `0.0`
+/// otherwise) — the cross-wire contract in flui-interaction's module doc.
+unsafe fn pointer_state(
+    ns_event: id,
+    scale_factor: f64,
+    view_height: f64,
+    count: u8,
+) -> PointerState {
     // SAFETY: caller guarantees `ns_event` is a valid NSEvent*;
     // `locationInWindow` is a plain NSPoint getter.
     unsafe {
@@ -363,16 +372,21 @@ unsafe fn pointer_state(ns_event: id, scale_factor: f64, view_height: f64) -> Po
         let location: NSPoint = msg_send![ns_event, locationInWindow];
         let modifiers = extract_modifiers(ns_event);
         let buttons = extract_mouse_buttons();
+        let pressure = if buttons == PointerButtons::default() {
+            0.0
+        } else {
+            0.5
+        };
 
         PointerState {
             time: event_timestamp_ns(),
             position: PhysicalPosition::new(location.x, view_height - location.y),
             buttons,
             modifiers,
-            count: 1,
+            count,
             contact_geometry: PhysicalSize::new(1.0, 1.0),
             orientation: PointerOrientation::default(),
-            pressure: 0.0,
+            pressure,
             tangential_pressure: 0.0,
             scale_factor,
         }
@@ -394,8 +408,10 @@ unsafe fn convert_mouse_button(
     // SAFETY: caller guarantees `ns_event` validity; forwarded to
     // `pointer_state` under the same contract.
     unsafe {
-        let mut state = pointer_state(ns_event, scale_factor, view_height);
-        state.pressure = if is_down { 0.5 } else { 0.0 };
+        // The held-set-derived pressure is already right for both edges:
+        // `pressedMouseButtons` includes the pressed button at Down and
+        // excludes it at Up.
+        let state = pointer_state(ns_event, scale_factor, view_height, 1);
 
         let button_event = PointerButtonEvent {
             pointer: primary_mouse_info(),
@@ -422,7 +438,7 @@ unsafe fn convert_mouse_move(ns_event: id, scale_factor: f64, view_height: f64) 
     // SAFETY: caller guarantees `ns_event` validity; forwarded to
     // `pointer_state` under the same contract.
     unsafe {
-        let state = pointer_state(ns_event, scale_factor, view_height);
+        let state = pointer_state(ns_event, scale_factor, view_height, 0);
 
         PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
             pointer: primary_mouse_info(),
@@ -451,7 +467,7 @@ unsafe fn convert_scroll_event(ns_event: id, scale_factor: f64, view_height: f64
     // SAFETY: caller guarantees `ns_event` validity; `scrollingDeltaX/Y` and
     // `hasPreciseScrollingDeltas` are documented NSEvent getters.
     unsafe {
-        let state = pointer_state(ns_event, scale_factor, view_height);
+        let state = pointer_state(ns_event, scale_factor, view_height, 0);
 
         let delta_x: f64 = msg_send![ns_event, scrollingDeltaX];
         let delta_y: f64 = msg_send![ns_event, scrollingDeltaY];
@@ -485,7 +501,7 @@ unsafe fn convert_gesture_event(
     gesture: ui_events::pointer::PointerGesture,
 ) -> PlatformInput {
     // SAFETY: forwarded caller guarantee.
-    let state = unsafe { pointer_state(ns_event, scale_factor, view_height) };
+    let state = unsafe { pointer_state(ns_event, scale_factor, view_height, 0) };
     PlatformInput::Pointer(PointerEvent::Gesture(
         ui_events::pointer::PointerGestureEvent {
             pointer: PointerInfo {

--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -45,10 +45,16 @@ use crate::traits::PlatformInput;
 /// Process-start epoch for monotonic event timestamps.
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
 
-/// Get monotonic timestamp in milliseconds since process start.
+/// Get monotonic timestamp in nanoseconds since process start.
 #[inline]
-fn event_timestamp_ms() -> u64 {
-    PROCESS_START.elapsed().as_millis() as u64
+fn event_timestamp_ns() -> u64 {
+    // Upstream ui-events documents PointerState.time as NANOSECONDS
+    // ("u64 nanoseconds real time"); a millisecond stamp here silently
+    // broke the unit for every consumer comparing across devices.
+    #[allow(clippy::cast_possible_truncation)] // ~584 years of nanoseconds fit u64
+    {
+        PROCESS_START.elapsed().as_nanos() as u64
+    }
 }
 
 /// Create a `PointerInfo` for the primary mouse pointer.
@@ -359,7 +365,7 @@ unsafe fn pointer_state(ns_event: id, scale_factor: f64, view_height: f64) -> Po
         let buttons = extract_mouse_buttons();
 
         PointerState {
-            time: event_timestamp_ms(),
+            time: event_timestamp_ns(),
             position: PhysicalPosition::new(location.x, view_height - location.y),
             buttons,
             modifiers,

--- a/crates/flui-platform/src/platforms/web/events.rs
+++ b/crates/flui-platform/src/platforms/web/events.rs
@@ -224,18 +224,22 @@ fn buttons_from_mask(mask: u16) -> ui_events::pointer::PointerButtons {
     buttons
 }
 
-fn make_pointer_state(pe: &web_sys::PointerEvent) -> ui_events::pointer::PointerState {
+/// `count` is the W3C click count — `1` on Down/Up, `0` on motion (the
+/// cross-wire contract in flui-interaction's module doc). `time` converts
+/// the DOM event's millisecond `timeStamp` (page-load base) to the
+/// contract's nanoseconds.
+fn make_pointer_state(pe: &web_sys::PointerEvent, count: u8) -> ui_events::pointer::PointerState {
     use dpi::{PhysicalPosition, PhysicalSize};
     use ui_events::pointer::{PointerOrientation, PointerState};
 
     let modifiers = extract_modifiers_from_mouse(pe);
 
     PointerState {
-        time: 0, // Browser doesn't expose nanosecond timestamps easily
+        time: (pe.time_stamp() * 1_000_000.0) as u64,
         position: PhysicalPosition::new(pe.offset_x() as f64, pe.offset_y() as f64),
         buttons: buttons_from_mask(pe.buttons()),
         modifiers,
-        count: 0,
+        count,
         contact_geometry: PhysicalSize::new(pe.width().max(1) as f64, pe.height().max(1) as f64),
         orientation: PointerOrientation::default(),
         pressure: pe.pressure(),
@@ -265,7 +269,7 @@ fn convert_pointer_down(pe: &web_sys::PointerEvent) -> PlatformInput {
     PlatformInput::Pointer(PointerEvent::Down(PointerButtonEvent {
         button: map_button(pe.button()),
         pointer: make_pointer_info(pe),
-        state: make_pointer_state(pe),
+        state: make_pointer_state(pe, 1),
     }))
 }
 
@@ -275,7 +279,7 @@ fn convert_pointer_up(pe: &web_sys::PointerEvent) -> PlatformInput {
     PlatformInput::Pointer(PointerEvent::Up(PointerButtonEvent {
         button: map_button(pe.button()),
         pointer: make_pointer_info(pe),
-        state: make_pointer_state(pe),
+        state: make_pointer_state(pe, 1),
     }))
 }
 
@@ -284,7 +288,7 @@ fn convert_pointer_move(pe: &web_sys::PointerEvent) -> PlatformInput {
 
     PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
         pointer: make_pointer_info(pe),
-        current: make_pointer_state(pe),
+        current: make_pointer_state(pe, 0),
         coalesced: Vec::new(),
         predicted: Vec::new(),
     }))
@@ -316,7 +320,7 @@ fn convert_wheel_event(we: &web_sys::WheelEvent) -> PlatformInput {
         },
         delta,
         state: PointerState {
-            time: 0,
+            time: (we.time_stamp() * 1_000_000.0) as u64,
             position: PhysicalPosition::new(we.offset_x() as f64, we.offset_y() as f64),
             buttons: buttons_from_mask(we.buttons()),
             modifiers,

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -233,6 +233,7 @@ fn pointer_state(
     scale_factor: f32,
     pressure: f32,
     buttons: PointerButtons,
+    count: u8,
 ) -> (PointerState, KeyboardModifiers) {
     pointer_state_at(
         get_x_lparam(lparam),
@@ -240,6 +241,7 @@ fn pointer_state(
         scale_factor,
         pressure,
         buttons,
+        count,
     )
 }
 
@@ -247,12 +249,15 @@ fn pointer_state(
 /// hand — for the wheel messages, whose `lParam` needs a screen-to-client
 /// conversion first (see [`wheel_pointer_state`]).
 #[inline]
+/// `count` is the W3C click count — `1` on Down/Up transitions, `0`
+/// elsewhere (the cross-wire contract in flui-interaction's module doc).
 fn pointer_state_at(
     x: i32,
     y: i32,
     scale_factor: f32,
     pressure: f32,
     buttons: PointerButtons,
+    count: u8,
 ) -> (PointerState, KeyboardModifiers) {
     // SAFETY: see `get_modifiers`'s own `# Safety` section — no
     // precondition to discharge here.
@@ -265,7 +270,7 @@ fn pointer_state_at(
         position: PhysicalPosition::new(logical_x as f64, logical_y as f64),
         buttons,
         modifiers,
-        count: 1,
+        count,
         contact_geometry: PhysicalSize::new(1.0, 1.0),
         orientation: PointerOrientation::default(),
         pressure,
@@ -288,6 +293,7 @@ pub fn mouse_button_event(
         scale_factor,
         if is_down { 0.5 } else { 0.0 },
         held_buttons(wparam),
+        1,
     );
 
     let _ = modifiers;
@@ -311,7 +317,15 @@ pub fn mouse_button_event(
 
 /// Convert WM_MOUSEMOVE to W3C PointerEvent
 pub fn mouse_move_event(wparam: WPARAM, lparam: LPARAM, scale_factor: f32) -> PlatformInput {
-    let (state, modifiers) = pointer_state(lparam, scale_factor, 0.0, held_buttons(wparam));
+    let held = held_buttons(wparam);
+    // Sensor-less pressure rule: 0.5 while any button is held (a drag),
+    // 0.0 on a hover.
+    let pressure = if held == PointerButtons::default() {
+        0.0
+    } else {
+        0.5
+    };
+    let (state, modifiers) = pointer_state(lparam, scale_factor, pressure, held, 0);
     let _ = modifiers;
 
     let event = PointerEvent::Move(PointerUpdate {
@@ -359,7 +373,7 @@ fn wheel_pointer_state(
             "ScreenToClient failed for a wheel message; scroll position stays in screen space"
         );
     }
-    pointer_state_at(point.x, point.y, scale_factor, 0.0, held_buttons(wparam))
+    pointer_state_at(point.x, point.y, scale_factor, 0.0, held_buttons(wparam), 0)
 }
 
 /// Convert WM_MOUSEWHEEL to W3C PointerEvent with Scroll

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -39,10 +39,16 @@ use crate::traits::{Key, PlatformInput, device_to_logical};
 /// Process-start epoch for monotonic event timestamps.
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
 
-/// Get monotonic timestamp in milliseconds since process start.
+/// Get monotonic timestamp in nanoseconds since process start.
 #[inline]
-fn event_timestamp_ms() -> u64 {
-    PROCESS_START.elapsed().as_millis() as u64
+fn event_timestamp_ns() -> u64 {
+    // Upstream ui-events documents PointerState.time as NANOSECONDS
+    // ("u64 nanoseconds real time"); a millisecond stamp here silently
+    // broke the unit for every consumer comparing across devices.
+    #[allow(clippy::cast_possible_truncation)] // ~584 years of nanoseconds fit u64
+    {
+        PROCESS_START.elapsed().as_nanos() as u64
+    }
 }
 
 /// Create a `PointerInfo` for the primary mouse pointer.
@@ -255,7 +261,7 @@ fn pointer_state_at(
     let logical_y = device_to_logical(y as f32, scale_factor);
 
     let state = PointerState {
-        time: event_timestamp_ms(),
+        time: event_timestamp_ns(),
         position: PhysicalPosition::new(logical_x as f64, logical_y as f64),
         buttons,
         modifiers,

--- a/crates/flui-platform/src/platforms/winit/events.rs
+++ b/crates/flui-platform/src/platforms/winit/events.rs
@@ -20,10 +20,16 @@ use crate::traits::PlatformInput;
 /// Process-start epoch for monotonic event timestamps.
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
 
-/// Get monotonic timestamp in milliseconds since process start.
+/// Get monotonic timestamp in nanoseconds since process start.
 #[inline]
-fn event_timestamp_ms() -> u64 {
-    PROCESS_START.elapsed().as_millis() as u64
+fn event_timestamp_ns() -> u64 {
+    // Upstream ui-events documents PointerState.time as NANOSECONDS
+    // ("u64 nanoseconds real time"); a millisecond stamp here silently
+    // broke the unit for every consumer comparing across devices.
+    #[allow(clippy::cast_possible_truncation)] // ~584 years of nanoseconds fit u64
+    {
+        PROCESS_START.elapsed().as_nanos() as u64
+    }
 }
 
 /// Create a `PointerInfo` for the primary mouse pointer.
@@ -44,22 +50,27 @@ fn primary_mouse_info() -> PointerInfo {
 /// the held set the same way). A move that always reports an empty set is
 /// classified as a hover, so an active pan never receives updates and
 /// drag-scrolling in a live window silently does nothing.
+/// `count` is the W3C click/tap count: `1` on Down/Up transitions, `0` on
+/// motion, hover, scroll and gesture states — the synthetic constructors
+/// stamp the same rule, so a recognizer reading it sees one contract on
+/// both wires.
 fn pointer_state(
     position: winit::dpi::PhysicalPosition<f64>,
     scale_factor: f64,
     pressure: f32,
     modifiers: KeyboardModifiers,
     buttons: PointerButtons,
+    count: u8,
 ) -> PointerState {
     let logical_x = position.x / scale_factor;
     let logical_y = position.y / scale_factor;
 
     PointerState {
-        time: event_timestamp_ms(),
+        time: event_timestamp_ns(),
         position: PhysicalPosition::new(logical_x, logical_y),
         buttons,
         modifiers,
-        count: 1,
+        count,
         contact_geometry: PhysicalSize::new(1.0, 1.0),
         orientation: PointerOrientation::default(),
         pressure,
@@ -163,7 +174,7 @@ pub fn cursor_moved_event(
     } else {
         0.5
     };
-    let state = pointer_state(position, scale_factor, pressure, modifiers, held_buttons);
+    let state = pointer_state(position, scale_factor, pressure, modifiers, held_buttons, 0);
 
     let event = PointerEvent::Move(PointerUpdate {
         pointer: primary_mouse_info(),
@@ -189,7 +200,7 @@ pub fn mouse_button_event(
     let is_down = state == ElementState::Pressed;
     let pointer_button = convert_mouse_button(button);
     let pressure = if is_down { 0.5 } else { 0.0 };
-    let pointer_state = pointer_state(position, scale_factor, pressure, modifiers, held_buttons);
+    let pointer_state = pointer_state(position, scale_factor, pressure, modifiers, held_buttons, 1);
 
     let event = if is_down {
         PointerEvent::Down(PointerButtonEvent {
@@ -247,6 +258,7 @@ pub fn touch_event(
                 contact_pressure,
                 modifiers,
                 contact_buttons,
+                1,
             ),
             button: Some(PointerButton::Primary),
         }),
@@ -258,6 +270,7 @@ pub fn touch_event(
                 contact_pressure,
                 modifiers,
                 contact_buttons,
+                0,
             ),
             coalesced: Vec::new(),
             predicted: Vec::new(),
@@ -270,6 +283,7 @@ pub fn touch_event(
                 0.0,
                 modifiers,
                 PointerButtons::default(),
+                1,
             ),
             button: Some(PointerButton::Primary),
         }),
@@ -321,6 +335,7 @@ pub fn trackpad_gesture_event(
             0.0,
             modifiers,
             PointerButtons::default(),
+            0,
         ),
     });
 
@@ -356,6 +371,7 @@ pub fn mouse_wheel_event(
         0.0,
         modifiers,
         PointerButtons::default(),
+        0,
     );
 
     let event = PointerEvent::Scroll(ui_events::pointer::PointerScrollEvent {
@@ -882,6 +898,64 @@ mod pointer_translation_tests {
             rotate.pointer.pointer_id, pinch.pointer.pointer_id,
             "one gesture stream, one identity"
         );
+    }
+
+    /// The cross-wire field contract (flui-interaction's module doc): time
+    /// in NANOSECONDS, pressure 0.5 while a button is held on sensor-less
+    /// hardware, click count 1 on transitions and 0 on motion/scroll.
+    #[test]
+    fn translated_events_meet_the_pointer_field_contract() {
+        let position = winit::dpi::PhysicalPosition::new(10.0, 10.0);
+        let held = PointerButtons::from(PointerButton::Primary);
+
+        // time: nanosecond scale — spin ~2ms of real time between two
+        // stamps; a millisecond stamp would show a delta of ~2, a
+        // nanosecond stamp ~2_000_000. (A bounded spin on Instant, not a
+        // pacing sleep: elapsed time IS the measured phenomenon here.)
+        let PlatformInput::Pointer(PointerEvent::Move(first)) = cursor_moved_event(
+            position,
+            1.0,
+            KeyboardModifiers::empty(),
+            PointerButtons::default(),
+        ) else {
+            panic!("expected Move");
+        };
+        let spin_start = Instant::now();
+        while spin_start.elapsed() < std::time::Duration::from_millis(2) {
+            std::hint::spin_loop();
+        }
+        let PlatformInput::Pointer(PointerEvent::Move(second)) = cursor_moved_event(
+            position,
+            1.0,
+            KeyboardModifiers::empty(),
+            PointerButtons::default(),
+        ) else {
+            panic!("expected Move");
+        };
+        let delta = second.current.time - first.current.time;
+        assert!(
+            delta >= 1_000_000,
+            "~2ms between stamps must read as ~2,000,000 time units — the \
+             contract is nanoseconds, and a millisecond stamp reads {delta}"
+        );
+
+        // pressure + count on a Down with a held button.
+        let PlatformInput::Pointer(PointerEvent::Down(down)) = mouse_button_event(
+            MouseButton::Left,
+            ElementState::Pressed,
+            position,
+            1.0,
+            KeyboardModifiers::empty(),
+            held,
+        ) else {
+            panic!("expected Down");
+        };
+        assert_eq!(down.state.pressure, 0.5, "W3C sensor-less held default");
+        assert_eq!(down.state.count, 1, "a Down is a click transition");
+
+        // A hover move carries neither.
+        assert_eq!(first.current.pressure, 0.0);
+        assert_eq!(first.current.count, 0, "motion is not a click");
     }
 }
 

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -1117,14 +1117,22 @@ impl ApplicationHandler for WinitApp {
                     }
                     (
                         s.current_modifiers,
-                        s.cursor_positions
-                            .get(&platform_id)
-                            .copied()
-                            .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                        s.cursor_positions.get(&platform_id).copied(),
                         held_pointer_buttons(&s.pressed_buttons),
                     )
                 });
 
+                // A click delivered before any CursorMoved has no tracked
+                // position; the old (0,0) stand-in actuated whatever widget
+                // sat in the top-left corner. No portable position query
+                // exists at this point — drop the event, traced.
+                let Some(cursor_pos) = cursor_pos else {
+                    tracing::debug!(
+                        ?platform_id,
+                        "dropping a mouse button event with no tracked cursor position"
+                    );
+                    return;
+                };
                 if let Some(ref win) = window {
                     let scale = win.scale_factor();
                     let input = winit_events::mouse_button_event(
@@ -1206,12 +1214,17 @@ impl ApplicationHandler for WinitApp {
                 let (modifiers, cursor_pos) = self.platform.with_state(|s| {
                     (
                         s.current_modifiers,
-                        s.cursor_positions
-                            .get(&platform_id)
-                            .copied()
-                            .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                        s.cursor_positions.get(&platform_id).copied(),
                     )
                 });
+                // Same untracked-position posture as the button arm above.
+                let Some(cursor_pos) = cursor_pos else {
+                    tracing::debug!(
+                        ?platform_id,
+                        "dropping a wheel event with no tracked cursor position"
+                    );
+                    return;
+                };
 
                 if let Some(ref win) = window {
                     let scale = win.scale_factor();

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -264,6 +264,11 @@ struct WinitPlatformState {
     /// contact tear down the other's sequence. Entries are removed on the
     /// terminal phases (Ended/Cancelled).
     touch_contacts: std::collections::HashMap<(winit::event::DeviceId, u64), u64>,
+    /// Buttons whose PRESS was dropped for lack of a tracked cursor
+    /// position: the matching release must be suppressed too, or consumers
+    /// receive an orphan Up (and, in between, moves that look like a drag
+    /// for a Down that never existed). Entries clear on the release.
+    suppressed_buttons: std::collections::HashSet<winit::event::MouseButton>,
     /// Next pointer id to hand a new touch contact. Starts past
     /// `PointerId::PRIMARY` (the mouse) and only grows — contact ids are
     /// never reused within a session, which keeps a late event for a dead
@@ -336,6 +341,7 @@ impl WinitPlatformState {
             current_modifiers: KeyboardModifiers::empty(),
             pressed_buttons: std::collections::HashSet::new(),
             touch_contacts: std::collections::HashMap::new(),
+            suppressed_buttons: std::collections::HashSet::new(),
             next_touch_pointer_id: 2,
         }
     }
@@ -1104,29 +1110,60 @@ impl ApplicationHandler for WinitApp {
                 }
             }
             WinitWindowEvent::MouseInput { state, button, .. } => {
-                let (modifiers, cursor_pos, held_buttons) = self.platform.with_state(|s| {
-                    // Track the RAW transition first: the emitted event's
-                    // `buttons` is the set held AFTER it (press included,
-                    // release excluded), per the W3C contract. Raw tracking
-                    // keeps aliased buttons (`Other(_)` normalizes onto
-                    // `Primary`) from clearing each other's bits.
-                    if state == winit::event::ElementState::Pressed {
-                        s.pressed_buttons.insert(button);
-                    } else {
-                        s.pressed_buttons.remove(&button);
-                    }
-                    (
-                        s.current_modifiers,
-                        s.cursor_positions.get(&platform_id).copied(),
-                        held_pointer_buttons(&s.pressed_buttons),
-                    )
-                });
+                let (modifiers, cursor_pos, held_buttons, suppressed) =
+                    self.platform.with_state(|s| {
+                        let cursor_pos = s.cursor_positions.get(&platform_id).copied();
+                        // A press with no tracked cursor position cannot be
+                        // delivered anywhere real (the old (0,0) stand-in
+                        // actuated the top-left widget) — suppress the WHOLE
+                        // sequence: the press never enters the held set, and
+                        // the matching release is swallowed below, so
+                        // consumers never see a drag or an orphan Up for a
+                        // Down that never existed.
+                        let suppressed = match state {
+                            winit::event::ElementState::Pressed => {
+                                if cursor_pos.is_none() {
+                                    s.suppressed_buttons.insert(button);
+                                    true
+                                } else {
+                                    // Track the RAW transition: the emitted
+                                    // event's `buttons` is the set held AFTER
+                                    // it, and raw tracking keeps aliased
+                                    // buttons from clearing each other's bits.
+                                    s.pressed_buttons.insert(button);
+                                    false
+                                }
+                            }
+                            winit::event::ElementState::Released => {
+                                if s.suppressed_buttons.remove(&button) {
+                                    true
+                                } else {
+                                    s.pressed_buttons.remove(&button);
+                                    false
+                                }
+                            }
+                        };
+                        (
+                            s.current_modifiers,
+                            cursor_pos,
+                            held_pointer_buttons(&s.pressed_buttons),
+                            suppressed,
+                        )
+                    });
 
-                // A click delivered before any CursorMoved has no tracked
-                // position; the old (0,0) stand-in actuated whatever widget
-                // sat in the top-left corner. No portable position query
-                // exists at this point — drop the event, traced.
+                if suppressed {
+                    tracing::debug!(
+                        ?platform_id,
+                        ?state,
+                        "suppressing a button event from an unpositioned press sequence"
+                    );
+                    return;
+                }
                 let Some(cursor_pos) = cursor_pos else {
+                    // A release whose press WAS delivered but whose position
+                    // tracking has since been lost (focus loss cleared it):
+                    // nothing sane to deliver at — drop, traced. The raw set
+                    // was already updated above.
                     tracing::debug!(
                         ?platform_id,
                         "dropping a mouse button event with no tracked cursor position"
@@ -1157,12 +1194,18 @@ impl ApplicationHandler for WinitApp {
                 let (modifiers, cursor_pos) = self.platform.with_state(|s| {
                     (
                         s.current_modifiers,
-                        s.cursor_positions
-                            .get(&platform_id)
-                            .copied()
-                            .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                        s.cursor_positions.get(&platform_id).copied(),
                     )
                 });
+                // Same no-made-up-origin contract as clicks and wheels: a
+                // gesture with no tracked cursor position is dropped.
+                let Some(cursor_pos) = cursor_pos else {
+                    tracing::debug!(
+                        ?platform_id,
+                        "dropping a trackpad gesture with no tracked cursor position"
+                    );
+                    return;
+                };
                 if let Some(ref win) = window {
                     let input = winit_events::trackpad_gesture_event(
                         gesture,
@@ -1177,12 +1220,18 @@ impl ApplicationHandler for WinitApp {
                 let (modifiers, cursor_pos) = self.platform.with_state(|s| {
                     (
                         s.current_modifiers,
-                        s.cursor_positions
-                            .get(&platform_id)
-                            .copied()
-                            .unwrap_or(winit::dpi::PhysicalPosition::new(0.0, 0.0)),
+                        s.cursor_positions.get(&platform_id).copied(),
                     )
                 });
+                // Same no-made-up-origin contract as clicks and wheels: a
+                // gesture with no tracked cursor position is dropped.
+                let Some(cursor_pos) = cursor_pos else {
+                    tracing::debug!(
+                        ?platform_id,
+                        "dropping a trackpad gesture with no tracked cursor position"
+                    );
+                    return;
+                };
                 if let Some(ref win) = window {
                     let input = winit_events::trackpad_gesture_event(
                         crate::shared::gestures::rotation_ccw_degrees(delta),


### PR DESCRIPTION
## What

Closes #731 (from the live-wire audit) — the synthetic constructors and live translations disagreed on every soft pointer field, the exact class that shipped the buttons-on-move bug.

## How

- **`time` is nanoseconds** (upstream ui-events' documented unit): winit, AppKit and Win32 stamped milliseconds — all three fixed (`event_timestamp_ns`); Android already stamped ns. Latent until now (the velocity tracker uses its own Instants), fixed before a consumer reads it.
- **`pressure`** follows W3C's sensor-less rule (0.5 held / 0.0 otherwise) — the live wire was right, the synthetic 1.0 wasn't; constructors aligned.
- **`count`** is the click/tap count — 1 on Down/Up, 0 on motion/hover/scroll/gesture — parameterized through the winit state builder (was hardcoded 1 everywhere).
- **No more (0,0) actuation**: a click/wheel arriving before any CursorMoved is dropped with a trace instead of hit-testing a made-up origin (`return` is the file's established arm posture; nothing follows the match).
- The contract is stated once in flui-interaction's module doc.

## Evidence

- `translated_events_meet_the_pointer_field_contract` pins ns-scale time (a ~2ms bounded spin must read ≥1,000,000 units — **red-verified** by reverting one stamp to ms), the 0.5/0.0 pressure rule, and the 1/0 count rule.
- Full flui-platform suite CI-style: 212/212; flui-interaction + flui-widgets: 2329 green after the synthetic pressure change (no test relied on the wrong 1.0). `just ci` green, log-verified (`JUST_CI_EXIT: 0`).
- Honest scope: the AppKit/Win32 ns fixes are clippy-covered like those backends' everything; the winit half carries the executing pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM