### PR TITLE
feat(widgets): InteractiveViewer consumes the pan-zoom lane — real pinch zoom

### DIFF
--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -894,6 +894,43 @@ pub fn make_move_event_with_button(
 }
 
 #[cfg(any(test, feature = "testing"))]
+/// Create a trackpad pinch `PointerEvent::Gesture` tick for testing — the
+/// shape the platform gesture producers emit (shared synthetic identity,
+/// touch-typed, per-tick magnification fraction).
+pub fn make_pinch_gesture_event(position: Offset<Pixels>, fraction: f32) -> PointerEvent {
+    use ui_events::pointer::{
+        ContactGeometry, PointerGesture, PointerGestureEvent, PointerOrientation, PointerState,
+    };
+
+    PointerEvent::Gesture(PointerGestureEvent {
+        pointer: PointerInfo {
+            pointer_id: PointerId::new(u64::MAX),
+            pointer_type: PointerType::Touch,
+            persistent_device_id: None,
+        },
+        gesture: PointerGesture::Pinch(fraction),
+        state: PointerState {
+            time: 0,
+            position: dpi::PhysicalPosition::new(
+                position.dx.get() as f64,
+                position.dy.get() as f64,
+            ),
+            buttons: PointerButtons::new(),
+            modifiers: Modifiers::empty(),
+            count: 0,
+            contact_geometry: ContactGeometry {
+                width: 1.0,
+                height: 1.0,
+            },
+            orientation: PointerOrientation::default(),
+            pressure: 0.0,
+            tangential_pressure: 0.0,
+            scale_factor: 1.0,
+        },
+    })
+}
+
+#[cfg(any(test, feature = "testing"))]
 /// Create a PointerEvent::Scroll for testing
 pub fn make_scroll_event(position: Offset<Pixels>, delta: Offset<Pixels>) -> PointerEvent {
     make_scroll_event_with_modifiers(position, delta, Modifiers::empty())

--- a/crates/flui-interaction/src/routing/hit_test.rs
+++ b/crates/flui-interaction/src/routing/hit_test.rs
@@ -792,6 +792,19 @@ pub(crate) fn transform_pointer_event(event: &PointerEvent, transform: &Matrix4)
                 delta: e.delta,
             })
         }
+        PointerEvent::Gesture(e) => {
+            // A gesture's focal point localizes exactly like a scroll's
+            // position — without this, a pinch consumer under any offset or
+            // transform scales around a window-global point and the content
+            // jumps instead of staying under the fingers.
+            let mut new_state = e.state.clone();
+            new_state.position = transform_position(e.state.position);
+            PointerEvent::Gesture(ui_events::pointer::PointerGestureEvent {
+                pointer: e.pointer,
+                gesture: e.gesture.clone(),
+                state: new_state,
+            })
+        }
         // Cancel, Enter, Leave don't have position - just clone
         other => other.clone(),
     }

--- a/crates/flui-widgets/src/interaction/interactive_viewer.rs
+++ b/crates/flui-widgets/src/interaction/interactive_viewer.rs
@@ -703,8 +703,81 @@ impl ViewState<InteractiveViewer> for InteractiveViewerState {
                 .on_pan_end(pan_end_details)
                 .child(clipped);
 
+            // -- Trackpad pinch (Listener::on_pointer_pan_zoom_update) ----
+            //
+            // The pan-zoom lane delivers per-tick updates whose `scale` is
+            // the tick's own factor (each converted gesture is a one-tick
+            // "cumulative" — see `convert_gesture`'s doc), so composing is
+            // a straight multiply per update, with the identical
+            // clamp-and-keep-the-focal-point-fixed steps the wheel branch
+            // uses. Ticks that change nothing (pure rotation, scale 1.0)
+            // fire the interaction callbacks and leave the transform alone.
+            let controller_pinch = controller.clone();
+            let anchor_pinch = anchor.clone();
+            let pipeline_cell_pinch = pipeline_cell.clone();
+            let on_start_pinch = on_start.clone();
+            let on_update_pinch = on_update.clone();
+            let on_end_pinch = on_end.clone();
+            let pan_zoom = move |event: &flui_interaction::PointerPanZoomEvent| {
+                let flui_interaction::PointerPanZoomEvent::Update {
+                    position, scale, ..
+                } = *event
+                else {
+                    return;
+                };
+                if let Some(callback) = &on_start_pinch {
+                    callback(InteractionStartDetails {
+                        focal_point: position,
+                        local_focal_point: position,
+                    });
+                }
+                #[allow(clippy::cast_possible_truncation)] // per-tick factors are near 1.0
+                let scale_change = scale as f32;
+                if scale_enabled
+                    && scale_change != 1.0
+                    && let Some((viewport, boundary)) = InteractiveViewerState::geometry(
+                        pipeline_cell_pinch.as_ref(),
+                        &anchor_pinch,
+                        boundary_margin,
+                    )
+                {
+                    let scene_before = controller_pinch.to_scene(position);
+                    let scaled = clamp_scale(
+                        controller_pinch.value(),
+                        scale_change,
+                        min_scale,
+                        max_scale,
+                        viewport,
+                        boundary,
+                    );
+                    controller_pinch.set_value(scaled);
+                    let scene_after = controller_pinch.to_scene(position);
+                    let correction = Offset::new(
+                        scene_after.dx - scene_before.dx,
+                        scene_after.dy - scene_before.dy,
+                    );
+                    let translated =
+                        clamp_translation(controller_pinch.value(), correction, viewport, boundary);
+                    controller_pinch.set_value(translated);
+                }
+                if let Some(callback) = &on_update_pinch {
+                    callback(InteractionUpdateDetails {
+                        focal_point: position,
+                        local_focal_point: position,
+                        scale: scale_change,
+                        focal_point_delta: Offset::ZERO,
+                    });
+                }
+                if let Some(callback) = &on_end_pinch {
+                    callback(InteractionEndDetails {
+                        velocity: Velocity::ZERO,
+                    });
+                }
+            };
+
             Listener::new()
                 .on_scroll_claim(scroll_claim)
+                .on_pointer_pan_zoom_update(pan_zoom)
                 .child(recognized)
         })
     }

--- a/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
+++ b/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
@@ -653,3 +653,42 @@ fn unmounting_the_widget_unsubscribes_from_an_external_controller() {
          forever, even though nothing is mounted against the controller anymore"
     );
 }
+
+/// A trackpad pinch tick — `PointerEvent::Gesture` through the real binding
+/// dispatch — scales the transform with the same focal-point correction the
+/// wheel path has. FLUI-added coverage: the gesture lane's producers landed
+/// after this port's V1 scoped pinch out; the lane delivers per-tick scale
+/// factors (each converted gesture is a one-tick cumulative), so two ticks
+/// compose multiplicatively.
+#[test]
+fn a_trackpad_pinch_tick_scales_the_transform() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .min_scale(0.01)
+        .max_scale(100.0)
+        .child(child());
+    let laid = lay_out(widget, loose(500.0));
+
+    let pinch_tick = |fraction: f32| {
+        flui_interaction::events::make_pinch_gesture_event(
+            Offset::new(px(100.0), px(100.0)),
+            fraction,
+        )
+    };
+
+    laid.dispatch_pointer_event(&pinch_tick(0.5));
+    let after_one = scale_of(controller.value());
+    assert!(
+        (after_one - 1.5).abs() < 1e-4,
+        "one +0.5 pinch tick scales by 1.5, got {after_one}"
+    );
+
+    laid.dispatch_pointer_event(&pinch_tick(0.5));
+    let after_two = scale_of(controller.value());
+    assert!(
+        (after_two - 2.25).abs() < 1e-3,
+        "ticks compose multiplicatively (1.5 * 1.5), got {after_two}"
+    );
+}

--- a/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
+++ b/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
@@ -671,14 +671,21 @@ fn a_trackpad_pinch_tick_scales_the_transform() {
         .child(child());
     let laid = lay_out(widget, loose(500.0));
 
-    let pinch_tick = |fraction: f32| {
-        flui_interaction::events::make_pinch_gesture_event(
-            Offset::new(px(100.0), px(100.0)),
-            fraction,
-        )
-    };
+    // Deliberately OFF-CENTER: a focal point at the viewport's center
+    // produces a zero correction by symmetry and would leave the
+    // keep-the-point-fixed half of the contract unasserted.
+    let focal = Offset::new(px(30.0), px(70.0));
+    let pinch_tick =
+        |fraction: f32| flui_interaction::events::make_pinch_gesture_event(focal, fraction);
 
+    let scene_before = controller.to_scene(focal);
     laid.dispatch_pointer_event(&pinch_tick(0.5));
+    let scene_after = controller.to_scene(focal);
+    assert!(
+        (scene_before.dx.get() - scene_after.dx.get()).abs() < 1e-3
+            && (scene_before.dy.get() - scene_after.dy.get()).abs() < 1e-3,
+        "an off-center pinch keeps its scene point fixed"
+    );
     let after_one = scale_of(controller.value());
     assert!(
         (after_one - 1.5).abs() < 1e-4,
@@ -690,5 +697,42 @@ fn a_trackpad_pinch_tick_scales_the_transform() {
     assert!(
         (after_two - 2.25).abs() < 1e-3,
         "ticks compose multiplicatively (1.5 * 1.5), got {after_two}"
+    );
+}
+
+/// A pinch over a viewer that does NOT sit at the window origin must keep
+/// the scene point under the fingers fixed — the routing layer localizes
+/// the gesture's focal position per hit entry exactly as it does for
+/// scrolls. Without that, the handler receives a window-global point and
+/// the content jumps on every tick.
+#[test]
+fn a_pinch_over_an_offset_viewer_keeps_the_focal_point_fixed() {
+    let controller = TransformationController::new();
+    // 100px of padding on every side puts the viewer's own origin at
+    // window (100, 100).
+    let widget = flui_widgets::Padding::all(100.0).child(
+        InteractiveViewer::new()
+            .controller(controller.clone())
+            .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+            .min_scale(0.01)
+            .max_scale(100.0)
+            .child(child()),
+    );
+    let laid = lay_out(widget, loose(500.0));
+
+    // Pinch at the viewer's LOCAL (50, 50) — window (150, 150). With
+    // correct localization the handler sees (50, 50), and after the zoom
+    // the same scene point maps back to that local position.
+    let scene_before = controller.to_scene(Offset::new(px(50.0), px(50.0)));
+    laid.dispatch_pointer_event(&flui_interaction::events::make_pinch_gesture_event(
+        Offset::new(px(150.0), px(150.0)),
+        0.5,
+    ));
+    let scene_after = controller.to_scene(Offset::new(px(50.0), px(50.0)));
+    assert!(
+        (scene_before.dx.get() - scene_after.dx.get()).abs() < 1e-3
+            && (scene_before.dy.get() - scene_after.dy.get()).abs() < 1e-3,
+        "the scene point under the fingers must stay fixed: before {scene_before:?}, \
+         after {scene_after:?}"
     );
 }


### PR DESCRIPTION
## What

Closes #769 — the pan-zoom lane became live end-to-end when the platform producers landed (#768), but `InteractiveViewer` still scaled from wheel ticks only.

## How

The viewer's listener adds `on_pointer_pan_zoom_update`: each update's `scale` is the tick's own factor (the conversion layer documents every gesture as a one-tick cumulative), so composition is a straight multiply through the exact clamp-scale + focal-point-correction steps the wheel branch uses. Interaction callbacks fire per tick, Flutter's shape; a no-op tick (pure rotation, scale 1.0) fires callbacks and leaves the transform alone. `make_pinch_gesture_event` joins the testing constructors with the producers' exact shape (shared synthetic identity, touch-typed).

## Evidence

- `a_trackpad_pinch_tick_scales_the_transform` drives synthetic `PointerEvent::Gesture` pinch ticks through the real binding dispatch: one +0.5 tick scales to 1.5, two compose to 2.25. **Red-verified** by removing the subscription (the test fails; wheel tests stay green).
- Full flui-widgets + flui-interaction suites: 2330 green. `just ci` green, log-verified (`JUST_CI_EXIT: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM