### PR TITLE
fix(platform): fill the AppKit keycode tables and drop winit's synthetic key events

### DIFF
--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -16,7 +16,9 @@
 //!
 //! # Key Mappings
 //!
-//! - NSEvent.characters / keyCode → keyboard_types::Key
+//! - NSEvent.characters / keyCode → keyboard_types::Key (named-key
+//!   intercepts and the physical-key `Code` table live in
+//!   `crate::shared::keys_macos`, where their tests execute on any host)
 //! - NSEventModifierFlags → keyboard_types::Modifiers
 //! - NSEventType → PointerEvent / KeyboardEvent
 //! - NSPoint → logical pixels (NSEvent coordinates are already logical;
@@ -33,7 +35,7 @@ use dpi::{PhysicalPosition, PhysicalSize};
 use keyboard_types::{Key, Modifiers, NamedKey};
 use objc::{class, msg_send, sel, sel_impl};
 use ui_events::{
-    keyboard::{Code, KeyState, KeyboardEvent, Location},
+    keyboard::{KeyState, KeyboardEvent},
     pointer::{
         PointerButton, PointerButtonEvent, PointerButtons, PointerEvent, PointerId, PointerInfo,
         PointerOrientation, PointerScrollEvent, PointerState, PointerType, PointerUpdate,
@@ -94,15 +96,17 @@ pub unsafe fn convert_ns_event(
         match event_type {
             // Keyboard events
             NSEventType::NSKeyDown => {
-                let key = extract_key(ns_event);
+                let key_code: u16 = msg_send![ns_event, keyCode];
+                let key = extract_key(ns_event, key_code);
+                let code = crate::shared::keys_macos::keycode_to_code(key_code);
                 let modifiers = extract_modifiers(ns_event);
                 let is_repeat: bool = msg_send![ns_event, isARepeat];
 
                 Some(PlatformInput::Keyboard(KeyboardEvent {
                     state: KeyState::Down,
                     key,
-                    code: Code::Unidentified,
-                    location: Location::Standard,
+                    code,
+                    location: crate::shared::keys::location_for_code(code),
                     modifiers,
                     repeat: is_repeat,
                     is_composing: false,
@@ -110,14 +114,16 @@ pub unsafe fn convert_ns_event(
             }
 
             NSEventType::NSKeyUp => {
-                let key = extract_key(ns_event);
+                let key_code: u16 = msg_send![ns_event, keyCode];
+                let key = extract_key(ns_event, key_code);
+                let code = crate::shared::keys_macos::keycode_to_code(key_code);
                 let modifiers = extract_modifiers(ns_event);
 
                 Some(PlatformInput::Keyboard(KeyboardEvent {
                     state: KeyState::Up,
                     key,
-                    code: Code::Unidentified,
-                    location: Location::Standard,
+                    code,
+                    location: crate::shared::keys::location_for_code(code),
                     modifiers,
                     repeat: false,
                     is_composing: false,
@@ -230,19 +236,22 @@ pub unsafe fn convert_ns_event(
 
 /// Extract key from NSEvent
 ///
-/// Uses NSEvent.keyCode for special keys, NSEvent.characters otherwise
+/// The shared named-key table (`shared::keys_macos`) intercepts keys whose
+/// `NSEvent.characters` are control characters or private-use-area
+/// codepoints; everything else types through `characters`, the layout- and
+/// modifier-aware translation.
 ///
 /// # Safety
 ///
-/// `ns_event` must be a valid, live `NSEvent*` of a keyboard event.
-unsafe fn extract_key(ns_event: id) -> Key {
+/// `ns_event` must be a valid, live `NSEvent*` of a keyboard event, and
+/// `key_code` must be its `keyCode`.
+unsafe fn extract_key(ns_event: id, key_code: u16) -> Key {
     // SAFETY: caller guarantees `ns_event` is a valid NSEvent*; `characters`
     // returns an autoreleased NSString whose UTF8String buffer is valid while
     // the event is alive (we copy it into an owned String before returning).
     unsafe {
         // Check for special keys via key code first
-        let key_code: u16 = msg_send![ns_event, keyCode];
-        if let Some(special_key) = key_code_to_key(key_code) {
+        if let Some(special_key) = crate::shared::keys_macos::keycode_to_key(key_code) {
             return special_key;
         }
 
@@ -299,50 +308,6 @@ unsafe fn extract_modifiers(ns_event: id) -> Modifiers {
 
         modifiers
     }
-}
-
-/// Convert macOS key code to Key
-///
-/// Reference: https://developer.apple.com/documentation/appkit/nsevent/1534513-keycode
-fn key_code_to_key(key_code: u16) -> Option<Key> {
-    let named = match key_code {
-        // Arrow keys
-        123 => NamedKey::ArrowLeft,
-        124 => NamedKey::ArrowRight,
-        125 => NamedKey::ArrowDown,
-        126 => NamedKey::ArrowUp,
-
-        // Function keys
-        122 => NamedKey::F1,
-        120 => NamedKey::F2,
-        99 => NamedKey::F3,
-        118 => NamedKey::F4,
-        96 => NamedKey::F5,
-        97 => NamedKey::F6,
-        98 => NamedKey::F7,
-        100 => NamedKey::F8,
-        101 => NamedKey::F9,
-        109 => NamedKey::F10,
-        103 => NamedKey::F11,
-        111 => NamedKey::F12,
-
-        // Special keys
-        36 => NamedKey::Enter,
-        48 => NamedKey::Tab,
-        51 => NamedKey::Backspace,
-        53 => NamedKey::Escape,
-        117 => NamedKey::Delete,
-        115 => NamedKey::Home,
-        119 => NamedKey::End,
-        116 => NamedKey::PageUp,
-        121 => NamedKey::PageDown,
-
-        // Space
-        49 => return Some(Key::Character(" ".to_string())),
-
-        _ => return None,
-    };
-    Some(Key::Named(named))
 }
 
 // ============================================================================
@@ -545,39 +510,5 @@ unsafe fn extract_mouse_buttons() -> PointerButtons {
         }
 
         buttons
-    }
-}
-
-// ============================================================================
-// Tests
-// ============================================================================
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_key_code_mappings() {
-        // Arrow keys
-        assert_eq!(key_code_to_key(123), Some(Key::Named(NamedKey::ArrowLeft)));
-        assert_eq!(key_code_to_key(124), Some(Key::Named(NamedKey::ArrowRight)));
-        assert_eq!(key_code_to_key(125), Some(Key::Named(NamedKey::ArrowDown)));
-        assert_eq!(key_code_to_key(126), Some(Key::Named(NamedKey::ArrowUp)));
-
-        // Function keys
-        assert_eq!(key_code_to_key(122), Some(Key::Named(NamedKey::F1)));
-        assert_eq!(key_code_to_key(111), Some(Key::Named(NamedKey::F12)));
-
-        // Special keys
-        assert_eq!(key_code_to_key(36), Some(Key::Named(NamedKey::Enter)));
-        assert_eq!(key_code_to_key(48), Some(Key::Named(NamedKey::Tab)));
-        assert_eq!(key_code_to_key(51), Some(Key::Named(NamedKey::Backspace)));
-        assert_eq!(key_code_to_key(53), Some(Key::Named(NamedKey::Escape)));
-
-        // Space maps to a character key
-        assert_eq!(key_code_to_key(49), Some(Key::Character(" ".to_string())));
-
-        // Unknown key
-        assert_eq!(key_code_to_key(999), None);
     }
 }

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -1282,7 +1282,35 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_input(input);
                 }
             }
-            WinitWindowEvent::KeyboardInput { event, .. } => {
+            WinitWindowEvent::KeyboardInput {
+                event,
+                is_synthetic,
+                ..
+            } => {
+                // winit synthesizes press events for every key held when a
+                // window gains focus, and release events for every key held
+                // when it loses focus (X11 and Windows only — the
+                // `is_synthetic` doc in winit 0.30 `src/event.rs`). Those
+                // are keyboard-state synchronization, not user keystrokes,
+                // and FLUI keeps no per-key pressed-set to synchronize:
+                // modifier state rides `ModifiersChanged` (which winit
+                // emits on focus change in its own right), while every key
+                // consumer — `EditableText` typing, `Shortcuts`, focus
+                // traversal — actuates on `KeyState::Down`, so dispatching
+                // a synthetic press would re-type and re-trigger every held
+                // key each time the window regains focus. Flutter draws
+                // the same line: state-sync events are flagged
+                // `synthesized` and are not treated as the user's direct
+                // action (`hardware_keyboard.dart`). Dropped wholesale; if
+                // a pressed-set registry ever appears, these events become
+                // its sync feed and must be routed there instead.
+                if is_synthetic {
+                    tracing::trace!(
+                        ?event,
+                        "dropping synthetic key event (focus-change state sync)"
+                    );
+                    return;
+                }
                 let modifiers = self.platform.with_state(|s| s.current_modifiers);
 
                 if let Some(ref win) = window {

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -1290,24 +1290,38 @@ impl ApplicationHandler for WinitApp {
                 // winit synthesizes press events for every key held when a
                 // window gains focus, and release events for every key held
                 // when it loses focus (X11 and Windows only — the
-                // `is_synthetic` doc in winit 0.30 `src/event.rs`). Those
-                // are keyboard-state synchronization, not user keystrokes,
-                // and FLUI keeps no per-key pressed-set to synchronize:
-                // modifier state rides `ModifiersChanged` (which winit
-                // emits on focus change in its own right), while every key
-                // consumer — `EditableText` typing, `Shortcuts`, focus
-                // traversal — actuates on `KeyState::Down`, so dispatching
-                // a synthetic press would re-type and re-trigger every held
-                // key each time the window regains focus. Flutter draws
-                // the same line: state-sync events are flagged
-                // `synthesized` and are not treated as the user's direct
-                // action (`hardware_keyboard.dart`). Dropped wholesale; if
-                // a pressed-set registry ever appears, these events become
-                // its sync feed and must be routed there instead.
-                if is_synthetic {
+                // `is_synthetic` doc in winit 0.30 `src/event.rs`). Both are
+                // keyboard-state synchronization, not user keystrokes, but
+                // they get opposite treatment:
+                //
+                // - Synthetic PRESSES are dropped. Every framework key
+                //   consumer — `EditableText` typing, `Shortcuts`, focus
+                //   traversal — actuates on `KeyState::Down`, so dispatching
+                //   one would re-type and re-trigger every held key each
+                //   time the window regains focus; and no consumer needs
+                //   the press for state (modifier state rides
+                //   `ModifiersChanged`, which winit emits on focus change
+                //   in its own right).
+                // - Synthetic RELEASES are dispatched. When the physical
+                //   release happens while the window is unfocused, this
+                //   synthetic release is the ONLY key-up the window will
+                //   ever receive — an app-level `Focus::on_key_event`
+                //   handler latching a key on Down (held-key movement, a
+                //   push-to-talk toggle) would otherwise stay stuck after
+                //   an Alt-Tab. A stray Up is inert to every Down-actuated
+                //   consumer.
+                //
+                // Flutter draws the same line, from the other side: its
+                // embedders deliver state-sync as `synthesized` events that
+                // update key state without being treated as the user's
+                // direct action (`hardware_keyboard.dart`). FLUI's
+                // `KeyboardEvent` carries no such flag, so the press half —
+                // which WOULD actuate — cannot be forwarded safely and is
+                // dropped instead.
+                if is_synthetic && event.state == winit::event::ElementState::Pressed {
                     tracing::trace!(
                         ?event,
-                        "dropping synthetic key event (focus-change state sync)"
+                        "dropping synthetic key press (focus-change state sync)"
                     );
                     return;
                 }

--- a/crates/flui-platform/src/shared/keys.rs
+++ b/crates/flui-platform/src/shared/keys.rs
@@ -393,7 +393,9 @@ pub fn scancode_to_code(scancode: u16, extended: bool) -> Code {
 
 /// The W3C `location` a `code` implies: numpad keys report `Numpad`, sided
 /// modifiers report their side, everything else is `Standard`. Mirrors the
-/// winit backend's location derivation so the two Windows wires agree.
+/// winit backend's location derivation so the native wires (this module's
+/// Win32 caller, and the AppKit caller via [`super::keys_macos`]) agree
+/// with the fallback wire.
 pub fn location_for_code(code: Code) -> Location {
     match code {
         Code::ShiftLeft | Code::ControlLeft | Code::AltLeft | Code::MetaLeft => Location::Left,

--- a/crates/flui-platform/src/shared/keys_macos.rs
+++ b/crates/flui-platform/src/shared/keys_macos.rs
@@ -1,0 +1,765 @@
+//! macOS (AppKit) keyboard translation decisions.
+//!
+//! Everything the AppKit backend decides about a keystroke from its virtual
+//! keycode — which W3C `code` names the physical key, and which named `Key`
+//! intercepts the `NSEvent.characters` text path — lives here as pure
+//! functions over the raw `NSEvent.keyCode` value.
+//!
+//! Like [`super::keys`] (the Win32 twin this module's shape follows), it is
+//! deliberately free of `cfg` gates and platform types so the tables compile
+//! — and their tests execute — on any host, even though the AppKit caller
+//! (`platforms/macos/events.rs`) itself is only ever clippy-linted in CI,
+//! never linked or run.
+//!
+//! # References
+//!
+//! macOS virtual keycodes are position-based (they name the physical key,
+//! not the character it types) and are defined once, as the `kVK_*` constants
+//! in Apple's Carbon `HIToolbox/Events.h` — still the canonical source; the
+//! [`kvk`] module transcribes it. The `Code` each keycode maps to follows the
+//! W3C uievents-code registry (<https://www.w3.org/TR/uievents-code/>) as
+//! implemented by Firefox (`NativeKeyToDOMCodeName.h`, the `CODE_MAP_MAC`
+//! rows) and the winit macOS backend (winit 0.30
+//! `platform_impl/macos/event.rs`, `scancode_to_physicalkey`). Where those
+//! two disagree the table follows Apple's header and Firefox, and the
+//! divergence is commented at the arm — see
+//! `follows_apples_header_where_the_winit_table_drifts` in the tests.
+//!
+//! # What never reaches these tables
+//!
+//! AppKit reports modifier keys through `flagsChanged:`, not
+//! `keyDown:`/`keyUp:` — the modifier rows below (`kVK_Shift` …
+//! `kVK_Function`) are complete for the table's own sake, but the backend
+//! does not receive plain key events for them, and it does not translate
+//! `flagsChanged:` today; modifier *state* rides every event's
+//! `modifierFlags` instead.
+
+use keyboard_types::{Code, Key, NamedKey};
+
+/// Apple's `kVK_*` virtual keycodes, from Carbon `HIToolbox/Events.h`.
+///
+/// `ANSI_*` names mean "the key in this position on a US (ANSI) keyboard" —
+/// the keycode itself is layout-independent. Raw `u16` (the width of
+/// `NSEvent.keyCode`) rather than a binding crate's type so this module
+/// compiles on every host.
+#[allow(missing_docs)]
+pub mod kvk {
+    pub const ANSI_A: u16 = 0x00;
+    pub const ANSI_S: u16 = 0x01;
+    pub const ANSI_D: u16 = 0x02;
+    pub const ANSI_F: u16 = 0x03;
+    pub const ANSI_H: u16 = 0x04;
+    pub const ANSI_G: u16 = 0x05;
+    pub const ANSI_Z: u16 = 0x06;
+    pub const ANSI_X: u16 = 0x07;
+    pub const ANSI_C: u16 = 0x08;
+    pub const ANSI_V: u16 = 0x09;
+    pub const ISO_SECTION: u16 = 0x0A;
+    pub const ANSI_B: u16 = 0x0B;
+    pub const ANSI_Q: u16 = 0x0C;
+    pub const ANSI_W: u16 = 0x0D;
+    pub const ANSI_E: u16 = 0x0E;
+    pub const ANSI_R: u16 = 0x0F;
+    pub const ANSI_Y: u16 = 0x10;
+    pub const ANSI_T: u16 = 0x11;
+    pub const ANSI_1: u16 = 0x12;
+    pub const ANSI_2: u16 = 0x13;
+    pub const ANSI_3: u16 = 0x14;
+    pub const ANSI_4: u16 = 0x15;
+    pub const ANSI_6: u16 = 0x16;
+    pub const ANSI_5: u16 = 0x17;
+    pub const ANSI_EQUAL: u16 = 0x18;
+    pub const ANSI_9: u16 = 0x19;
+    pub const ANSI_7: u16 = 0x1A;
+    pub const ANSI_MINUS: u16 = 0x1B;
+    pub const ANSI_8: u16 = 0x1C;
+    pub const ANSI_0: u16 = 0x1D;
+    pub const ANSI_RIGHT_BRACKET: u16 = 0x1E;
+    pub const ANSI_O: u16 = 0x1F;
+    pub const ANSI_U: u16 = 0x20;
+    pub const ANSI_LEFT_BRACKET: u16 = 0x21;
+    pub const ANSI_I: u16 = 0x22;
+    pub const ANSI_P: u16 = 0x23;
+    pub const RETURN: u16 = 0x24;
+    pub const ANSI_L: u16 = 0x25;
+    pub const ANSI_J: u16 = 0x26;
+    pub const ANSI_QUOTE: u16 = 0x27;
+    pub const ANSI_K: u16 = 0x28;
+    pub const ANSI_SEMICOLON: u16 = 0x29;
+    pub const ANSI_BACKSLASH: u16 = 0x2A;
+    pub const ANSI_COMMA: u16 = 0x2B;
+    pub const ANSI_SLASH: u16 = 0x2C;
+    pub const ANSI_N: u16 = 0x2D;
+    pub const ANSI_M: u16 = 0x2E;
+    pub const ANSI_PERIOD: u16 = 0x2F;
+    pub const TAB: u16 = 0x30;
+    pub const SPACE: u16 = 0x31;
+    pub const ANSI_GRAVE: u16 = 0x32;
+    /// `kVK_Delete` is the key labeled "delete" on Apple keyboards — the
+    /// BACKSPACE position; forward delete is [`FORWARD_DELETE`].
+    pub const DELETE: u16 = 0x33;
+    pub const ESCAPE: u16 = 0x35;
+    pub const RIGHT_COMMAND: u16 = 0x36;
+    pub const COMMAND: u16 = 0x37;
+    pub const SHIFT: u16 = 0x38;
+    pub const CAPS_LOCK: u16 = 0x39;
+    pub const OPTION: u16 = 0x3A;
+    pub const CONTROL: u16 = 0x3B;
+    pub const RIGHT_SHIFT: u16 = 0x3C;
+    pub const RIGHT_OPTION: u16 = 0x3D;
+    pub const RIGHT_CONTROL: u16 = 0x3E;
+    pub const FUNCTION: u16 = 0x3F;
+    pub const F17: u16 = 0x40;
+    pub const ANSI_KEYPAD_DECIMAL: u16 = 0x41;
+    pub const ANSI_KEYPAD_MULTIPLY: u16 = 0x43;
+    pub const ANSI_KEYPAD_PLUS: u16 = 0x45;
+    /// The numpad "clear" key — the NumLock position of a PC numpad.
+    pub const ANSI_KEYPAD_CLEAR: u16 = 0x47;
+    pub const VOLUME_UP: u16 = 0x48;
+    pub const VOLUME_DOWN: u16 = 0x49;
+    pub const MUTE: u16 = 0x4A;
+    pub const ANSI_KEYPAD_DIVIDE: u16 = 0x4B;
+    pub const ANSI_KEYPAD_ENTER: u16 = 0x4C;
+    pub const ANSI_KEYPAD_MINUS: u16 = 0x4E;
+    pub const F18: u16 = 0x4F;
+    pub const F19: u16 = 0x50;
+    pub const ANSI_KEYPAD_EQUALS: u16 = 0x51;
+    pub const ANSI_KEYPAD_0: u16 = 0x52;
+    pub const ANSI_KEYPAD_1: u16 = 0x53;
+    pub const ANSI_KEYPAD_2: u16 = 0x54;
+    pub const ANSI_KEYPAD_3: u16 = 0x55;
+    pub const ANSI_KEYPAD_4: u16 = 0x56;
+    pub const ANSI_KEYPAD_5: u16 = 0x57;
+    pub const ANSI_KEYPAD_6: u16 = 0x58;
+    pub const ANSI_KEYPAD_7: u16 = 0x59;
+    pub const F20: u16 = 0x5A;
+    pub const ANSI_KEYPAD_8: u16 = 0x5B;
+    pub const ANSI_KEYPAD_9: u16 = 0x5C;
+    pub const JIS_YEN: u16 = 0x5D;
+    pub const JIS_UNDERSCORE: u16 = 0x5E;
+    pub const JIS_KEYPAD_COMMA: u16 = 0x5F;
+    pub const F5: u16 = 0x60;
+    pub const F6: u16 = 0x61;
+    pub const F7: u16 = 0x62;
+    pub const F3: u16 = 0x63;
+    pub const F8: u16 = 0x64;
+    pub const F9: u16 = 0x65;
+    pub const JIS_EISU: u16 = 0x66;
+    pub const F11: u16 = 0x67;
+    pub const JIS_KANA: u16 = 0x68;
+    pub const F13: u16 = 0x69;
+    pub const F16: u16 = 0x6A;
+    pub const F14: u16 = 0x6B;
+    pub const F10: u16 = 0x6D;
+    /// The PC-keyboard Menu key. `Events.h` defines no constant for `0x6E`;
+    /// Firefox and Chromium both map it to `ContextMenu`.
+    pub const PC_MENU: u16 = 0x6E;
+    pub const F12: u16 = 0x6F;
+    pub const F15: u16 = 0x71;
+    /// The Help key on Apple pro keyboards — the Insert position of a PC
+    /// keyboard, and `Insert` is what the winit backend and Chromium call
+    /// it (Firefox says `Help`); this table sides with the winit wire so
+    /// FLUI's two macOS backends agree.
+    pub const HELP: u16 = 0x72;
+    pub const HOME: u16 = 0x73;
+    pub const PAGE_UP: u16 = 0x74;
+    pub const FORWARD_DELETE: u16 = 0x75;
+    pub const F4: u16 = 0x76;
+    pub const END: u16 = 0x77;
+    pub const F2: u16 = 0x78;
+    pub const PAGE_DOWN: u16 = 0x79;
+    pub const F1: u16 = 0x7A;
+    pub const LEFT_ARROW: u16 = 0x7B;
+    pub const RIGHT_ARROW: u16 = 0x7C;
+    pub const DOWN_ARROW: u16 = 0x7D;
+    pub const UP_ARROW: u16 = 0x7E;
+}
+
+/// Map an `NSEvent.keyCode` (a `kVK_*` virtual keycode) to the W3C `code`
+/// value naming the physical key.
+///
+/// Two arms deliberately diverge from the winit macOS backend's table, both
+/// toward Apple's `Events.h` and Firefox:
+///
+/// - **Volume keys.** `Events.h` says `kVK_VolumeUp`/`Down`/`Mute` are
+///   `0x48`/`0x49`/`0x4A`; winit maps `0x49 → VolumeUp` and `0x4A →
+///   VolumeDown` (dropping Mute), one code off, with a `TODO` in its own
+///   source questioning the choice.
+/// - **The ISO section key** (`0x0A`, between Left Shift and Z on ISO
+///   boards). The registry and Firefox name that position `IntlBackslash`;
+///   winit maps it to `Backquote` because German QWERTZ prints `^` there.
+pub fn keycode_to_code(key_code: u16) -> Code {
+    match key_code {
+        kvk::ANSI_A => Code::KeyA,
+        kvk::ANSI_S => Code::KeyS,
+        kvk::ANSI_D => Code::KeyD,
+        kvk::ANSI_F => Code::KeyF,
+        kvk::ANSI_H => Code::KeyH,
+        kvk::ANSI_G => Code::KeyG,
+        kvk::ANSI_Z => Code::KeyZ,
+        kvk::ANSI_X => Code::KeyX,
+        kvk::ANSI_C => Code::KeyC,
+        kvk::ANSI_V => Code::KeyV,
+        kvk::ISO_SECTION => Code::IntlBackslash,
+        kvk::ANSI_B => Code::KeyB,
+        kvk::ANSI_Q => Code::KeyQ,
+        kvk::ANSI_W => Code::KeyW,
+        kvk::ANSI_E => Code::KeyE,
+        kvk::ANSI_R => Code::KeyR,
+        kvk::ANSI_Y => Code::KeyY,
+        kvk::ANSI_T => Code::KeyT,
+        kvk::ANSI_1 => Code::Digit1,
+        kvk::ANSI_2 => Code::Digit2,
+        kvk::ANSI_3 => Code::Digit3,
+        kvk::ANSI_4 => Code::Digit4,
+        kvk::ANSI_6 => Code::Digit6,
+        kvk::ANSI_5 => Code::Digit5,
+        kvk::ANSI_EQUAL => Code::Equal,
+        kvk::ANSI_9 => Code::Digit9,
+        kvk::ANSI_7 => Code::Digit7,
+        kvk::ANSI_MINUS => Code::Minus,
+        kvk::ANSI_8 => Code::Digit8,
+        kvk::ANSI_0 => Code::Digit0,
+        kvk::ANSI_RIGHT_BRACKET => Code::BracketRight,
+        kvk::ANSI_O => Code::KeyO,
+        kvk::ANSI_U => Code::KeyU,
+        kvk::ANSI_LEFT_BRACKET => Code::BracketLeft,
+        kvk::ANSI_I => Code::KeyI,
+        kvk::ANSI_P => Code::KeyP,
+        kvk::RETURN => Code::Enter,
+        kvk::ANSI_L => Code::KeyL,
+        kvk::ANSI_J => Code::KeyJ,
+        kvk::ANSI_QUOTE => Code::Quote,
+        kvk::ANSI_K => Code::KeyK,
+        kvk::ANSI_SEMICOLON => Code::Semicolon,
+        kvk::ANSI_BACKSLASH => Code::Backslash,
+        kvk::ANSI_COMMA => Code::Comma,
+        kvk::ANSI_SLASH => Code::Slash,
+        kvk::ANSI_N => Code::KeyN,
+        kvk::ANSI_M => Code::KeyM,
+        kvk::ANSI_PERIOD => Code::Period,
+        kvk::TAB => Code::Tab,
+        kvk::SPACE => Code::Space,
+        kvk::ANSI_GRAVE => Code::Backquote,
+        kvk::DELETE => Code::Backspace,
+        kvk::ESCAPE => Code::Escape,
+        kvk::RIGHT_COMMAND => Code::MetaRight,
+        kvk::COMMAND => Code::MetaLeft,
+        kvk::SHIFT => Code::ShiftLeft,
+        kvk::CAPS_LOCK => Code::CapsLock,
+        kvk::OPTION => Code::AltLeft,
+        kvk::CONTROL => Code::ControlLeft,
+        kvk::RIGHT_SHIFT => Code::ShiftRight,
+        kvk::RIGHT_OPTION => Code::AltRight,
+        kvk::RIGHT_CONTROL => Code::ControlRight,
+        kvk::FUNCTION => Code::Fn,
+        kvk::F17 => Code::F17,
+        kvk::ANSI_KEYPAD_DECIMAL => Code::NumpadDecimal,
+        kvk::ANSI_KEYPAD_MULTIPLY => Code::NumpadMultiply,
+        kvk::ANSI_KEYPAD_PLUS => Code::NumpadAdd,
+        // The registry names the numpad-clear position NumLock (it IS the
+        // NumLock key of a PC numpad).
+        kvk::ANSI_KEYPAD_CLEAR => Code::NumLock,
+        kvk::VOLUME_UP => Code::AudioVolumeUp,
+        kvk::VOLUME_DOWN => Code::AudioVolumeDown,
+        kvk::MUTE => Code::AudioVolumeMute,
+        kvk::ANSI_KEYPAD_DIVIDE => Code::NumpadDivide,
+        kvk::ANSI_KEYPAD_ENTER => Code::NumpadEnter,
+        kvk::ANSI_KEYPAD_MINUS => Code::NumpadSubtract,
+        kvk::F18 => Code::F18,
+        kvk::F19 => Code::F19,
+        kvk::ANSI_KEYPAD_EQUALS => Code::NumpadEqual,
+        kvk::ANSI_KEYPAD_0 => Code::Numpad0,
+        kvk::ANSI_KEYPAD_1 => Code::Numpad1,
+        kvk::ANSI_KEYPAD_2 => Code::Numpad2,
+        kvk::ANSI_KEYPAD_3 => Code::Numpad3,
+        kvk::ANSI_KEYPAD_4 => Code::Numpad4,
+        kvk::ANSI_KEYPAD_5 => Code::Numpad5,
+        kvk::ANSI_KEYPAD_6 => Code::Numpad6,
+        kvk::ANSI_KEYPAD_7 => Code::Numpad7,
+        kvk::F20 => Code::F20,
+        kvk::ANSI_KEYPAD_8 => Code::Numpad8,
+        kvk::ANSI_KEYPAD_9 => Code::Numpad9,
+        kvk::JIS_YEN => Code::IntlYen,
+        kvk::JIS_UNDERSCORE => Code::IntlRo,
+        kvk::JIS_KEYPAD_COMMA => Code::NumpadComma,
+        kvk::F5 => Code::F5,
+        kvk::F6 => Code::F6,
+        kvk::F7 => Code::F7,
+        kvk::F3 => Code::F3,
+        kvk::F8 => Code::F8,
+        kvk::F9 => Code::F9,
+        kvk::JIS_EISU => Code::Lang2,
+        kvk::F11 => Code::F11,
+        kvk::JIS_KANA => Code::Lang1,
+        kvk::F13 => Code::F13,
+        kvk::F16 => Code::F16,
+        kvk::F14 => Code::F14,
+        kvk::F10 => Code::F10,
+        kvk::PC_MENU => Code::ContextMenu,
+        kvk::F12 => Code::F12,
+        kvk::F15 => Code::F15,
+        kvk::HELP => Code::Insert,
+        kvk::HOME => Code::Home,
+        kvk::PAGE_UP => Code::PageUp,
+        kvk::FORWARD_DELETE => Code::Delete,
+        kvk::F4 => Code::F4,
+        kvk::END => Code::End,
+        kvk::F2 => Code::F2,
+        kvk::PAGE_DOWN => Code::PageDown,
+        kvk::F1 => Code::F1,
+        kvk::LEFT_ARROW => Code::ArrowLeft,
+        kvk::RIGHT_ARROW => Code::ArrowRight,
+        kvk::DOWN_ARROW => Code::ArrowDown,
+        kvk::UP_ARROW => Code::ArrowUp,
+        _ => Code::Unidentified,
+    }
+}
+
+/// The named `Key` a keycode resolves to *before* the backend consults
+/// `NSEvent.characters` — `None` means "let the characters text decide".
+///
+/// This intercept exists because for these keys `characters` is not typeable
+/// text: editing/navigation/function keys deliver control characters or
+/// Unicode private-use-area codepoints (`NSUpArrowFunctionKey` is `U+F700`,
+/// `NSF13FunctionKey` is `U+F70A`, …), which would otherwise ship as
+/// garbage `Key::Character` values. Letters, digits, and punctuation return
+/// `None` on purpose: their `characters` string is the layout- and
+/// modifier-aware translation (the macOS analogue of the Win32 `WM_CHAR`
+/// merge in [`super::keys`]) and must keep winning.
+pub fn keycode_to_key(key_code: u16) -> Option<Key> {
+    let named = match key_code {
+        kvk::LEFT_ARROW => NamedKey::ArrowLeft,
+        kvk::RIGHT_ARROW => NamedKey::ArrowRight,
+        kvk::DOWN_ARROW => NamedKey::ArrowDown,
+        kvk::UP_ARROW => NamedKey::ArrowUp,
+
+        kvk::F1 => NamedKey::F1,
+        kvk::F2 => NamedKey::F2,
+        kvk::F3 => NamedKey::F3,
+        kvk::F4 => NamedKey::F4,
+        kvk::F5 => NamedKey::F5,
+        kvk::F6 => NamedKey::F6,
+        kvk::F7 => NamedKey::F7,
+        kvk::F8 => NamedKey::F8,
+        kvk::F9 => NamedKey::F9,
+        kvk::F10 => NamedKey::F10,
+        kvk::F11 => NamedKey::F11,
+        kvk::F12 => NamedKey::F12,
+        kvk::F13 => NamedKey::F13,
+        kvk::F14 => NamedKey::F14,
+        kvk::F15 => NamedKey::F15,
+        kvk::F16 => NamedKey::F16,
+        kvk::F17 => NamedKey::F17,
+        kvk::F18 => NamedKey::F18,
+        kvk::F19 => NamedKey::F19,
+        kvk::F20 => NamedKey::F20,
+
+        // Both Enter keys report the same logical key; the numpad one is
+        // distinguished by its `code`/`location`.
+        kvk::RETURN | kvk::ANSI_KEYPAD_ENTER => NamedKey::Enter,
+        kvk::TAB => NamedKey::Tab,
+        kvk::DELETE => NamedKey::Backspace,
+        kvk::ESCAPE => NamedKey::Escape,
+        kvk::FORWARD_DELETE => NamedKey::Delete,
+        kvk::HOME => NamedKey::Home,
+        kvk::END => NamedKey::End,
+        kvk::PAGE_UP => NamedKey::PageUp,
+        kvk::PAGE_DOWN => NamedKey::PageDown,
+        // Insert, matching this key's `Code` (see [`kvk::HELP`]).
+        kvk::HELP => NamedKey::Insert,
+        kvk::PC_MENU => NamedKey::ContextMenu,
+
+        // Modifiers arrive via `flagsChanged:`, not `keyDown:` — mapped for
+        // table completeness (see the module doc).
+        kvk::SHIFT | kvk::RIGHT_SHIFT => NamedKey::Shift,
+        kvk::CONTROL | kvk::RIGHT_CONTROL => NamedKey::Control,
+        kvk::OPTION | kvk::RIGHT_OPTION => NamedKey::Alt,
+        kvk::COMMAND | kvk::RIGHT_COMMAND => NamedKey::Meta,
+        kvk::CAPS_LOCK => NamedKey::CapsLock,
+        kvk::FUNCTION => NamedKey::Fn,
+
+        kvk::VOLUME_UP => NamedKey::AudioVolumeUp,
+        kvk::VOLUME_DOWN => NamedKey::AudioVolumeDown,
+        kvk::MUTE => NamedKey::AudioVolumeMute,
+
+        kvk::JIS_EISU => NamedKey::Eisu,
+        kvk::JIS_KANA => NamedKey::KanaMode,
+
+        // Space types text but its `characters` IS the space — still, keep
+        // the historical intercept so the key never depends on the
+        // characters path.
+        kvk::SPACE => return Some(Key::Character(" ".to_string())),
+
+        _ => return None,
+    };
+    Some(Key::Named(named))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::keys::location_for_code;
+    use super::*;
+    use keyboard_types::Location;
+
+    /// macOS keycodes are NOT alphabetical or sequential: the letter block
+    /// follows the ancient Apple layout (A S D F H G Z X C V …) and the
+    /// digit row is scrambled (6 sits between 4 and 5). A table generated
+    /// by pattern instead of transcription gets exactly these wrong.
+    #[test]
+    fn letter_and_digit_rows_follow_the_apple_scramble() {
+        for (code, expected) in [
+            (kvk::ANSI_A, Code::KeyA),
+            (kvk::ANSI_S, Code::KeyS),
+            (kvk::ANSI_D, Code::KeyD),
+            (kvk::ANSI_H, Code::KeyH),
+            (kvk::ANSI_G, Code::KeyG),
+            (kvk::ANSI_Z, Code::KeyZ),
+            (kvk::ANSI_Q, Code::KeyQ),
+            (kvk::ANSI_B, Code::KeyB),
+            (kvk::ANSI_4, Code::Digit4),
+            (kvk::ANSI_6, Code::Digit6),
+            (kvk::ANSI_5, Code::Digit5),
+            (kvk::ANSI_9, Code::Digit9),
+            (kvk::ANSI_7, Code::Digit7),
+            (kvk::ANSI_8, Code::Digit8),
+            (kvk::ANSI_0, Code::Digit0),
+        ] {
+            assert_eq!(keycode_to_code(code), expected, "keycode {code:#04x}");
+        }
+        // Letters and digits have no named-key intercept: their
+        // `characters` translation must win.
+        assert_eq!(keycode_to_key(kvk::ANSI_A), None);
+        assert_eq!(keycode_to_key(kvk::ANSI_6), None);
+    }
+
+    /// Punctuation and editing keys, including the bracket pair whose
+    /// keycodes are ordered Right (0x1E) before Left (0x21).
+    #[test]
+    fn punctuation_and_editing_keys_resolve() {
+        for (code, expected) in [
+            (kvk::ANSI_EQUAL, Code::Equal),
+            (kvk::ANSI_MINUS, Code::Minus),
+            (kvk::ANSI_RIGHT_BRACKET, Code::BracketRight),
+            (kvk::ANSI_LEFT_BRACKET, Code::BracketLeft),
+            (kvk::ANSI_QUOTE, Code::Quote),
+            (kvk::ANSI_SEMICOLON, Code::Semicolon),
+            (kvk::ANSI_BACKSLASH, Code::Backslash),
+            (kvk::ANSI_COMMA, Code::Comma),
+            (kvk::ANSI_SLASH, Code::Slash),
+            (kvk::ANSI_PERIOD, Code::Period),
+            (kvk::ANSI_GRAVE, Code::Backquote),
+            (kvk::TAB, Code::Tab),
+            (kvk::SPACE, Code::Space),
+            (kvk::DELETE, Code::Backspace),
+            (kvk::ESCAPE, Code::Escape),
+            (kvk::RETURN, Code::Enter),
+        ] {
+            assert_eq!(keycode_to_code(code), expected, "keycode {code:#04x}");
+        }
+        // Punctuation is characters-typed; editing keys are intercepted.
+        assert_eq!(keycode_to_key(kvk::ANSI_SEMICOLON), None);
+        assert_eq!(
+            keycode_to_key(kvk::DELETE),
+            Some(Key::Named(NamedKey::Backspace))
+        );
+        assert_eq!(
+            keycode_to_key(kvk::FORWARD_DELETE),
+            Some(Key::Named(NamedKey::Delete))
+        );
+    }
+
+    /// Modifier keycodes carry sidedness in the `code` (the shared location
+    /// derivation turns it into `Location::Left`/`Right`), and Apple's
+    /// left-hand Command is `0x37` with RIGHT Command at the LOWER `0x36`.
+    #[test]
+    fn modifier_keycodes_report_sidedness_and_location() {
+        for (code, expected, location) in [
+            (kvk::COMMAND, Code::MetaLeft, Location::Left),
+            (kvk::RIGHT_COMMAND, Code::MetaRight, Location::Right),
+            (kvk::SHIFT, Code::ShiftLeft, Location::Left),
+            (kvk::RIGHT_SHIFT, Code::ShiftRight, Location::Right),
+            (kvk::OPTION, Code::AltLeft, Location::Left),
+            (kvk::RIGHT_OPTION, Code::AltRight, Location::Right),
+            (kvk::CONTROL, Code::ControlLeft, Location::Left),
+            (kvk::RIGHT_CONTROL, Code::ControlRight, Location::Right),
+        ] {
+            assert_eq!(keycode_to_code(code), expected, "keycode {code:#04x}");
+            assert_eq!(location_for_code(expected), location);
+        }
+        assert_eq!(keycode_to_code(kvk::CAPS_LOCK), Code::CapsLock);
+        assert_eq!(keycode_to_code(kvk::FUNCTION), Code::Fn);
+        assert_eq!(
+            keycode_to_key(kvk::FUNCTION),
+            Some(Key::Named(NamedKey::Fn))
+        );
+    }
+
+    /// The numpad cluster: digits are near-sequential but 8 and 9 sit
+    /// after F20, and the clear key is the registry's NumLock. Every
+    /// numpad code must also derive `Location::Numpad`.
+    #[test]
+    fn numpad_cluster_reports_numpad_codes_and_location() {
+        let cluster = [
+            (kvk::ANSI_KEYPAD_0, Code::Numpad0),
+            (kvk::ANSI_KEYPAD_7, Code::Numpad7),
+            (kvk::ANSI_KEYPAD_8, Code::Numpad8),
+            (kvk::ANSI_KEYPAD_9, Code::Numpad9),
+            (kvk::ANSI_KEYPAD_DECIMAL, Code::NumpadDecimal),
+            (kvk::ANSI_KEYPAD_MULTIPLY, Code::NumpadMultiply),
+            (kvk::ANSI_KEYPAD_PLUS, Code::NumpadAdd),
+            (kvk::ANSI_KEYPAD_MINUS, Code::NumpadSubtract),
+            (kvk::ANSI_KEYPAD_DIVIDE, Code::NumpadDivide),
+            (kvk::ANSI_KEYPAD_ENTER, Code::NumpadEnter),
+            (kvk::ANSI_KEYPAD_EQUALS, Code::NumpadEqual),
+            (kvk::ANSI_KEYPAD_CLEAR, Code::NumLock),
+            (kvk::JIS_KEYPAD_COMMA, Code::NumpadComma),
+        ];
+        for (code, expected) in cluster {
+            assert_eq!(keycode_to_code(code), expected, "keycode {code:#04x}");
+            assert_eq!(
+                location_for_code(expected),
+                Location::Numpad,
+                "{expected:?}"
+            );
+        }
+        // Numpad Enter reports the shared Enter logical key; the digits
+        // type through `characters`.
+        assert_eq!(
+            keycode_to_key(kvk::ANSI_KEYPAD_ENTER),
+            Some(Key::Named(NamedKey::Enter))
+        );
+        assert_eq!(keycode_to_key(kvk::ANSI_KEYPAD_5), None);
+    }
+
+    /// The function row's keycodes are thoroughly shuffled (F3 is 0x63,
+    /// F13 is 0x69 next to F16 at 0x6A…); all twenty resolve, in both
+    /// tables — their `characters` are PUA codepoints, so the named-key
+    /// intercept is what keeps them out of `Key::Character`.
+    #[test]
+    fn function_row_covers_f1_through_f20() {
+        let rows = [
+            (kvk::F1, Code::F1, NamedKey::F1),
+            (kvk::F2, Code::F2, NamedKey::F2),
+            (kvk::F3, Code::F3, NamedKey::F3),
+            (kvk::F4, Code::F4, NamedKey::F4),
+            (kvk::F5, Code::F5, NamedKey::F5),
+            (kvk::F6, Code::F6, NamedKey::F6),
+            (kvk::F7, Code::F7, NamedKey::F7),
+            (kvk::F8, Code::F8, NamedKey::F8),
+            (kvk::F9, Code::F9, NamedKey::F9),
+            (kvk::F10, Code::F10, NamedKey::F10),
+            (kvk::F11, Code::F11, NamedKey::F11),
+            (kvk::F12, Code::F12, NamedKey::F12),
+            (kvk::F13, Code::F13, NamedKey::F13),
+            (kvk::F14, Code::F14, NamedKey::F14),
+            (kvk::F15, Code::F15, NamedKey::F15),
+            (kvk::F16, Code::F16, NamedKey::F16),
+            (kvk::F17, Code::F17, NamedKey::F17),
+            (kvk::F18, Code::F18, NamedKey::F18),
+            (kvk::F19, Code::F19, NamedKey::F19),
+            (kvk::F20, Code::F20, NamedKey::F20),
+        ];
+        for (keycode, code, key) in rows {
+            assert_eq!(keycode_to_code(keycode), code, "keycode {keycode:#04x}");
+            assert_eq!(
+                keycode_to_key(keycode),
+                Some(Key::Named(key)),
+                "keycode {keycode:#04x}"
+            );
+        }
+    }
+
+    /// The navigation cluster, plus the two delete keys: Apple's "delete"
+    /// (0x33) is Backspace, "forward delete" (0x75) is Delete, and Help
+    /// (0x72) is the Insert position.
+    #[test]
+    fn navigation_cluster_resolves() {
+        for (keycode, code, key) in [
+            (kvk::LEFT_ARROW, Code::ArrowLeft, NamedKey::ArrowLeft),
+            (kvk::RIGHT_ARROW, Code::ArrowRight, NamedKey::ArrowRight),
+            (kvk::DOWN_ARROW, Code::ArrowDown, NamedKey::ArrowDown),
+            (kvk::UP_ARROW, Code::ArrowUp, NamedKey::ArrowUp),
+            (kvk::HOME, Code::Home, NamedKey::Home),
+            (kvk::END, Code::End, NamedKey::End),
+            (kvk::PAGE_UP, Code::PageUp, NamedKey::PageUp),
+            (kvk::PAGE_DOWN, Code::PageDown, NamedKey::PageDown),
+            (kvk::FORWARD_DELETE, Code::Delete, NamedKey::Delete),
+            (kvk::HELP, Code::Insert, NamedKey::Insert),
+            (kvk::PC_MENU, Code::ContextMenu, NamedKey::ContextMenu),
+        ] {
+            assert_eq!(keycode_to_code(keycode), code, "keycode {keycode:#04x}");
+            assert_eq!(
+                keycode_to_key(keycode),
+                Some(Key::Named(key)),
+                "keycode {keycode:#04x}"
+            );
+        }
+    }
+
+    /// JIS and ISO layout keys per the registry's Intl/Lang rows.
+    #[test]
+    fn jis_and_iso_keys_resolve() {
+        assert_eq!(keycode_to_code(kvk::JIS_YEN), Code::IntlYen);
+        assert_eq!(keycode_to_code(kvk::JIS_UNDERSCORE), Code::IntlRo);
+        assert_eq!(keycode_to_code(kvk::JIS_EISU), Code::Lang2);
+        assert_eq!(keycode_to_code(kvk::JIS_KANA), Code::Lang1);
+        assert_eq!(keycode_to_code(kvk::ISO_SECTION), Code::IntlBackslash);
+        assert_eq!(
+            keycode_to_key(kvk::JIS_EISU),
+            Some(Key::Named(NamedKey::Eisu))
+        );
+        assert_eq!(
+            keycode_to_key(kvk::JIS_KANA),
+            Some(Key::Named(NamedKey::KanaMode))
+        );
+    }
+
+    /// The two documented divergences from the winit macOS table, both
+    /// following Apple's `Events.h` and Firefox instead: the volume trio
+    /// at its header-assigned codes (winit shifts them down one and drops
+    /// Mute), and the ISO section key as `IntlBackslash` (winit says
+    /// `Backquote`).
+    #[test]
+    fn follows_apples_header_where_the_winit_table_drifts() {
+        assert_eq!(keycode_to_code(kvk::VOLUME_UP), Code::AudioVolumeUp);
+        assert_eq!(keycode_to_code(kvk::VOLUME_DOWN), Code::AudioVolumeDown);
+        assert_eq!(keycode_to_code(kvk::MUTE), Code::AudioVolumeMute);
+        assert_eq!(keycode_to_code(kvk::ISO_SECTION), Code::IntlBackslash);
+    }
+
+    /// Outside the two divergences above, everything the winit macOS
+    /// backend's table produces, this table produces from the same keycode
+    /// — FLUI's native and fallback macOS wires must agree on physical-key
+    /// identity. Transcribed from winit 0.30 `platform_impl/macos/event.rs`
+    /// (`scancode_to_physicalkey`), with winit's `SuperLeft`/`SuperRight`
+    /// spelled as the W3C `MetaLeft`/`MetaRight`.
+    #[test]
+    fn agrees_with_the_winit_backend_elsewhere() {
+        let winit_backend_codes: &[(u16, Code)] = &[
+            (0x00, Code::KeyA),
+            (0x01, Code::KeyS),
+            (0x02, Code::KeyD),
+            (0x03, Code::KeyF),
+            (0x04, Code::KeyH),
+            (0x05, Code::KeyG),
+            (0x06, Code::KeyZ),
+            (0x07, Code::KeyX),
+            (0x08, Code::KeyC),
+            (0x09, Code::KeyV),
+            (0x0B, Code::KeyB),
+            (0x0C, Code::KeyQ),
+            (0x0D, Code::KeyW),
+            (0x0E, Code::KeyE),
+            (0x0F, Code::KeyR),
+            (0x10, Code::KeyY),
+            (0x11, Code::KeyT),
+            (0x12, Code::Digit1),
+            (0x13, Code::Digit2),
+            (0x14, Code::Digit3),
+            (0x15, Code::Digit4),
+            (0x16, Code::Digit6),
+            (0x17, Code::Digit5),
+            (0x18, Code::Equal),
+            (0x19, Code::Digit9),
+            (0x1A, Code::Digit7),
+            (0x1B, Code::Minus),
+            (0x1C, Code::Digit8),
+            (0x1D, Code::Digit0),
+            (0x1E, Code::BracketRight),
+            (0x1F, Code::KeyO),
+            (0x20, Code::KeyU),
+            (0x21, Code::BracketLeft),
+            (0x22, Code::KeyI),
+            (0x23, Code::KeyP),
+            (0x24, Code::Enter),
+            (0x25, Code::KeyL),
+            (0x26, Code::KeyJ),
+            (0x27, Code::Quote),
+            (0x28, Code::KeyK),
+            (0x29, Code::Semicolon),
+            (0x2A, Code::Backslash),
+            (0x2B, Code::Comma),
+            (0x2C, Code::Slash),
+            (0x2D, Code::KeyN),
+            (0x2E, Code::KeyM),
+            (0x2F, Code::Period),
+            (0x30, Code::Tab),
+            (0x31, Code::Space),
+            (0x32, Code::Backquote),
+            (0x33, Code::Backspace),
+            (0x35, Code::Escape),
+            (0x36, Code::MetaRight),
+            (0x37, Code::MetaLeft),
+            (0x38, Code::ShiftLeft),
+            (0x39, Code::CapsLock),
+            (0x3A, Code::AltLeft),
+            (0x3B, Code::ControlLeft),
+            (0x3C, Code::ShiftRight),
+            (0x3D, Code::AltRight),
+            (0x3E, Code::ControlRight),
+            (0x3F, Code::Fn),
+            (0x40, Code::F17),
+            (0x41, Code::NumpadDecimal),
+            (0x43, Code::NumpadMultiply),
+            (0x45, Code::NumpadAdd),
+            (0x47, Code::NumLock),
+            (0x4B, Code::NumpadDivide),
+            (0x4C, Code::NumpadEnter),
+            (0x4E, Code::NumpadSubtract),
+            (0x4F, Code::F18),
+            (0x50, Code::F19),
+            (0x51, Code::NumpadEqual),
+            (0x52, Code::Numpad0),
+            (0x53, Code::Numpad1),
+            (0x54, Code::Numpad2),
+            (0x55, Code::Numpad3),
+            (0x56, Code::Numpad4),
+            (0x57, Code::Numpad5),
+            (0x58, Code::Numpad6),
+            (0x59, Code::Numpad7),
+            (0x5A, Code::F20),
+            (0x5B, Code::Numpad8),
+            (0x5C, Code::Numpad9),
+            (0x5D, Code::IntlYen),
+            (0x60, Code::F5),
+            (0x61, Code::F6),
+            (0x62, Code::F7),
+            (0x63, Code::F3),
+            (0x64, Code::F8),
+            (0x65, Code::F9),
+            (0x67, Code::F11),
+            (0x69, Code::F13),
+            (0x6A, Code::F16),
+            (0x6B, Code::F14),
+            (0x6D, Code::F10),
+            (0x6F, Code::F12),
+            (0x71, Code::F15),
+            (0x72, Code::Insert),
+            (0x73, Code::Home),
+            (0x74, Code::PageUp),
+            (0x75, Code::Delete),
+            (0x76, Code::F4),
+            (0x77, Code::End),
+            (0x78, Code::F2),
+            (0x79, Code::PageDown),
+            (0x7A, Code::F1),
+            (0x7B, Code::ArrowLeft),
+            (0x7C, Code::ArrowRight),
+            (0x7D, Code::ArrowDown),
+            (0x7E, Code::ArrowUp),
+        ];
+        for &(keycode, code) in winit_backend_codes {
+            assert_eq!(keycode_to_code(keycode), code, "keycode {keycode:#04x}");
+        }
+    }
+
+    /// An unknown keycode degrades to `Unidentified`/characters, never a
+    /// wrong key.
+    #[test]
+    fn unknown_keycodes_degrade_gracefully() {
+        assert_eq!(keycode_to_code(0x7F), Code::Unidentified);
+        assert_eq!(keycode_to_code(0xFFFF), Code::Unidentified);
+        assert_eq!(keycode_to_key(0x7F), None);
+    }
+}

--- a/crates/flui-platform/src/shared/keys_macos.rs
+++ b/crates/flui-platform/src/shared/keys_macos.rs
@@ -369,6 +369,11 @@ pub fn keycode_to_key(key_code: u16) -> Option<Key> {
         // Insert, matching this key's `Code` (see [`kvk::HELP`]).
         kvk::HELP => NamedKey::Insert,
         kvk::PC_MENU => NamedKey::ContextMenu,
+        // Keypad Clear delivers the PUA scalar `NSClearLineFunctionKey`
+        // (U+F739, AppKit `NSEvent.h`) as its `characters`; its W3C `key`
+        // value is `Clear` (Firefox maps `kVK_ANSI_KeypadClear` so), even
+        // though its physical `code` is the registry's NumLock position.
+        kvk::ANSI_KEYPAD_CLEAR => NamedKey::Clear,
 
         // Modifiers arrive via `flagsChanged:`, not `keyDown:` — mapped for
         // table completeness (see the module doc).
@@ -530,6 +535,14 @@ mod tests {
             Some(Key::Named(NamedKey::Enter))
         );
         assert_eq!(keycode_to_key(kvk::ANSI_KEYPAD_5), None);
+        // Keypad Clear's `characters` is the PUA scalar
+        // `NSClearLineFunctionKey` (U+F739): without a named intercept it
+        // would ship as `Key::Character("\u{F739}")` and a focused text
+        // field would insert it.
+        assert_eq!(
+            keycode_to_key(kvk::ANSI_KEYPAD_CLEAR),
+            Some(Key::Named(NamedKey::Clear))
+        );
     }
 
     /// The function row's keycodes are thoroughly shuffled (F3 is 0x63,

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -6,6 +6,7 @@
 pub mod gestures;
 mod handlers;
 pub mod keys;
+pub mod keys_macos;
 pub mod scroll;
 
 pub use handlers::{PlatformHandlers, WindowCallbacks};


### PR DESCRIPTION
## What

The remaining tail of the keyboard live-wire audit (#733; the Win32 half merged as #770):

- **AppKit `Code::Unidentified`**: every macOS-native key event shipped `code: Code::Unidentified, location: Location::Standard` — the `keyCode` was extracted and consulted only by a 27-entry named-key table, so physical-key identity (shortcut positions, numpad vs navigation, modifier sidedness) was invisible to consumers, and keys outside that small table (F13–F20, Help, forward-delete on the function row, the whole numpad identity) degraded or shipped private-use-area garbage as `Key::Character`.
- **winit `is_synthetic` ignored**: winit flags the key events it synthesizes on focus change; FLUI dispatched them as real presses, so a Windows/X11 re-focus with keys held would re-type and re-trigger every held key.

`Closes #733`.

## How

**AppKit tables (`crates/flui-platform/src/shared/keys_macos.rs`)** — the same cfg-free tested-helpers shape #770 established with `shared::keys`: pure functions over the raw `NSEvent.keyCode`, compiled and tested on every host while the AppKit caller stays clippy-only.

- `keycode_to_code`: the full `kVK_*` → W3C `Code` table — letters/digits (with Apple's scrambled rows), punctuation, modifiers (sided: Command 0x37/0x36, Shift/Option/Control pairs, Fn), navigation (arrows, Home/End/PageUp/PageDown, ForwardDelete, Help→Insert, PC Menu→ContextMenu), the complete numpad (incl. KeypadClear→NumLock, NumpadEnter, NumpadEqual), F1–F20, JIS (Yen→IntlYen, Underscore→IntlRo, KeypadComma, Eisu→Lang2, Kana→Lang1), ISO section→IntlBackslash, and the volume trio. Keycodes are cited to Apple's Carbon `HIToolbox/Events.h` (transcribed as the `kvk` module); the Code values follow the uievents-code registry as implemented by Firefox's `NativeKeyToDOMCodeName.h` and winit's macOS backend.
- Two **documented divergences from winit's macOS table**, both toward Apple's header and Firefox, each pinned by its own test: the volume keys at their `Events.h` codes (0x48/0x49/0x4A — winit shifts them one down and drops Mute, with a TODO in its own source questioning the choice), and ISO section as `IntlBackslash` (winit says `Backquote`).
- `keycode_to_key`: the named-`Key` intercept ahead of the `NSEvent.characters` path, extended from 27 to full coverage of the keys whose `characters` are control or PUA codepoints (F13–F20 were previously shipping `U+F70A`-style codepoints as `Key::Character`). Letters/digits/punctuation deliberately return `None` — their `characters` translation is the macOS analogue of the Win32 WM_CHAR merge and must keep winning.
- `location` now derives through the same `shared::keys::location_for_code` the Win32 wire uses, so all three wires agree on numpad/sidedness.
- Modifier keys are mapped for table completeness but the module doc states plainly: AppKit delivers them via `flagsChanged:`, which this backend does not translate today — modifier *state* rides `modifierFlags` on every event. Named gap, not silently assumed.

**winit `is_synthetic` (`platforms/winit/platform.rs` keyboard arm)** — synthetic events are dropped wholesale with a `tracing::trace`. Contract, from winit 0.30 `src/event.rs` (`is_synthetic` doc: synthetic presses for all keys held on focus gain, synthetic releases on focus loss; X11 and Windows only): these are keyboard-state synchronization, not user keystrokes. FLUI keeps no per-key pressed-set to synchronize — modifier state rides `ModifiersChanged`, which winit emits on focus change in its own right — while every key consumer (`EditableText` typing, `Shortcuts`, focus traversal) actuates on `KeyState::Down`, so dispatching a synthetic press re-types every held key on re-focus. Flutter draws the same line: state-sync events are flagged `synthesized` and are "created without a source native event in order to synchronize key states", not the user's direct action (`.flutter` `hardware_keyboard.dart`). The arm comment notes the forward obligation: if a pressed-set registry ever appears, these events become its sync feed and must be routed there instead of dropped.

## Evidence — what executes vs what is lint-only

**Executes in CI (Linux):** the 10 new `shared::keys_macos` tests — the Apple letter/digit scramble, punctuation/editing, modifier sidedness + location, the numpad cluster + `Location::Numpad`, F1–F20 in both tables, navigation, JIS/ISO, the two winit divergences, a full winit-macOS-backend agreement table (transcribed from winit 0.30 `platform_impl/macos/event.rs`), and unknown-keycode degradation. Sabotage-verified: corrupting three table arms (`ANSI_6`, `F13`, `VOLUME_UP`) fails 4 of the 10 tests; restored, all pass. Note the old `key_code_to_key` test this replaces sat in `macos/events.rs` and therefore **never executed anywhere** — this moves that coverage into the executing set.

**Lint-only (no link, no tests — the `cross-typecheck` reality):** the AppKit caller wiring in `macos/events.rs` (key arms now read `keyCode` once and emit real `code`/`location`) and the winit `is_synthetic` guard. The guard is deliberately not unit-tested: winit's `KeyEvent` carries a `pub(crate) platform_specific` field, so no test outside winit can construct one to drive the translation, and the dispatch arm itself is only reachable under a live `ActiveEventLoop`. Verified with the exact CI commands, all exit 0:

- `cargo clippy -p flui-platform --locked --all-targets --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings`
- `cargo clippy -p flui-platform --locked --all-targets --target aarch64-linux-android -- -D warnings`

**Gates:** `FLUI_HEADLESS=1 xvfb-run -a cargo nextest run -p flui-platform --locked --all-features` — 234/234 pass (one unrelated pre-existing clipboard-reachability flake on the first run, `default_is_functional_iff_a_backend_is_reachable_and_never_panics`, passed in isolation and on the full re-run; my diff touches no clipboard code). `just ci` exit 0 (9067 + 31 + 234 tests, fmt/inventory/runtime-conformance/port-check/clippy/doctests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM