### PR TITLE
feat(semantics): key the update payload family by stable AccessibilityNodeId

### DIFF
--- a/crates/flui-rendering/src/lib.rs
+++ b/crates/flui-rendering/src/lib.rs
@@ -161,8 +161,8 @@ pub mod prelude {
         pipeline::{Canvas, Paint, PaintStyle, PipelineCell, PipelineOwner},
         protocol::{BoxProtocol, Protocol, SliverProtocol},
         semantics::{
-            SemanticsAction, SemanticsConfiguration, SemanticsNode, SemanticsNodeUpdate,
-            SemanticsOwner, SemanticsTreeUpdate,
+            SemanticsAction, SemanticsConfiguration, SemanticsNode, SemanticsOwner,
+            SemanticsTreeUpdate,
         },
         traits::{RenderBox, RenderObject, TextBaseline},
         view::{

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -1639,8 +1639,8 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     /// lazy-creation path in [`Self::set_semantics_enabled`].
     ///
     /// The escape hatch for a platform binding that needs its own update
-    /// callback (forwarding [`flui_semantics::SemanticsNodeUpdate`] batches
-    /// to a real OS accessibility bridge once one exists), or a test that
+    /// callback (forwarding the translated [`flui_semantics::TreeUpdate`]s
+    /// to a real OS accessibility bridge), or a test that
     /// wants to observe `flush()`'s callback invocations directly. Call
     /// this *before* `set_semantics_enabled(true)` — the enable path only
     /// lazily creates a no-op-callback owner when none is installed yet.

--- a/crates/flui-semantics/README.md
+++ b/crates/flui-semantics/README.md
@@ -24,7 +24,7 @@ RenderObject (flui-rendering)
     │  assembleSemanticsNode() during the paint phase
     ▼
 SemanticsNode (this crate)  —  SemanticsTree (slab storage, 1-based SemanticsId)
-    │  flush() batches dirty nodes into a SemanticsTreeUpdate
+    │  flush() publishes an accesskit::TreeUpdate keyed by stable AccessibilityNodeId
     ▼
 Platform accessibility API (via flui-platform backends)
 ```

--- a/crates/flui-semantics/src/accesskit_translation.rs
+++ b/crates/flui-semantics/src/accesskit_translation.rs
@@ -463,11 +463,14 @@ pub fn tree_to_update(
 
     let nodes: Vec<(NodeId, Node)> = tree
         .iter()
-        .filter_map(|(id, node)| {
-            let node_id = NodeId(node.accessibility_id()?.as_u64());
-            // `node_data` resolves the children into the same stable space
-            // and applies the identical skip rule for unaddressable ones.
-            Some((node_id, to_node(&tree.node_data(id)?)))
+        .filter_map(|(_, node)| {
+            // `node_data_of` skips an unaddressable node (returns `None`),
+            // resolves the children into the same stable space with the
+            // identical skip rule, and works from the reference already in
+            // hand — no second arena lookup per node on the publish path.
+            let data = tree.node_data_of(node)?;
+            let node_id = NodeId(data.id?.as_u64());
+            Some((node_id, to_node(&data)))
         })
         .collect();
 

--- a/crates/flui-semantics/src/accesskit_translation.rs
+++ b/crates/flui-semantics/src/accesskit_translation.rs
@@ -321,12 +321,14 @@ pub fn semantics_action_args_for(
 
 /// Translate one FLUI semantics node into an AccessKit node.
 ///
-/// `children` are the caller's already-resolved AccessKit ids. They are NOT
-/// derived from [`SemanticsNodeData::children`], which holds arena positions in
-/// the `SemanticsId` space — see [`tree_to_update`] for why that space must not
-/// reach an adapter.
+/// Children come from [`SemanticsNodeData::children`], which carries the
+/// stable [`AccessibilityNodeId`](crate::AccessibilityNodeId)s — the same
+/// space AccessKit ids are published in, so the mapping is a transparent
+/// repack. (An earlier payload shape held arena positions there, and this
+/// function had to refuse them; the type now makes that leak
+/// unrepresentable.)
 #[must_use]
-pub(crate) fn to_node(data: &SemanticsNodeData, children: Vec<NodeId>) -> Node {
+pub(crate) fn to_node(data: &SemanticsNodeData) -> Node {
     let mut node = Node::new(resolve_role(data));
 
     if let Some(label) = &data.label {
@@ -370,7 +372,12 @@ pub(crate) fn to_node(data: &SemanticsNodeData, children: Vec<NodeId>) -> Node {
     apply_state(&mut node, data.flags);
     apply_actions(&mut node, data.actions);
 
-    node.set_children(children);
+    node.set_children(
+        data.children
+            .iter()
+            .map(|child| NodeId(child.as_u64()))
+            .collect::<Vec<_>>(),
+    );
 
     node
 }
@@ -457,13 +464,10 @@ pub fn tree_to_update(
     let nodes: Vec<(NodeId, Node)> = tree
         .iter()
         .filter_map(|(id, node)| {
-            let node_id = stable_id(id)?;
-            let children = node
-                .children()
-                .iter()
-                .filter_map(|&child| stable_id(child))
-                .collect();
-            Some((node_id, to_node(&node.to_node_data(id), children)))
+            let node_id = NodeId(node.accessibility_id()?.as_u64());
+            // `node_data` resolves the children into the same stable space
+            // and applies the identical skip rule for unaddressable ones.
+            Some((node_id, to_node(&tree.node_data(id)?)))
         })
         .collect();
 
@@ -493,7 +497,7 @@ mod tests {
 
     /// Childless translation; child wiring is covered by the tree-level tests.
     fn translate(data: &SemanticsNodeData) -> Node {
-        to_node(data, Vec::new())
+        to_node(data)
     }
 
     /// A render identity whose packed value is deliberately unequal to any

--- a/crates/flui-semantics/src/lib.rs
+++ b/crates/flui-semantics/src/lib.rs
@@ -129,8 +129,7 @@ pub use node::SemanticsNode;
 // RE-EXPORTS - Owner Types
 // ============================================================================
 pub use owner::{
-    SemanticsActionError, SemanticsActionInvocation, SemanticsNodeUpdate, SemanticsOwner,
-    SemanticsUpdateCallback,
+    SemanticsActionError, SemanticsActionInvocation, SemanticsOwner, SemanticsUpdateCallback,
 };
 // ============================================================================
 // RE-EXPORTS - Property Types
@@ -182,8 +181,8 @@ pub mod prelude {
         SemanticsActionError, SemanticsActionHandler, SemanticsActionInvocation,
         SemanticsActionRequest, SemanticsConfiguration, SemanticsEvent, SemanticsEventType,
         SemanticsFlag, SemanticsFlags, SemanticsId, SemanticsNode, SemanticsNodeData,
-        SemanticsNodeSnapshot, SemanticsNodeUpdate, SemanticsOwner, SemanticsProperties,
-        SemanticsRole, SemanticsSnapshot, SemanticsSnapshotError, SemanticsTag, SemanticsTree,
+        SemanticsNodeSnapshot, SemanticsOwner, SemanticsProperties, SemanticsRole,
+        SemanticsSnapshot, SemanticsSnapshotError, SemanticsTag, SemanticsTree,
         SemanticsTreeUpdate, SemanticsTreeUpdateBuilder, TextDirection,
     };
 }

--- a/crates/flui-semantics/src/node.rs
+++ b/crates/flui-semantics/src/node.rs
@@ -279,13 +279,17 @@ impl SemanticsNode {
 
     // ========== Data Export ==========
 
-    /// Converts this node to [`SemanticsNodeData`] — an in-process batching
-    /// payload whose `id`/`children` are 0-based arena positions, NOT the
-    /// stable platform identity (see `update.rs`'s module doc; the platform
-    /// payload is built by `tree_to_update` from `accessibility_id`).
-    pub fn to_node_data(&self, id: SemanticsId) -> SemanticsNodeData {
+    /// Converts this node's content to [`SemanticsNodeData`], keyed by its
+    /// stable [`accessibility_id`](Self::accessibility_id) (`None` for a node
+    /// never bound to a render boundary — such a node is not publishable).
+    ///
+    /// `children` is left **empty**: a node stores its children as arena
+    /// [`SemanticsId`]s and cannot resolve their stable identities alone. The
+    /// payload constructor that fills `children` is
+    /// [`SemanticsTree::node_data`](crate::tree::SemanticsTree::node_data).
+    pub fn to_node_data(&self) -> SemanticsNodeData {
         SemanticsNodeData {
-            id: (id.get() - 1) as u64,
+            id: self.accessibility_id(),
             flags: self.config.flags().bits(),
             actions: self.config.effective_actions_as_bits(),
             label: self.config.label().map(|l| l.string.clone()),
@@ -298,7 +302,7 @@ impl SemanticsNode {
             role: self.config.role(),
             rect: self.rect,
             transform: self.transform.unwrap_or(Matrix4::IDENTITY),
-            children: self.children.iter().map(|c| (c.get() - 1) as u64).collect(),
+            children: smallvec::SmallVec::new(),
             platform_view_id: self.config.platform_view_id(),
             max_value_length: self.config.max_value_length(),
             current_value_length: self.config.current_value_length(),
@@ -479,7 +483,11 @@ mod tests {
 
     #[test]
     fn test_semantics_node_to_data() {
-        let mut node = SemanticsNode::new();
+        let source = RenderId::new_gen(
+            9,
+            core::num::NonZeroU32::new(3).expect("test generation is non-zero"),
+        );
+        let mut node = SemanticsNode::new().with_source_render_id(source);
         node.config_mut().set_label("Test Label");
         node.config_mut().set_button(true);
         node.config_mut()
@@ -491,10 +499,13 @@ mod tests {
         node.config_mut().set_blocks_user_actions(true);
         node.set_rect(Rect::from_xywh(px(10.0), px(20.0), px(100.0), px(50.0)));
 
-        let id = SemanticsId::new(5);
-        let data = node.to_node_data(id);
+        let data = node.to_node_data();
 
-        assert_eq!(data.id, 4); // id - 1
+        assert_eq!(
+            data.id,
+            Some(AccessibilityNodeId::from(source)),
+            "the payload identity is the stable render-boundary id, never an arena position"
+        );
         assert_eq!(data.label, Some("Test Label".into()));
         assert!(data.flags & SemanticsFlag::IsButton.value() != 0);
         assert_eq!(
@@ -524,7 +535,7 @@ mod role_propagation_tests {
         let mut node = SemanticsNode::new();
         node.config_mut().set_role(SemanticsRole::ColumnHeader);
 
-        let data = node.to_node_data(SemanticsId::new(1));
+        let data = node.to_node_data();
 
         assert_eq!(
             data.role,
@@ -538,7 +549,15 @@ mod role_propagation_tests {
     #[test]
     fn a_node_without_an_explicit_role_reports_none() {
         let node = SemanticsNode::new();
-        let data = node.to_node_data(SemanticsId::new(1));
+        let data = node.to_node_data();
         assert_eq!(data.role, SemanticsRole::None);
+    }
+
+    /// A node never bound to a render boundary has no stable identity to
+    /// export; the payload must say so rather than fabricate one.
+    #[test]
+    fn an_unbound_node_exports_no_payload_identity() {
+        let node = SemanticsNode::new();
+        assert_eq!(node.to_node_data().id, None);
     }
 }

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -16,7 +16,6 @@ use crate::{
     node::SemanticsNode,
     snapshot::{SemanticsSnapshot, SemanticsSnapshotError},
     tree::SemanticsTree,
-    update::SemanticsNodeData,
 };
 
 // ============================================================================
@@ -34,10 +33,11 @@ use crate::{
 /// - The platform capability speaks accesskit types only, because
 ///   `flui-platform` (layer 2) cannot depend on `flui-semantics` (layer 3).
 ///   Translating on the producing side is what keeps that edge absent.
-/// - [`SemanticsNodeUpdate`] carries `SemanticsId`s, which are arena positions
-///   in a tree the pipeline rebuilds every pass. It cannot express the stable
-///   `AccessibilityNodeId` an adapter must publish and route actions back
-///   through — see [`crate::tree_to_update`].
+/// - The payload must be keyed by the stable `AccessibilityNodeId` an adapter
+///   publishes and routes actions back through — never by `SemanticsId`,
+///   which is an arena position in a tree the pipeline rebuilds every pass.
+///   (A per-node payload keyed on `SemanticsId` used to live here and was
+///   removed for exactly that reason.) See [`crate::tree_to_update`].
 pub type SemanticsUpdateCallback = Arc<dyn Fn(&crate::TreeUpdate) + Send + Sync>;
 
 // ============================================================================
@@ -137,56 +137,6 @@ impl SemanticsActionInvocation {
 }
 
 // ============================================================================
-// SEMANTICS NODE UPDATE
-// ============================================================================
-
-/// A single semantics node update to send to the platform.
-///
-/// This represents an update for one node in the semantics tree,
-/// including its data, parent reference, and children.
-///
-/// See also [`SemanticsTreeUpdate`](crate::update::SemanticsTreeUpdate) for
-/// batched tree-level updates.
-#[derive(Debug, Clone)]
-pub struct SemanticsNodeUpdate {
-    /// The semantics node ID.
-    pub id: SemanticsId,
-
-    /// The semantics data for this node.
-    pub data: SemanticsNodeData,
-
-    /// Parent node ID (None for root).
-    pub parent: Option<SemanticsId>,
-
-    /// Child node IDs.
-    pub children: Vec<SemanticsId>,
-}
-
-impl SemanticsNodeUpdate {
-    /// Creates a new semantics node update.
-    pub fn new(id: SemanticsId, data: SemanticsNodeData) -> Self {
-        Self {
-            id,
-            data,
-            parent: None,
-            children: Vec::new(),
-        }
-    }
-
-    /// Sets the parent node ID.
-    pub fn with_parent(mut self, parent: Option<SemanticsId>) -> Self {
-        self.parent = parent;
-        self
-    }
-
-    /// Sets the child node IDs.
-    pub fn with_children(mut self, children: Vec<SemanticsId>) -> Self {
-        self.children = children;
-        self
-    }
-}
-
-// ============================================================================
 // SEMANTICS OWNER
 // ============================================================================
 
@@ -212,9 +162,9 @@ impl SemanticsNodeUpdate {
 /// use std::sync::Arc;
 ///
 /// // Create owner with platform callback
-/// let callback = Arc::new(|updates: &[SemanticsNodeUpdate]| {
-///     for update in updates {
-///         println!("Semantics update: {:?}", update.id);
+/// let callback = Arc::new(|update: &flui_semantics::TreeUpdate| {
+///     for (id, _node) in &update.nodes {
+///         tracing::debug!(?id, "semantics update");
 ///     }
 /// });
 /// let mut owner = SemanticsOwner::new(callback);
@@ -947,22 +897,6 @@ mod tests {
 
         assert!(owner.tree().is_empty());
         assert!(owner.root().is_none());
-    }
-
-    #[test]
-    fn test_semantics_node_update() {
-        let data = SemanticsNodeData {
-            label: Some("Test".into()),
-            ..Default::default()
-        };
-
-        let update = SemanticsNodeUpdate::new(SemanticsId::new(1), data)
-            .with_parent(Some(SemanticsId::new(2)))
-            .with_children(vec![SemanticsId::new(3), SemanticsId::new(4)]);
-
-        assert_eq!(update.id, SemanticsId::new(1));
-        assert_eq!(update.parent, Some(SemanticsId::new(2)));
-        assert_eq!(update.children.len(), 2);
     }
 
     #[test]

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -310,7 +310,11 @@ impl SemanticsTree {
     }
 
     /// Builds the stable-identity payload for one node, or `None` if `id` is
-    /// not live.
+    /// not live **or the node is unaddressable** (never bound to a render
+    /// boundary). A payload names its subject, so a node with no stable
+    /// identity has no payload — the same skip rule as
+    /// [`tree_to_update`](crate::tree_to_update), applied at construction
+    /// rather than trusted to every consumer.
     ///
     /// This is the constructor for
     /// [`SemanticsNodeData`](crate::update::SemanticsNodeData): content and
@@ -320,12 +324,23 @@ impl SemanticsTree {
     /// children as arena [`SemanticsId`]s — is filled here with each
     /// addressable child's stable
     /// [`AccessibilityNodeId`](crate::AccessibilityNodeId), in child order. An
-    /// unaddressable child (never bound to a render boundary) is omitted, the
-    /// same skip rule as [`tree_to_update`](crate::tree_to_update), so the
-    /// payload never references a node the platform was not given.
+    /// unaddressable child is likewise omitted, so the payload never
+    /// references a node the platform was not given.
     pub fn node_data(&self, id: SemanticsId) -> Option<crate::update::SemanticsNodeData> {
-        let node = self.get(id)?;
+        self.node_data_of(self.get(id)?)
+    }
+
+    /// [`Self::node_data`] for a node reference already in hand — the
+    /// whole-tree publish path iterates nodes and must not pay a second
+    /// arena lookup per node just to rebuild the reference it started from.
+    pub(crate) fn node_data_of(
+        &self,
+        node: &SemanticsNode,
+    ) -> Option<crate::update::SemanticsNodeData> {
         let mut data = node.to_node_data();
+        // No identity, no payload: an update entry the platform cannot
+        // address is worse than an absent one.
+        data.id?;
         data.children = node
             .children()
             .iter()

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -309,6 +309,31 @@ impl SemanticsTree {
         self.get(id).map(SemanticsNode::children)
     }
 
+    /// Builds the stable-identity payload for one node, or `None` if `id` is
+    /// not live.
+    ///
+    /// This is the constructor for
+    /// [`SemanticsNodeData`](crate::update::SemanticsNodeData): content and
+    /// identity come from the node
+    /// ([`SemanticsNode::to_node_data`](crate::SemanticsNode::to_node_data)),
+    /// and `children` — which a node alone cannot resolve, since it stores its
+    /// children as arena [`SemanticsId`]s — is filled here with each
+    /// addressable child's stable
+    /// [`AccessibilityNodeId`](crate::AccessibilityNodeId), in child order. An
+    /// unaddressable child (never bound to a render boundary) is omitted, the
+    /// same skip rule as [`tree_to_update`](crate::tree_to_update), so the
+    /// payload never references a node the platform was not given.
+    pub fn node_data(&self, id: SemanticsId) -> Option<crate::update::SemanticsNodeData> {
+        let node = self.get(id)?;
+        let mut data = node.to_node_data();
+        data.children = node
+            .children()
+            .iter()
+            .filter_map(|&child| self.get(child).and_then(SemanticsNode::accessibility_id))
+            .collect();
+        Some(data)
+    }
+
     // ========== Dirty Tracking ==========
 
     /// Returns all dirty node ids in the tree.

--- a/crates/flui-semantics/src/update.rs
+++ b/crates/flui-semantics/src/update.rs
@@ -54,10 +54,14 @@ use crate::role::SemanticsRole;
 pub struct SemanticsNodeData {
     /// The node's stable OS-facing identity.
     ///
-    /// `None` only for a node never bound to a render boundary — such a node
-    /// is unaddressable and is not published (the same skip rule as
-    /// [`tree_to_update`](crate::tree_to_update)). Every node the pipeline
-    /// assembles carries an identity.
+    /// `None` only in hand-built content (fixtures, node-level export of a
+    /// node never bound to a render boundary). Such a payload is
+    /// unaddressable and never enters an update: the constructor
+    /// ([`SemanticsTree::node_data`](crate::tree::SemanticsTree::node_data))
+    /// returns `None` for an unaddressable node, and
+    /// [`SemanticsTreeUpdateBuilder::add_node`] omits an id-less payload —
+    /// the same skip rule as [`tree_to_update`](crate::tree_to_update).
+    /// Every node the pipeline assembles carries an identity.
     pub id: Option<AccessibilityNodeId>,
     /// Flags bitmask.
     pub flags: u64,
@@ -210,7 +214,21 @@ impl SemanticsTreeUpdateBuilder {
     }
 
     /// Adds a node to the update.
+    ///
+    /// A payload without an identity ([`SemanticsNodeData::id`] of `None`) is
+    /// **omitted**: an update entry the platform cannot address or diff is
+    /// worse than an absent one, and the tree-level constructor
+    /// ([`SemanticsTree::node_data`](crate::tree::SemanticsTree::node_data))
+    /// never produces one — only a hand-built payload can get here without an
+    /// id, and it is dropped with a warning rather than batched.
     pub fn add_node(&mut self, node: SemanticsNodeData) {
+        if node.id.is_none() {
+            tracing::warn!(
+                label = node.label.as_deref(),
+                "dropping a semantics update payload without a stable identity"
+            );
+            return;
+        }
         self.nodes.push(node);
     }
 
@@ -420,6 +438,40 @@ mod tests {
         let update = builder.build();
 
         assert_eq!(update.removed_node_ids[0].as_u64(), published);
+    }
+
+    /// A payload names its subject; a node with no stable identity has no
+    /// payload. Returning content under `id: None` would let it into an
+    /// update that platform and diff consumers cannot address.
+    #[test]
+    fn node_data_is_none_for_an_unaddressable_node() {
+        let mut tree = SemanticsTree::new();
+        let unaddressable = tree.insert(SemanticsNode::new());
+        tree.set_root(Some(unaddressable));
+
+        assert!(tree.node_data(unaddressable).is_none());
+    }
+
+    /// The builder is the assembly seam for `SemanticsTreeUpdate`, so the
+    /// publish path's skip rule must hold there too: a hand-built payload
+    /// without identity is omitted, never batched.
+    #[test]
+    fn the_builder_omits_a_payload_without_identity() {
+        let mut builder = SemanticsTreeUpdateBuilder::new();
+
+        builder.add_node(SemanticsNodeData::default());
+        builder.add_node(SemanticsNodeData {
+            id: Some(AccessibilityNodeId::from(render_id(9))),
+            ..Default::default()
+        });
+
+        let update = builder.build();
+        assert_eq!(update.node_count(), 1);
+        assert_eq!(
+            update.nodes[0].id,
+            Some(AccessibilityNodeId::from(render_id(9))),
+            "only the addressable payload survives into the update"
+        );
     }
 
     #[test]

--- a/crates/flui-semantics/src/update.rs
+++ b/crates/flui-semantics/src/update.rs
@@ -1,33 +1,44 @@
-//! Batched semantics-update payloads.
+//! Batched semantics-update payloads, keyed by stable identity.
 //!
-//! # These payloads are NOT the platform format — their ids are arena positions
+//! # One id space: [`AccessibilityNodeId`]
 //!
-//! Every identity in this module (`SemanticsNodeData::id`, its `children`,
-//! `SemanticsTreeUpdate::removed_node_ids`) is a 0-based arena position in a
-//! tree the pipeline rebuilds every pass. Inserting or removing a sibling
-//! shifts later positions, and a recycled slot hands a retired control's
-//! number to an unrelated one — so publishing these values to an OS
-//! accessibility adapter drops screen-reader focus on unrelated changes, and
-//! an action request addressed back with one of them lands in the wrong
-//! number space entirely (`SemanticsOwner::resolve_action` matches the stable
-//! [`AccessibilityNodeId`](crate::AccessibilityNodeId) space, so every such
-//! action fails as `NodeNotFound`). That is the exact bug the AccessKit
-//! translation shipped once and was caught in review.
+//! Every identity in this module — [`SemanticsNodeData::id`], its
+//! [`children`](SemanticsNodeData::children), and
+//! [`SemanticsTreeUpdate::removed_node_ids`] — is the stable OS-facing
+//! [`AccessibilityNodeId`], the same space [`tree_to_update`](crate::tree_to_update)
+//! publishes and [`SemanticsOwner::resolve_action`](crate::SemanticsOwner::resolve_action)
+//! matches inbound actions against. `SemanticsId` — an arena position in a
+//! tree the pipeline rebuilds every pass — never appears here.
 //!
-//! What actually crosses to a platform adapter is [`accesskit::TreeUpdate`],
-//! produced by [`tree_to_update`](crate::tree_to_update), which takes node
-//! identity from [`SemanticsNode::accessibility_id`](crate::SemanticsNode::accessibility_id)
-//! — never from these payloads. Use this module for in-process batching and
-//! diagnostics. If a consumer ever needs stable identity here, add
-//! `accessibility_id` to the payload *with* that consumer — the field is
-//! deliberately not added speculatively, because an identity nothing reads
-//! cannot be verified against anything.
+//! This mirrors Flutter, whose update payload
+//! (`SemanticsUpdateBuilder.updateNode`) carries the node's stable
+//! `SemanticsNode.id` and its children (`childrenInTraversalOrder`) in that
+//! one id space, with no positional identity anywhere in the payload. FLUI
+//! derives the stable id from the boundary's generational render identity
+//! instead of a construction-time counter — see
+//! [`AccessibilityNodeId`] for that documented
+//! divergence — but the payload contract is the same: a node that logically
+//! persists keeps its id across rebuilds and sibling reorders, so an adapter
+//! can diff two updates and assistive-technology focus stays attached.
+//!
+//! An earlier shape of this payload carried 0-based arena positions and was
+//! doc-labelled as the platform format; publishing those values shifts a
+//! control's identity whenever a sibling is inserted or removed, and an
+//! action request addressed back with one lands in the wrong number space
+//! entirely. The types here now make that unrepresentable: there is no arena
+//! value to leak.
+//!
+//! The constructor that fills a node's payload — including resolving its
+//! children into this space — is
+//! [`SemanticsTree::node_data`](crate::tree::SemanticsTree::node_data); only
+//! the tree can resolve child identities, because a node stores its children
+//! as arena ids.
 
-use flui_foundation::SemanticsId;
 use flui_types::{Matrix4, Rect, geometry::Pixels};
 use smallvec::SmallVec;
 use smol_str::SmolStr;
 
+use crate::identity::AccessibilityNodeId;
 use crate::properties::TextDirection;
 use crate::role::SemanticsRole;
 
@@ -35,17 +46,19 @@ use crate::role::SemanticsRole;
 // SemanticsNodeData
 // ============================================================================
 
-/// Serialized data for one semantics node.
+/// Serialized data for one semantics node, keyed by its stable identity.
 ///
-/// **Not the platform format**: `id` and `children` are 0-based arena
-/// positions, valid only within the pass that produced them — see the module
-/// doc for why publishing them to an accessibility adapter is a bug and what
-/// the real platform payload is.
+/// `id` and `children` are [`AccessibilityNodeId`]s — the space the platform
+/// tree is published in and actions come back in (see the module doc).
 #[derive(Debug, Clone)]
 pub struct SemanticsNodeData {
-    /// The node's 0-based arena position — NOT its stable
-    /// [`AccessibilityNodeId`](crate::AccessibilityNodeId); see the module doc.
-    pub id: u64,
+    /// The node's stable OS-facing identity.
+    ///
+    /// `None` only for a node never bound to a render boundary — such a node
+    /// is unaddressable and is not published (the same skip rule as
+    /// [`tree_to_update`](crate::tree_to_update)). Every node the pipeline
+    /// assembles carries an identity.
+    pub id: Option<AccessibilityNodeId>,
     /// Flags bitmask.
     pub flags: u64,
     /// Actions bitmask.
@@ -68,9 +81,16 @@ pub struct SemanticsNodeData {
     pub rect: Rect<Pixels>,
     /// Transform matrix.
     pub transform: Matrix4,
-    /// Children as 0-based arena positions — same space and caveat as
-    /// [`Self::id`].
-    pub children: SmallVec<[u64; 4]>,
+    /// Stable identities of this node's addressable children, in child order.
+    ///
+    /// Same space as [`Self::id`]. An unaddressable child is omitted rather
+    /// than exported under a fabricated id. Only
+    /// [`SemanticsTree::node_data`](crate::tree::SemanticsTree::node_data)
+    /// can fill this — a node alone cannot resolve its children's stable
+    /// identities — so a node-level export
+    /// ([`SemanticsNode::to_node_data`](crate::SemanticsNode::to_node_data))
+    /// leaves it empty.
+    pub children: SmallVec<[AccessibilityNodeId; 4]>,
     /// Platform view ID.
     pub platform_view_id: Option<i32>,
     /// Maximum value length for text fields.
@@ -102,7 +122,7 @@ pub struct SemanticsNodeData {
 impl Default for SemanticsNodeData {
     fn default() -> Self {
         Self {
-            id: 0,
+            id: None,
             flags: 0,
             actions: 0,
             label: None,
@@ -134,20 +154,17 @@ impl Default for SemanticsNodeData {
 
 /// A batched semantics-tree update: added/updated nodes plus removed ids.
 ///
-/// **Not the platform format** — every id here is a 0-based arena position
-/// (see the module doc). In particular, a removal notice keyed on an arena
-/// position would tell an adapter to drop an id it was never given.
-///
-/// See also [`SemanticsNodeUpdate`](crate::owner::SemanticsNodeUpdate) for
-/// individual node updates.
+/// Every id is a stable [`AccessibilityNodeId`] (module doc). In particular a
+/// removal notice names exactly the id the node was published under, so an
+/// adapter told to drop it is dropping an id it was actually given.
 #[derive(Debug, Clone, Default)]
 pub struct SemanticsTreeUpdate {
     /// Nodes that have been added or updated.
     pub nodes: Vec<SemanticsNodeData>,
 
-    /// 0-based arena positions of nodes that have been removed — the same
-    /// in-process space as [`SemanticsNodeData::id`], with the same caveat.
-    pub removed_node_ids: SmallVec<[u64; 8]>,
+    /// Stable identities of nodes that have been removed — the same space as
+    /// [`SemanticsNodeData::id`].
+    pub removed_node_ids: SmallVec<[AccessibilityNodeId; 8]>,
 }
 
 impl SemanticsTreeUpdate {
@@ -183,7 +200,7 @@ impl SemanticsTreeUpdate {
 #[derive(Debug, Default)]
 pub struct SemanticsTreeUpdateBuilder {
     nodes: Vec<SemanticsNodeData>,
-    removed_node_ids: SmallVec<[u64; 8]>,
+    removed_node_ids: SmallVec<[AccessibilityNodeId; 8]>,
 }
 
 impl SemanticsTreeUpdateBuilder {
@@ -197,15 +214,15 @@ impl SemanticsTreeUpdateBuilder {
         self.nodes.push(node);
     }
 
-    /// Adds a removed node ID.
-    pub fn add_removed_node(&mut self, id: SemanticsId) {
-        // 0-based arena position — same in-process space as the rest
-        // of this payload, NOT a platform-facing identity (module doc).
-        self.removed_node_ids.push((id.get() - 1) as u64);
-    }
-
-    /// Adds a removed node by raw ID.
-    pub fn add_removed_node_raw(&mut self, id: u64) {
+    /// Records the removal of the node published under `id`.
+    ///
+    /// Takes the stable [`AccessibilityNodeId`] — obtained from
+    /// [`SemanticsNode::accessibility_id`](crate::SemanticsNode::accessibility_id)
+    /// *before* the node is dropped from the tree, since the identity is not
+    /// resolvable afterwards. There is deliberately no raw-integer variant:
+    /// re-entering this space from an untyped number is how an arena position
+    /// leaks back in.
+    pub fn add_removed_node(&mut self, id: AccessibilityNodeId) {
         self.removed_node_ids.push(id);
     }
 
@@ -232,7 +249,20 @@ impl SemanticsTreeUpdateBuilder {
 
 #[cfg(test)]
 mod tests {
+    use flui_foundation::RenderId;
+
     use super::*;
+    use crate::node::SemanticsNode;
+    use crate::tree::SemanticsTree;
+
+    /// A render identity whose packed value is deliberately unequal to any
+    /// plausible arena position, so a test cannot pass by coincidence.
+    fn render_id(index: u32) -> RenderId {
+        RenderId::new_gen(
+            index,
+            core::num::NonZeroU32::new(7).expect("fixture generation is non-zero"),
+        )
+    }
 
     #[test]
     fn test_semantics_tree_update_empty() {
@@ -247,29 +277,149 @@ mod tests {
         let mut builder = SemanticsTreeUpdateBuilder::new();
 
         builder.add_node(SemanticsNodeData {
-            id: 0,
+            id: Some(AccessibilityNodeId::from(render_id(1))),
             label: Some(SmolStr::from("Test")),
             ..Default::default()
         });
 
-        builder.add_removed_node_raw(5);
+        let removed = AccessibilityNodeId::from(render_id(5));
+        builder.add_removed_node(removed);
 
         let update = builder.build();
 
         assert!(!update.is_empty());
         assert_eq!(update.node_count(), 1);
         assert_eq!(update.removed_count(), 1);
-        assert!(update.removed_node_ids.contains(&5));
+        assert!(update.removed_node_ids.contains(&removed));
     }
 
     #[test]
     fn test_semantics_node_data_default() {
         let data = SemanticsNodeData::default();
-        assert_eq!(data.id, 0);
+        assert!(data.id.is_none());
         assert_eq!(data.flags, 0);
         assert_eq!(data.actions, 0);
         assert!(data.label.is_none());
         assert!(data.children.is_empty());
+    }
+
+    /// **The identity-stability contract this payload exists for.** Inserting
+    /// a sibling ahead of a control shifts its arena position; its payload
+    /// identity must not move, or an adapter diffing two updates sees an
+    /// unchanged control as removed-and-replaced and drops focus.
+    #[test]
+    fn payload_identity_survives_a_sibling_inserted_before_the_node() {
+        let source = render_id(42);
+
+        let data_for = |leading_siblings: u32| {
+            let mut tree = SemanticsTree::new();
+            let mut root_node = SemanticsNode::new().with_source_render_id(render_id(1));
+            for index in 0..leading_siblings {
+                let sibling =
+                    tree.insert(SemanticsNode::new().with_source_render_id(render_id(100 + index)));
+                root_node.add_child(sibling);
+            }
+            let target = tree.insert(SemanticsNode::new().with_source_render_id(source));
+            root_node.add_child(target);
+            let root = tree.insert(root_node);
+            tree.set_root(Some(root));
+            tree.node_data(target).expect("target is live")
+        };
+
+        let before = data_for(0);
+        let after = data_for(3);
+
+        assert_eq!(
+            before.id,
+            Some(AccessibilityNodeId::from(source)),
+            "the payload id is the stable render-boundary identity"
+        );
+        assert_eq!(
+            before.id, after.id,
+            "arena positions shifted; the payload identity must not"
+        );
+    }
+
+    /// Children are exported in the same stable space as the ids they will be
+    /// published under — never as arena positions.
+    #[test]
+    fn payload_children_are_stable_identities_in_child_order() {
+        let first = render_id(51);
+        let second = render_id(52);
+
+        let mut tree = SemanticsTree::new();
+        let first_id = tree.insert(SemanticsNode::new().with_source_render_id(first));
+        let second_id = tree.insert(SemanticsNode::new().with_source_render_id(second));
+        let mut root_node = SemanticsNode::new().with_source_render_id(render_id(50));
+        root_node.add_child(first_id);
+        root_node.add_child(second_id);
+        let root = tree.insert(root_node);
+        tree.set_root(Some(root));
+
+        let data = tree.node_data(root).expect("root is live");
+        assert_eq!(
+            data.children.as_slice(),
+            &[
+                AccessibilityNodeId::from(first),
+                AccessibilityNodeId::from(second),
+            ],
+        );
+        assert_ne!(
+            data.children[0].as_u64(),
+            (first_id.get() - 1) as u64,
+            "the fixture is only meaningful while the two id spaces differ"
+        );
+    }
+
+    /// An unaddressable child has no identity to export; omitting it mirrors
+    /// the publish path's skip rule rather than inventing an id that could
+    /// collide with a real control.
+    #[test]
+    fn an_unaddressable_child_is_omitted_from_the_payload() {
+        let mut tree = SemanticsTree::new();
+        let unaddressable = tree.insert(SemanticsNode::new());
+        let addressable_render = render_id(61);
+        let addressable =
+            tree.insert(SemanticsNode::new().with_source_render_id(addressable_render));
+        let mut root_node = SemanticsNode::new().with_source_render_id(render_id(60));
+        root_node.add_child(unaddressable);
+        root_node.add_child(addressable);
+        let root = tree.insert(root_node);
+        tree.set_root(Some(root));
+
+        let data = tree.node_data(root).expect("root is live");
+        assert_eq!(
+            data.children.as_slice(),
+            &[AccessibilityNodeId::from(addressable_render)],
+        );
+    }
+
+    /// A removal notice names exactly the id the node was published under, so
+    /// the two ends of the payload cannot drift into different number spaces.
+    #[test]
+    fn a_removal_notice_names_the_id_the_node_was_published_under() {
+        let source = render_id(71);
+        let mut tree = SemanticsTree::new();
+        let root = tree.insert(SemanticsNode::new().with_source_render_id(source));
+        tree.set_root(Some(root));
+
+        let published = crate::tree_to_update(&tree, None)
+            .expect("a rooted tree yields an update")
+            .nodes
+            .first()
+            .map(|(id, _)| id.0)
+            .expect("one node");
+
+        let identity = tree
+            .get(root)
+            .and_then(SemanticsNode::accessibility_id)
+            .expect("a render-backed node is addressable");
+
+        let mut builder = SemanticsTreeUpdateBuilder::new();
+        builder.add_removed_node(identity);
+        let update = builder.build();
+
+        assert_eq!(update.removed_node_ids[0].as_u64(), published);
     }
 
     #[test]
@@ -277,10 +427,10 @@ mod tests {
         let mut data = SemanticsNodeData::default();
 
         // Add children up to inline capacity
-        data.children.push(1);
-        data.children.push(2);
-        data.children.push(3);
-        data.children.push(4);
+        for index in 1..=4 {
+            data.children
+                .push(AccessibilityNodeId::from(render_id(index)));
+        }
 
         assert_eq!(data.children.len(), 4);
         // Should be inline, not heap allocated


### PR DESCRIPTION
## What

Closes #680. The in-process semantics update payloads — `SemanticsNodeData` (`id`, `children`), `SemanticsTreeUpdate::removed_node_ids`, and the `SemanticsNodeUpdate` type — were the last platform-advertised surfaces still carrying 0-based arena positions (`SemanticsId` arithmetic, valid only within the pass that produced them). This PR re-keys the whole family to the stable OS-facing `AccessibilityNodeId`, the same space `tree_to_update` publishes and `SemanticsOwner::resolve_action` matches inbound actions against, so an arena position can no longer leak into anything an adapter (or #687's incremental diff) consumes. The leak is now unrepresentable in the type system, not just doc-warned against.

## Identity model (vs Flutter)

Verified against `.flutter/packages/flutter/lib/src/semantics/semantics.dart`: Flutter allocates a stable per-node id at `SemanticsNode` construction (`_generateNewId`) and keys the entire update payload (`SemanticsUpdateBuilder.updateNode`: `id`, `childrenInTraversalOrder`) in that single stable space — no positional identity anywhere in the payload. FLUI ports the payload contract (one stable id space; a logically-persistent node keeps its id across rebuilds and sibling reorders) but keeps its documented divergence in *derivation*: the id follows the boundary's generational `RenderId` (`AccessibilityNodeId`, `identity.rs`) rather than a construction counter, because FLUI rebuilds the semantics arena every pass while Flutter persists node objects. Same observable stability; slot reuse mints a fresh id, exactly as Flutter's detach/reattach does.

**Alternatives considered** (per the id-allocation design note): (a) a process/realm-global counter with a persistence map, closer to Flutter's mechanism — rejected: it would introduce a second identity authority next to the render tree and a map that must be garbage-collected in lockstep with it; (b) additive-only (`accessibility_id: Option<...>` next to the arena `id`, the issue's minimal sketch) — rejected: a dual-space payload keeps the trap half-alive, and Flutter's payload has exactly one space.

## How

- `SemanticsNodeData.id: Option<AccessibilityNodeId>` (`None` only for a node never bound to a render boundary — unpublishable, same skip rule as `tree_to_update`); `children: SmallVec<[AccessibilityNodeId; 4]>`, addressable children only, in child order.
- `SemanticsTree::node_data(SemanticsId)` is the payload constructor — only the tree can resolve child identities, since a node stores its children as arena ids. `SemanticsNode::to_node_data()` (arena-id parameter dropped) exports content + own identity, children deliberately empty and doc'd.
- `SemanticsTreeUpdate::removed_node_ids: SmallVec<[AccessibilityNodeId; 8]>`; `add_removed_node` takes the typed identity; `add_removed_node_raw` (untyped u64 re-entry) deleted.
- `SemanticsNodeUpdate` deleted: keyed on `SemanticsId`, structurally unable to express stable identity (why #677 removed `to_tree_update`), zero consumers (`rg` sweep: only its own tests, the flui-semantics/flui-rendering re-exports, and one doc-comment — all updated).
- AccessKit translation now derives children from the payload (`to_node(data)`), collapsing the dual-source design whose doc had to warn "children are NOT derived from `SemanticsNodeData::children`".
- Docs: `update.rs` module doc rewritten from "NOT the platform format" warnings to the positive single-space contract; README pipeline sketch and `accessors.rs` escape-hatch doc updated.

## Evidence

- **Sabotage-verified red** (behavioral, not compile-level): re-deriving payload `id`/`children` from arena positions fails 3 new pins (`payload_identity_survives_a_sibling_inserted_before_the_node`, `payload_children_are_stable_identities_in_child_order`, `an_unaddressable_child_is_omitted_from_the_payload`) plus 2 pre-existing translation pins; re-entering the removal list from a shifted number space fails `a_removal_notice_names_the_id_the_node_was_published_under`. Fixtures use generation-7 render ids so stable and arena values can never collide by coincidence.
- Suites: flui-semantics 190/190; flui-rendering 868/868; flui-platform (`--all-features`, `FLUI_HEADLESS=1` + `xvfb-run`, the CI mechanism) 234 passed / 8 skipped.
- Full gate: `just ci` exit 0 (workspace nextest 9073 passed / 11 skipped, plus doc tests); `typos`, `taplo fmt --check`, `just port-check`, `just inventory-check`, `just runtime-conformance-check` all clean (no monitored export touched — the export-root manifest covers neither flui-semantics nor flui-rendering's prelude).

## What this unblocks, and what remains elsewhere

- **#687**: its prerequisite ("carry stable identity in the node payload") is done; still open there — the per-node diff in `flush`, the O(1) dirty counter, and assembly reuse.
- **#675**: the AT-SPI bridge already consumed the stable-keyed `accesskit::TreeUpdate`; this removes the mis-advertised arena payloads an adapter author could have trusted. Remaining #675 slices (Windows/macOS adapters, agent surface) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM