### PR TITLE
feat(semantics): incremental flush — idle publishes nothing, a change publishes O(dirty)

### DIFF
--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -355,10 +355,18 @@ impl PresentationState {
         });
 
         let enabled_flag = semantics.platform_semantics_enabled_handle();
+        let republish_flag = semantics.full_republish_handle();
         let wake = Arc::clone(wake);
         let awaken_window = Arc::downgrade(window);
         bridge.set_activation_listener(Arc::new(move |active| {
             enabled_flag.store(active, Ordering::Relaxed);
+            if active {
+                // A (re)attached assistive technology's state is unknown —
+                // it may have forgotten everything — and flushes publish
+                // incrementally, so it must be answered with a
+                // self-contained full tree, not the next diff.
+                republish_flag.store(true, Ordering::Relaxed);
+            }
             // The flag alone changes nothing until a frame runs: wake the
             // loop and poke this window so the reconcile actually happens.
             wake();
@@ -877,9 +885,22 @@ impl PresentationState {
     /// the two transitions.
     pub(crate) fn reconcile_semantics_enablement(&self) {
         let wanted = self.semantics.semantics_enabled();
+        // Consumed unconditionally: a request that arrives alongside a
+        // deactivation must not linger and fire on some later re-enable.
+        let full_republish = self.semantics.take_full_republish_request();
         self.pipeline.with_mut(|owner| {
             if owner.semantics_enabled() != wanted {
                 owner.set_semantics_enabled(wanted);
+            }
+            if full_republish && wanted {
+                // Activation with an owner already alive (a screen reader
+                // restarting without an intervening deactivation, or one
+                // attaching after a handle enabled semantics first): the
+                // adapter must be re-answered with a self-contained tree.
+                // On the enable transition just above this is a no-op-shaped
+                // reinforcement — the fresh owner's first flush is full
+                // anyway.
+                owner.request_semantics_full_publish();
             }
         });
     }

--- a/crates/flui-app/src/app/semantics_host.rs
+++ b/crates/flui-app/src/app/semantics_host.rs
@@ -90,6 +90,21 @@ pub(crate) struct SemanticsHost {
     /// `needs_redraw` handle-sharing shape for the identical reason.
     platform_semantics_enabled: Arc<AtomicBool>,
 
+    /// Whether the platform adapter needs a self-contained full republish.
+    ///
+    /// Set (from the adapter's own thread, via
+    /// [`Self::full_republish_handle`]) whenever assistive technology
+    /// activates: the adapter's state is unknown at that moment — a freshly
+    /// started screen reader has nothing, and `SemanticsOwner::flush`
+    /// publishes incrementally, so waiting for the next diff would leave it
+    /// with a fragment. Consumed on the owner thread by
+    /// [`Self::take_full_republish_request`] during
+    /// `PresentationState::reconcile_semantics_enablement`, which routes it
+    /// to `PipelineOwner::request_semantics_full_publish`. Same
+    /// `Arc`-wrapped shape as `platform_semantics_enabled`, for the same
+    /// self-reference reason.
+    full_republish_requested: Arc<AtomicBool>,
+
     /// Callback for accessibility announcements. `PresentationState::close()`
     /// clears this unconditionally in production (see
     /// [`Self::clear_announce_callback`]); `announce()`'s read side still
@@ -113,6 +128,7 @@ impl SemanticsHost {
         Self {
             handle_count: Arc::new(AtomicUsize::new(0)),
             platform_semantics_enabled: Arc::new(AtomicBool::new(false)),
+            full_republish_requested: Arc::new(AtomicBool::new(false)),
             announce_callback: RwLock::new(None),
             event_callback: RwLock::new(None),
         }
@@ -179,6 +195,20 @@ impl SemanticsHost {
     /// borrowing `&self`. Wired at `UiRealm::construct`.
     pub(crate) fn platform_semantics_enabled_handle(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.platform_semantics_enabled)
+    }
+
+    /// A cheap clone of the full-republish request flag, for the activation
+    /// listener (which runs on the adapter's thread and can only touch
+    /// `Send + Sync` state). See the field's own doc for the contract.
+    pub(crate) fn full_republish_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.full_republish_requested)
+    }
+
+    /// Consumes a pending full-republish request, if any — the owner-thread
+    /// half of the activation seam. Returns `true` at most once per
+    /// request.
+    pub(crate) fn take_full_republish_request(&self) -> bool {
+        self.full_republish_requested.swap(false, Ordering::Relaxed)
     }
 
     // ========== Announcements ==========

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -3814,6 +3814,50 @@ mod tests {
         );
     }
 
+    /// Assistive technology attaching must also request a self-contained
+    /// full republish (the adapter's state is unknown, and flushes publish
+    /// incrementally — the next diff would answer a fresh screen reader
+    /// with a fragment). The listener may only set the flag; the frame
+    /// reconcile consumes it on the owner thread and routes it to
+    /// `PipelineOwner::request_semantics_full_publish`.
+    #[test]
+    fn at_activation_requests_a_full_republish_and_the_reconcile_consumes_it() {
+        let fake = Arc::new(flui_platform::FakeAccessibility::new());
+        let window =
+            crate::app::presentation::test_platform_window_with_accessibility(Arc::clone(&fake));
+        let realm = UiRealm::new(noop_wake(), window, 1.0, Arc::new(AtomicBool::new(false)))
+            .expect("realm");
+        let host_flag = realm
+            .presentations
+            .primary()
+            .semantics_host()
+            .full_republish_handle();
+        let constraints = BoxConstraints::tight(Size::new(px(100.0), px(100.0)));
+
+        fake.set_active(true);
+        assert!(
+            host_flag.load(Ordering::Relaxed),
+            "activation must record that the adapter needs a full tree"
+        );
+
+        realm.enter(|_| {
+            let _ = realm.draw_frame_entered(constraints);
+        });
+        assert!(
+            !host_flag.load(Ordering::Relaxed),
+            "the frame reconcile consumes the request exactly once"
+        );
+
+        fake.set_active(false);
+        realm.enter(|_| {
+            let _ = realm.draw_frame_entered(constraints);
+        });
+        assert!(
+            !host_flag.load(Ordering::Relaxed),
+            "deactivation must not request a republish nobody will hear"
+        );
+    }
+
     /// Teardown withdraws from the platform bridge: after the presentation
     /// closes, an activation flip delivered by the (longer-lived) adapter
     /// must not reach the dead presentation's enablement flag — `close()`

--- a/crates/flui-platform/src/platforms/linux/accessibility.rs
+++ b/crates/flui-platform/src/platforms/linux/accessibility.rs
@@ -52,9 +52,18 @@ use crate::traits::{
 struct Shared {
     /// Whether assistive technology is currently attached.
     active: AtomicBool,
-    /// The most recent tree, kept so a late activation can be answered
-    /// immediately rather than showing an empty application until the next
-    /// frame happens to dirty something.
+    /// The most recent **self-contained** update (one carrying
+    /// [`TreeUpdate::tree`] metadata — the producer's promise that it stands
+    /// alone), kept so a late activation can be answered immediately rather
+    /// than showing an empty application until the next frame happens to
+    /// dirty something.
+    ///
+    /// Incremental updates (`tree: None`) are deliberately not retained:
+    /// applied in isolation they describe a handful of changed nodes, and
+    /// answering a fresh screen reader with one would present a fragment as
+    /// the whole interface. The composition root re-publishes a full tree on
+    /// every activation, so this retained answer is at worst one full
+    /// publish behind and is corrected within a frame.
     latest: Mutex<Option<TreeUpdate>>,
     activation_listener: Mutex<Option<AccessibilityActivationListener>>,
     action_listener: Mutex<Option<AccessibilityActionListener>>,
@@ -158,15 +167,20 @@ impl std::fmt::Debug for UnixAccessibility {
 
 impl PlatformAccessibility for UnixAccessibility {
     fn publish(&self, update: TreeUpdate) {
-        // Retained even while inactive: a screen reader started later asks for
-        // an initial tree, and answering it from here shows the real interface
-        // immediately instead of an empty window until something next changes.
+        // Self-contained updates are retained even while inactive: a screen
+        // reader started later asks for an initial tree, and answering it
+        // from here shows the real interface immediately instead of an empty
+        // window until something next changes. Incremental updates are not
+        // retained — see the field doc for why a fragment must never answer
+        // an activation.
         //
         // Exactly one clone, and it buys that retention. `update_if_active`
         // takes a factory, so the owned value moves into the adapter only when
         // something is attached; with nobody listening the closure never runs
         // and the value is simply dropped.
-        *self.shared.latest.lock() = Some(update.clone());
+        if update.tree.is_some() {
+            *self.shared.latest.lock() = Some(update.clone());
+        }
         self.adapter.lock().update_if_active(move || update);
     }
 
@@ -227,6 +241,29 @@ mod tests {
         let retained = retained.expect("the tree is kept for a late activation");
         let (_, node) = retained.nodes.first().expect("one node");
         assert_eq!(node.label(), Some("Submit"));
+    }
+
+    /// An incremental update — no tree metadata, a fragment of changed
+    /// nodes — must never become the answer to a fresh activation: applied
+    /// in isolation it would present a handful of nodes as the whole
+    /// interface. Only self-contained updates are retained.
+    #[test]
+    fn an_incremental_update_is_not_retained_for_activation() {
+        let accessibility = UnixAccessibility::new();
+        accessibility.publish(tree_update("Submit"));
+
+        let mut fragment = tree_update("Changed");
+        fragment.tree = None;
+        accessibility.publish(fragment);
+
+        let retained = accessibility.shared.latest.lock().clone();
+        let retained = retained.expect("the earlier full update stays retained");
+        let (_, node) = retained.nodes.first().expect("one node");
+        assert_eq!(
+            node.label(),
+            Some("Submit"),
+            "the retained answer is the last self-contained update, not the fragment"
+        );
     }
 
     /// The activation handler answers with the retained tree, which is the

--- a/crates/flui-platform/src/traits/accessibility.rs
+++ b/crates/flui-platform/src/traits/accessibility.rs
@@ -55,16 +55,20 @@ pub type AccessibilityActionListener = Arc<dyn Fn(ActionRequest) + Send + Sync>;
 
 /// Platform capability for exposing one window's accessibility tree.
 pub trait PlatformAccessibility: Send + Sync {
-    /// Hand the platform the current tree.
+    /// Hand the platform an update — incremental or self-contained.
     ///
-    /// Taken **by value** so an implementation can move it into the platform's
-    /// own update call instead of cloning. A full-tree update is what
-    /// `SemanticsOwner::flush` produces, so on the active path a borrowed
-    /// parameter would charge one whole-tree clone per publish, per frame that
-    /// changed anything — see the cost issue on the semantics pipeline.
+    /// `SemanticsOwner::flush` publishes incrementally: most updates carry
+    /// only the nodes that changed, with `TreeUpdate::tree` set to `None`.
+    /// An update whose `tree` metadata is present is the producer's promise
+    /// that it is **self-contained** (the initializing publish, a root
+    /// change, and every reconnect-driven `send_full_tree`) — the only kind
+    /// an implementation may retain to answer a late-activating screen
+    /// reader on its own.
     ///
-    /// An implementation with nothing attached simply drops it, which costs
-    /// nothing the caller had not already spent building it.
+    /// Taken **by value** so an implementation can move it into the
+    /// platform's own update call instead of cloning. An implementation with
+    /// nothing attached simply drops it, which costs nothing the caller had
+    /// not already spent building it.
     fn publish(&self, update: TreeUpdate);
 
     /// Whether assistive technology is currently attached.

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -1624,6 +1624,27 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         self.semantics_update_callback = Some(callback);
     }
 
+    /// Schedules a self-contained full semantics publish, re-seeding the
+    /// assembly pass so it actually happens.
+    ///
+    /// The reconnect path: assistive technology (re)activated, so whatever
+    /// the adapter previously held is unknown — the owner forgets its
+    /// published-state mirror ([`flui_semantics::SemanticsOwner::schedule_full_publish`])
+    /// and the root is marked as needing semantics so the next
+    /// `run_semantics` rebuilds and flushes even on an otherwise-idle
+    /// frame. A no-op while no owner exists: the enable transition that
+    /// creates one starts from an empty mirror, which is already a full
+    /// first publish.
+    pub fn request_semantics_full_publish(&mut self) {
+        let Some(owner) = self.semantics_owner.as_mut() else {
+            return;
+        };
+        owner.schedule_full_publish();
+        if let Some(root_id) = self.root_id {
+            self.mark_needs_semantics(root_id);
+        }
+    }
+
     /// Returns the semantics owner, if semantics is currently enabled.
     ///
     /// `None` until [`Self::set_semantics_enabled`]`(true)` lazily creates

--- a/crates/flui-rendering/src/pipeline/owner/mod.rs
+++ b/crates/flui-rendering/src/pipeline/owner/mod.rs
@@ -715,6 +715,108 @@ mod tests {
         );
     }
 
+    /// The pipeline-level idle contract: `run_semantics` reassembles the
+    /// whole arena whenever anything is marked (ADR-0014), but a pass whose
+    /// assembly reproduces the same tree must deliver NOTHING to the
+    /// platform — the owner's flush diffs per-node payloads against the
+    /// last delivered update. Before that diff, every marked-but-unchanged
+    /// pass republished the entire tree.
+    #[test]
+    fn an_identical_second_semantics_pass_publishes_nothing() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let root_id = owner.set_root_render_object(Box::new(SemanticLeaf::labeled("Submit")));
+        owner.set_semantics_enabled(true);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let mut owner = owner.finish();
+        assert_eq!(
+            captured
+                .lock()
+                .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                .len(),
+            1,
+            "the first pass publishes the initializing full tree"
+        );
+
+        // Mark the root again without changing anything observable — the
+        // shape of "a repaint touched this subtree, semantics did not move".
+        owner.mark_needs_semantics(root_id);
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("second semantics pass");
+
+        assert_eq!(
+            captured
+                .lock()
+                .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                .len(),
+            1,
+            "a pass that reassembles an identical tree must publish nothing"
+        );
+    }
+
+    /// The reconnect path: `request_semantics_full_publish` must make the
+    /// next pass republish a self-contained full tree even though nothing
+    /// changed — a (re)activated adapter's state is unknown, and an
+    /// incremental flush would answer it with silence. The accessor also
+    /// re-seeds assembly itself; the test deliberately marks nothing.
+    #[test]
+    fn request_semantics_full_publish_makes_an_idle_pass_republish_everything() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let _ = owner.set_root_render_object(Box::new(SemanticLeaf::labeled("Submit")));
+        owner.set_semantics_enabled(true);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let mut owner = owner.finish();
+
+        owner.request_semantics_full_publish();
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("reconnect semantics pass");
+
+        let published = captured
+            .lock()
+            .expect("BUG: capture mutex is uncontended in this single-threaded test");
+        assert_eq!(
+            published.len(),
+            2,
+            "the reconnect pass must publish despite zero changes"
+        );
+        assert!(
+            published[1].tree.is_some(),
+            "and what it publishes is self-contained (tree metadata present)"
+        );
+        assert_eq!(
+            published[1].nodes.len(),
+            published[0].nodes.len(),
+            "carrying every node, not a diff"
+        );
+    }
+
     #[test]
     fn run_semantics_builds_owner_tree() {
         let mut owner = PipelineOwner::new();

--- a/crates/flui-semantics/benches/publish_cost.rs
+++ b/crates/flui-semantics/benches/publish_cost.rs
@@ -12,14 +12,17 @@
 //! # The three scenarios
 //!
 //! - **idle** — a clean tree, the common case while a screen reader is
-//!   attached but nothing is changing. This is the one whose cost is
-//!   counter-intuitive: `has_dirty_nodes` short-circuits on the *first dirty*
-//!   node, so a clean tree is scanned to the end. Idle is the worst case, not
-//!   the cheap one.
-//! - **one_dirty** — a single changed node, the shape of a checkbox toggling.
-//!   Measures what one small change costs: today, a full-tree translation.
-//! - **all_dirty** — every node changed, the shape of a route transition, and
-//!   the ceiling `one_dirty` should be far below but currently approaches.
+//!   attached but nothing is changing. The dirty check is counter-backed
+//!   O(1); before that counter it was an `any()` scan whose worst case was
+//!   exactly this scenario (a clean tree was scanned to the end), so idle
+//!   was the most expensive check of the three.
+//! - **one_dirty** — a single genuinely changed node, the shape of a
+//!   checkbox toggling. The incremental flush translates the one dirty node
+//!   and publishes the one changed node; before the diff this scenario
+//!   translated and published the whole tree, tracking `all_dirty`.
+//! - **all_dirty** — every node changed, the shape of a route transition,
+//!   and the full-republish path (`send_full_tree`) by construction: the
+//!   ceiling `one_dirty` must stay far below.
 //!
 //! Sizes span 16..1024 nodes. A real application's semantics tree holds
 //! *boundaries*, not widgets, so 1024 is a large app rather than an absurd one.
@@ -69,9 +72,9 @@ fn publish_cost(c: &mut Criterion) {
     let mut group = c.benchmark_group("semantics_publish");
 
     for count in [16u32, 64, 256, 1024] {
-        // A clean tree publishes nothing. What it still pays is the dirty
-        // check — and that check scans furthest precisely when there is
-        // nothing to do.
+        // A clean tree publishes nothing. What it pays is the dirty check
+        // alone — counter-backed O(1) now; it used to be a scan that walked
+        // furthest precisely when there was nothing to do.
         group.bench_with_input(BenchmarkId::new("idle", count), &count, |b, &count| {
             let mut owner = owner_with(count);
             b.iter(|| {
@@ -80,14 +83,22 @@ fn publish_cost(c: &mut Criterion) {
             });
         });
 
-        // One changed node. Today this translates and publishes the whole
-        // tree, so it should track `all_dirty` rather than staying flat —
-        // that gap is the thing worth closing.
+        // One genuinely changed node — the shape of a checkbox toggling.
+        // The label alternates so every iteration publishes a real
+        // single-node diff; a no-op re-mark would measure only the
+        // empty-diff path. This is the scenario the incremental flush
+        // exists for: translate the one dirty node, publish the one
+        // changed node, never the tree.
         group.bench_with_input(BenchmarkId::new("one_dirty", count), &count, |b, &count| {
             let mut owner = owner_with(count);
             let target = owner.root().expect("the tree is rooted");
+            let mut flip = false;
             b.iter(|| {
-                owner.mark_dirty(target);
+                flip = !flip;
+                if let Some(node) = owner.get_mut(target) {
+                    node.config_mut()
+                        .set_label(if flip { "toggled on" } else { "toggled off" });
+                }
                 owner.flush();
             });
         });

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -226,15 +226,20 @@ struct PublishedState {
 
 impl PublishedState {
     /// Mirror of a self-contained full update the adapter was just given.
-    fn mirror_of(update: &crate::TreeUpdate) -> Self {
+    ///
+    /// Consumes the update (callers are done delivering it by reference) so
+    /// the mirror is built by moving the translated nodes, not re-cloning
+    /// every label and property the adapter just received — on the full
+    /// publish path that clone was the single largest added cost.
+    fn mirror_of(update: crate::TreeUpdate) -> Self {
         Self {
-            nodes: update.nodes.iter().cloned().collect(),
             root: update
                 .tree
                 .as_ref()
                 .map(|tree| tree.root)
                 .expect("BUG: a full update always carries tree metadata"),
             focus: update.focus,
+            nodes: update.nodes.into_iter().collect(),
         }
     }
 }
@@ -317,7 +322,7 @@ impl SemanticsOwner {
             && let Some(update) = crate::tree_to_update(&self.tree, None)
         {
             callback(&update);
-            self.published = Some(PublishedState::mirror_of(&update));
+            self.published = Some(PublishedState::mirror_of(update));
         }
         self.callback = Some(callback);
     }
@@ -647,7 +652,7 @@ impl SemanticsOwner {
             callback(&update);
         }
 
-        self.published = Some(PublishedState::mirror_of(&update));
+        self.published = Some(PublishedState::mirror_of(update));
         self.full_publish_pending = false;
         self.tree.mark_all_clean();
     }

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -568,10 +568,9 @@ impl SemanticsOwner {
     /// arena every assembly pass (ADR-0014) where Flutter mutates persistent
     /// nodes: a rebuild marks every node dirty, so the dirty bit alone cannot
     /// say what changed. The diff therefore compares each dirty node's
-    /// translation, keyed by its stable [`AccessibilityNodeId`], against the
-    /// [`PublishedState`] mirror of the last delivered update — payload
-    /// equality is authoritative, dirty bits only bound how much is
-    /// re-examined.
+    /// translation, keyed by its stable [`AccessibilityNodeId`], against a
+    /// private mirror of the last delivered update — payload equality is
+    /// authoritative, dirty bits only bound how much is re-examined.
     ///
     /// Three shapes come out of one call:
     ///
@@ -590,7 +589,7 @@ impl SemanticsOwner {
     ///
     /// An unrooted tree publishes nothing and stays dirty, so the first
     /// rooted flush retries (unchanged from the pre-diff behavior; see the
-    /// comment inside [`Self::publish_full`]).
+    /// comment inside the private full-publish path).
     pub fn flush(&mut self) {
         if !self.enabled || !(self.tree.has_dirty_nodes() || self.full_publish_pending) {
             return;

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use flui_foundation::SemanticsId;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -191,6 +191,52 @@ pub struct SemanticsOwner {
 
     /// Whether semantics is enabled.
     enabled: bool,
+
+    /// What the last update told the platform, keyed by stable identity.
+    ///
+    /// `None` until the first publish (or after
+    /// [`Self::schedule_full_publish`] deliberately forgets it): the next
+    /// flush is then a self-contained full update. While `Some`, a flush
+    /// diffs each dirty node's translation against this mirror and publishes
+    /// only what actually changed — which is what keeps a rebuild-everything
+    /// assembly pass (ADR-0014) from republishing an entire tree because one
+    /// checkbox toggled.
+    published: Option<PublishedState>,
+
+    /// Forces the next flush to publish the complete tree even if the diff
+    /// would be empty. Set by [`Self::send_full_tree`] and
+    /// [`Self::schedule_full_publish`]; cleared once a full update is
+    /// actually delivered (an unrooted tree leaves it pending, exactly like
+    /// the dirty bits it travels with).
+    full_publish_pending: bool,
+}
+
+/// Mirror of the adapter-visible tree as of the last delivered update.
+///
+/// The map holds the translated [`accesskit::Node`] per published
+/// [`accesskit::NodeId`] — equality against a fresh translation is the diff.
+/// Entries are pruned when their node leaves the arena, so a node that is
+/// removed and later returns with identical content is correctly republished
+/// (the adapter dropped it in between; the mirror must forget it too).
+struct PublishedState {
+    nodes: FxHashMap<accesskit::NodeId, accesskit::Node>,
+    root: accesskit::NodeId,
+    focus: accesskit::NodeId,
+}
+
+impl PublishedState {
+    /// Mirror of a self-contained full update the adapter was just given.
+    fn mirror_of(update: &crate::TreeUpdate) -> Self {
+        Self {
+            nodes: update.nodes.iter().cloned().collect(),
+            root: update
+                .tree
+                .as_ref()
+                .map(|tree| tree.root)
+                .expect("BUG: a full update always carries tree metadata"),
+            focus: update.focus,
+        }
+    }
 }
 
 impl std::fmt::Debug for SemanticsOwner {
@@ -199,6 +245,11 @@ impl std::fmt::Debug for SemanticsOwner {
             .field("tree", &self.tree)
             .field("callback", &self.callback.as_ref().map(|_| "<callback>"))
             .field("enabled", &self.enabled)
+            .field(
+                "published",
+                &self.published.as_ref().map(|state| state.nodes.len()),
+            )
+            .field("full_publish_pending", &self.full_publish_pending)
             .finish()
     }
 }
@@ -210,6 +261,8 @@ impl SemanticsOwner {
             tree: SemanticsTree::new(),
             callback: Some(callback),
             enabled: true,
+            published: None,
+            full_publish_pending: false,
         }
     }
 
@@ -225,6 +278,8 @@ impl SemanticsOwner {
             tree: SemanticsTree::new(),
             callback: None,
             enabled: true,
+            published: None,
+            full_publish_pending: false,
         }
     }
 
@@ -234,6 +289,8 @@ impl SemanticsOwner {
             tree: SemanticsTree::with_capacity(capacity),
             callback: Some(callback),
             enabled: true,
+            published: None,
+            full_publish_pending: false,
         }
     }
 
@@ -249,11 +306,18 @@ impl SemanticsOwner {
     /// until the user did something. So a rooted current tree is published
     /// through the new callback immediately; translation is snapshot-shaped,
     /// so this says exactly what a flush would say.
+    ///
+    /// The swap also resets the published-state mirror to exactly what the
+    /// new callback was just told: the previous adapter's knowledge is
+    /// irrelevant to this one, and diffing future flushes against it would
+    /// withhold nodes the new adapter has never seen.
     pub fn set_callback(&mut self, callback: SemanticsUpdateCallback) {
+        self.published = None;
         if self.enabled
             && let Some(update) = crate::tree_to_update(&self.tree, None)
         {
             callback(&update);
+            self.published = Some(PublishedState::mirror_of(&update));
         }
         self.callback = Some(callback);
     }
@@ -458,6 +522,8 @@ impl SemanticsOwner {
         self.tree.clear();
         self.callback = None;
         self.enabled = false;
+        self.published = None;
+        self.full_publish_pending = false;
     }
 
     // ========== Tree Operations ==========
@@ -488,33 +554,80 @@ impl SemanticsOwner {
 
     // ========== Flush to Platform ==========
 
-    /// Publishes the tree to the platform when anything has changed.
+    /// Publishes what changed — and only what changed — to the platform.
     ///
-    /// Assembly is a classic full rebuild (ADR-0014), so the published
-    /// [`accesskit::TreeUpdate`] carries every node rather than a diff. That is
-    /// what `TreeUpdate` permits but does not require; adapters suppress
-    /// extraneous events, so this is correct-but-chatty. Incremental diffing
-    /// needs the identity to be carried per node and gets its own oracle.
+    /// The observable contract is Flutter's (`SemanticsOwner
+    /// .sendSemanticsUpdate`): an idle frame publishes nothing and returns in
+    /// O(1); only nodes whose content actually changed serialize into the
+    /// update. The *mechanism* diverges because FLUI rebuilds the semantics
+    /// arena every assembly pass (ADR-0014) where Flutter mutates persistent
+    /// nodes: a rebuild marks every node dirty, so the dirty bit alone cannot
+    /// say what changed. The diff therefore compares each dirty node's
+    /// translation, keyed by its stable [`AccessibilityNodeId`], against the
+    /// [`PublishedState`] mirror of the last delivered update — payload
+    /// equality is authoritative, dirty bits only bound how much is
+    /// re-examined.
     ///
-    /// A clean tree publishes nothing and performs no translation. The trigger
-    /// is [`SemanticsTree::has_dirty_nodes`], which scans until it finds dirt:
-    /// O(1) average on a dirty tree (it stops at the first dirty node), O(n)
-    /// worst case — and the worst case is the *idle* frame, since a clean tree
-    /// is the one that must be scanned to the end. `n` is the number of
-    /// semantics boundaries, not widgets. A cached dirty count would make this
-    /// O(1) unconditionally; that is a separate change, with a benchmark, not
-    /// an assertion made in a doc comment.
+    /// Three shapes come out of one call:
+    ///
+    /// - **Clean tree** — O(1) early return, no translation, no callback.
+    /// - **First publish / [`Self::schedule_full_publish`] pending / root
+    ///   identity changed** — a self-contained full update carrying
+    ///   [`accesskit::TreeUpdate::tree`] metadata. `tree: Some` is this
+    ///   owner's promise that the update stands alone (the Linux bridge
+    ///   retains exactly these to answer a late-activating screen reader).
+    /// - **Otherwise** — an incremental update: changed nodes only,
+    ///   `tree: None`. Structure changes ride along for free because a
+    ///   node's children list is part of its payload — the parent whose
+    ///   children changed is itself a changed node, which is also how an
+    ///   adapter learns a removed child is gone. If nothing survives the
+    ///   diff and focus is unchanged, no update is delivered at all.
+    ///
+    /// An unrooted tree publishes nothing and stays dirty, so the first
+    /// rooted flush retries (unchanged from the pre-diff behavior; see the
+    /// comment inside [`Self::publish_full`]).
     pub fn flush(&mut self) {
-        if !self.enabled || !self.tree.has_dirty_nodes() {
+        if !self.enabled || !(self.tree.has_dirty_nodes() || self.full_publish_pending) {
             return;
         }
 
+        let needs_full = self.full_publish_pending
+            || match (&self.published, self.current_root_id()) {
+                // A changed root identity is a different tree to the
+                // adapter; a diff cannot express that transition, so it
+                // escalates to a self-contained full update.
+                (Some(state), Some(root)) => state.root != root,
+                // Nothing published yet — or no addressable root (both
+                // paths publish nothing and stay dirty; route through the
+                // full path for one exit).
+                _ => true,
+            };
+
+        if needs_full {
+            self.publish_full();
+        } else {
+            self.publish_incremental();
+        }
+    }
+
+    /// The stable identity the current root would publish under.
+    fn current_root_id(&self) -> Option<accesskit::NodeId> {
+        self.tree
+            .root()
+            .and_then(|root| self.tree.get(root))
+            .and_then(SemanticsNode::accessibility_id)
+            .map(|id| accesskit::NodeId(id.as_u64()))
+    }
+
+    /// Publishes the complete rooted tree and resets the mirror to it.
+    fn publish_full(&mut self) {
         // Translate before touching the callback so the borrow of `self.tree`
         // ends first.
         let Some(update) = crate::tree_to_update(&self.tree, None) else {
             // No root yet — nothing an adapter could apply. Leave the tree
-            // dirty so the next flush retries once assembly has rooted it,
-            // rather than silently swallowing the first real update.
+            // dirty (and any full publish pending) so the next flush retries
+            // once assembly has rooted it, rather than silently swallowing
+            // the first real update.
             //
             // A tree that *loses* its root after publishing takes this path
             // too, and nothing withdraws the tree already sent: the adapter
@@ -534,24 +647,130 @@ impl SemanticsOwner {
             callback(&update);
         }
 
+        self.published = Some(PublishedState::mirror_of(&update));
+        self.full_publish_pending = false;
         self.tree.mark_all_clean();
     }
 
-    /// Forces a full tree update.
+    /// Diffs dirty nodes against the mirror and publishes only the changes.
     ///
-    /// Marks all nodes dirty and flushes to platform.
-    /// Use when accessibility services reconnect or request full tree.
+    /// One pass over the arena does all four jobs: collect the live id set
+    /// (to prune mirror entries for removed nodes), re-translate dirty nodes
+    /// (clean ones are unchanged by the dirty-bit contract and are skipped),
+    /// compare against the mirror, and derive focus. The pass is O(arena)
+    /// with translation cost O(dirty) — the arena walk itself is the same
+    /// order as the assembly pass that produced the dirt.
+    fn publish_incremental(&mut self) {
+        let state = self
+            .published
+            .as_mut()
+            .expect("BUG: incremental publish requires a prior published state");
+
+        let mut live: FxHashSet<accesskit::NodeId> =
+            FxHashSet::with_capacity_and_hasher(self.tree.len(), rustc_hash::FxBuildHasher);
+        let mut changed: Vec<(accesskit::NodeId, accesskit::Node)> = Vec::new();
+        // Focus derivation, folded into the same pass `focused_node` would
+        // otherwise repeat: exactly one claimant wins, ambiguity falls back
+        // to the root (matching `tree_to_update`).
+        let mut focus_claimant: Option<accesskit::NodeId> = None;
+        let mut focus_ambiguous = false;
+
+        for (_, node) in self.tree.iter() {
+            let Some(identity) = node.accessibility_id() else {
+                // Unaddressable: never published, nothing to diff. Same
+                // skip rule as `tree_to_update`.
+                continue;
+            };
+            let id = accesskit::NodeId(identity.as_u64());
+            live.insert(id);
+
+            if node.config().is_focused() {
+                if focus_claimant.is_some() {
+                    focus_ambiguous = true;
+                } else {
+                    focus_claimant = Some(id);
+                }
+            }
+
+            if !node.is_dirty() {
+                continue;
+            }
+            let Some(data) = self.tree.node_data_of(node) else {
+                continue;
+            };
+            let translated = crate::accesskit_translation::to_node(&data);
+            if state.nodes.get(&id) != Some(&translated) {
+                changed.push((id, translated));
+            }
+        }
+
+        // Prune mirror entries whose nodes left the arena. Without this, a
+        // node that is removed and later returns with identical content
+        // would diff as "unchanged" against a mirror the adapter no longer
+        // agrees with — the adapter dropped it when its parent was
+        // republished without it — and never be re-sent.
+        state.nodes.retain(|id, _| live.contains(id));
+
+        if focus_ambiguous {
+            tracing::warn!("semantics tree has more than one focused node; publishing the root");
+        }
+        let focus = focus_claimant
+            .filter(|_| !focus_ambiguous)
+            .filter(|claimant| live.contains(claimant))
+            .unwrap_or(state.root);
+
+        if changed.is_empty() && focus == state.focus {
+            // Everything the dirty bits pointed at translated identically —
+            // a rebuild that reproduced the same tree. The adapter hears
+            // nothing; the dirt is simply consumed.
+            self.tree.mark_all_clean();
+            return;
+        }
+
+        for (id, node) in &changed {
+            state.nodes.insert(*id, node.clone());
+        }
+        state.focus = focus;
+
+        let update = crate::TreeUpdate {
+            nodes: changed,
+            tree: None,
+            tree_id: accesskit::TreeId::ROOT,
+            focus,
+        };
+
+        let callback = self.callback.as_ref().map(Arc::clone);
+        if let Some(callback) = callback {
+            callback(&update);
+        }
+
+        self.tree.mark_all_clean();
+    }
+
+    /// Forces the next flush to publish a self-contained full update, even
+    /// if no node is dirty.
+    ///
+    /// The reconnect primitive: when assistive technology (re)activates, the
+    /// adapter's state is unknown — it may have forgotten everything — so the
+    /// mirror is forgotten with it. The composition root pairs this with
+    /// re-seeding the assembly pass so a flush actually runs.
+    pub fn schedule_full_publish(&mut self) {
+        self.published = None;
+        self.full_publish_pending = true;
+    }
+
+    /// Forces a full tree update, now.
+    ///
+    /// Marks all nodes dirty and publishes the complete tree, bypassing the
+    /// incremental diff. Use when accessibility services reconnect or
+    /// request the full tree.
     pub fn send_full_tree(&mut self) {
         if !self.enabled {
             return;
         }
 
-        // Mark all nodes dirty
-        for (_, node) in self.tree.iter_mut() {
-            node.mark_dirty();
-        }
-
-        // Flush
+        self.tree.mark_all_dirty();
+        self.full_publish_pending = true;
         self.flush();
     }
 }

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -545,9 +545,14 @@ impl SemanticsOwner {
 
     // ========== Dirty Tracking ==========
 
-    /// Returns true if any node needs to be sent to the platform.
+    /// Returns true if the next [`Self::flush`] would have work to do —
+    /// dirty nodes, or a scheduled full publish
+    /// ([`Self::schedule_full_publish`]) that is pending on an otherwise
+    /// clean tree. This predicate mirrors `flush`'s own gate exactly: a
+    /// frame loop consulting a narrower one would never deliver the
+    /// reconnect update.
     pub fn needs_flush(&self) -> bool {
-        self.enabled && self.tree.has_dirty_nodes()
+        self.enabled && (self.tree.has_dirty_nodes() || self.full_publish_pending)
     }
 
     /// Marks a specific node as dirty.

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -60,6 +60,27 @@ pub struct SemanticsTree {
 
     /// Root SemanticsNode ID (None if tree is empty)
     root: Option<SemanticsId>,
+
+    /// Upper bound on the number of dirty nodes, maintained at every seam
+    /// that can flip a node's dirty bit ([`Self::insert`], [`Self::get_mut`],
+    /// [`Self::iter_mut`], [`Self::remove_shallow`], [`Self::clear`],
+    /// [`Self::mark_all_dirty`], [`Self::mark_all_clean`]).
+    ///
+    /// This is what makes [`Self::has_dirty_nodes`] O(1): the previous
+    /// implementation scanned with `any()`, which short-circuits on a dirty
+    /// tree but walks the whole arena on a clean one — the *idle* frame was
+    /// the worst case. Flutter maintains the same information as
+    /// `SemanticsOwner._dirtyNodes` (a set filled by `_markDirty`), so its
+    /// `sendSemanticsUpdate` early-out is O(1); this counter is the
+    /// arena-storage port of that.
+    ///
+    /// Deliberately an upper bound, not an exact count: handing out
+    /// `&mut SemanticsNode` (via [`Self::get_mut`] / [`Self::iter_mut`])
+    /// counts the node as dirty *at the borrow*, so nothing the caller does
+    /// through the borrow can under-count. Over-counting is self-healing —
+    /// a flush that finds no dirty bits publishes nothing and resets the
+    /// counter via [`Self::mark_all_clean`].
+    dirty_count: usize,
 }
 
 impl SemanticsTree {
@@ -68,6 +89,7 @@ impl SemanticsTree {
         Self {
             nodes: Slab::new(),
             root: None,
+            dirty_count: 0,
         }
     }
 
@@ -76,6 +98,7 @@ impl SemanticsTree {
         Self {
             nodes: Slab::with_capacity(capacity),
             root: None,
+            dirty_count: 0,
         }
     }
 
@@ -131,6 +154,9 @@ impl SemanticsTree {
     /// let id = tree.insert(node);
     /// ```
     pub fn insert(&mut self, node: SemanticsNode) -> SemanticsId {
+        if node.is_dirty() {
+            self.dirty_count += 1;
+        }
         let slab_index = self.nodes.insert(node);
         SemanticsId::new(slab_index + 1) // +1 offset
     }
@@ -156,9 +182,20 @@ impl SemanticsTree {
     }
 
     /// Returns a mutable reference to a SemanticsNode.
-    #[inline]
+    ///
+    /// The node is conservatively counted as dirty **at the borrow**: the
+    /// tree cannot observe what the caller does through `&mut SemanticsNode`
+    /// (node-level mutators set the node's own dirty bit, but the tree's
+    /// O(1) dirty accounting cannot see that transition), so it presumes
+    /// mutation. A borrow that turns out to be read-only costs one spurious
+    /// dirty bit that the next flush clears without publishing anything.
     pub fn get_mut(&mut self, id: SemanticsId) -> Option<&mut SemanticsNode> {
-        self.nodes.get_mut(id.get() - 1)
+        let node = self.nodes.get_mut(id.get() - 1)?;
+        if !node.is_dirty() {
+            node.mark_dirty();
+            self.dirty_count += 1;
+        }
+        Some(node)
     }
 
     // NOTE: the inherent `pub fn remove` that used to live here was
@@ -194,7 +231,10 @@ impl SemanticsTree {
             return None;
         }
         // Unlink from parent's children vec — matches the trait
-        // contract.
+        // contract. `get_mut` also marks the parent dirty, which is
+        // load-bearing for incremental publishing: the parent's children
+        // list is part of its published payload, and republishing the
+        // parent is what tells an adapter the child is gone.
         if let Some(parent_id) = self.get(id).and_then(SemanticsNode::parent)
             && let Some(parent) = self.get_mut(parent_id)
         {
@@ -203,13 +243,18 @@ impl SemanticsTree {
         if self.root == Some(id) {
             self.root = None;
         }
-        self.nodes.try_remove(id.get() - 1)
+        let removed = self.nodes.try_remove(id.get() - 1);
+        if removed.as_ref().is_some_and(SemanticsNode::is_dirty) {
+            self.dirty_count = self.dirty_count.saturating_sub(1);
+        }
+        removed
     }
 
     /// Clears all nodes from the tree.
     pub fn clear(&mut self) {
         self.nodes.clear();
         self.root = None;
+        self.dirty_count = 0;
     }
 
     // ========== Tree Operations ==========
@@ -372,16 +417,43 @@ impl SemanticsTree {
             .map(|(index, node)| (SemanticsId::new(index + 1), node))
     }
 
+    /// Marks a single node as dirty (no-op for a missing id).
+    ///
+    /// The tree-level entry point for "this node's published payload is
+    /// stale" — routes through [`Self::get_mut`] so the O(1) dirty
+    /// accounting observes the transition.
+    pub fn mark_dirty(&mut self, id: SemanticsId) {
+        let _ = self.get_mut(id);
+    }
+
+    /// Marks every node as dirty.
+    ///
+    /// The full-republish primitive (`SemanticsOwner::send_full_tree`):
+    /// after this, a flush re-examines every node.
+    pub fn mark_all_dirty(&mut self) {
+        for (_, node) in &mut self.nodes {
+            node.mark_dirty();
+        }
+        self.dirty_count = self.nodes.len();
+    }
+
     /// Marks all nodes as clean.
     pub fn mark_all_clean(&mut self) {
         for (_, node) in &mut self.nodes {
             node.mark_clean();
         }
+        self.dirty_count = 0;
     }
 
-    /// Returns true if any node is dirty.
+    /// Returns true if any node may be dirty — O(1).
+    ///
+    /// Backed by the maintained counter rather than a scan; see the
+    /// `dirty_count` field doc for why the scan was the wrong shape (it
+    /// walked the entire arena precisely on the idle frame) and for the
+    /// conservative-upper-bound contract (`true` can be spurious after a
+    /// read-only `&mut` borrow; `false` is always exact).
     pub fn has_dirty_nodes(&self) -> bool {
-        self.nodes.iter().any(|(_, node)| node.is_dirty())
+        self.dirty_count > 0
     }
 
     // ========== Iteration ==========
@@ -402,7 +474,13 @@ impl SemanticsTree {
 
     /// Returns a mutable iterator over all (SemanticsId, &mut SemanticsNode)
     /// pairs.
+    ///
+    /// Every yielded node is conservatively counted as dirty, for the same
+    /// reason [`Self::get_mut`] counts its borrow: the tree cannot observe
+    /// mutation through the handed-out `&mut`, and under-counting would let
+    /// a real change slip past the O(1) dirty check.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (SemanticsId, &mut SemanticsNode)> + '_ {
+        self.mark_all_dirty();
         self.nodes
             .iter_mut()
             .map(|(index, node)| (SemanticsId::new(index + 1), node))
@@ -679,6 +757,76 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&id1));
         assert!(ids.contains(&id2));
+    }
+
+    /// `has_dirty_nodes` is counter-backed (O(1)), and the counter must stay
+    /// truthful across every seam that can flip a dirty bit. A silent
+    /// under-count here would make an idle-looking tree swallow a real
+    /// change; an over-count only costs a no-op flush.
+    #[test]
+    fn the_dirty_gate_tracks_insert_remove_and_clear() {
+        let mut tree = SemanticsTree::new();
+        assert!(!tree.has_dirty_nodes(), "an empty tree is clean");
+
+        let id = tree.insert(SemanticsNode::new());
+        assert!(tree.has_dirty_nodes(), "a fresh insert is dirty");
+
+        tree.mark_all_clean();
+        assert!(!tree.has_dirty_nodes());
+
+        tree.mark_dirty(id);
+        assert!(tree.has_dirty_nodes());
+        let removed = tree.remove_shallow(id);
+        assert!(removed.is_some());
+        assert!(
+            !tree.has_dirty_nodes(),
+            "removing the only dirty node cleans the gate"
+        );
+
+        let _ = tree.insert(SemanticsNode::new());
+        tree.clear();
+        assert!(!tree.has_dirty_nodes(), "clear resets the gate");
+    }
+
+    /// Handing out `&mut SemanticsNode` counts the node as dirty at the
+    /// borrow — the tree cannot see what happens through the borrow, and
+    /// presuming mutation is the only direction that cannot under-count.
+    #[test]
+    fn a_mutable_borrow_counts_as_dirty() {
+        let mut tree = SemanticsTree::new();
+        let id = tree.insert(SemanticsNode::new());
+        tree.mark_all_clean();
+
+        let _ = tree.get_mut(id);
+        assert!(
+            tree.has_dirty_nodes(),
+            "a mutable borrow must be presumed a mutation"
+        );
+        assert_eq!(tree.dirty_nodes().count(), 1);
+
+        tree.mark_all_clean();
+        let _ = tree.iter_mut();
+        assert!(
+            tree.has_dirty_nodes(),
+            "a mutable iteration presumes mutation of every node"
+        );
+    }
+
+    /// `mark_all_dirty` is the full-republish primitive: every node becomes
+    /// re-examinable, and `mark_all_clean` fully resets the gate after.
+    #[test]
+    fn mark_all_dirty_marks_every_node() {
+        let mut tree = SemanticsTree::new();
+        let _ = tree.insert(SemanticsNode::new());
+        let _ = tree.insert(SemanticsNode::new());
+        tree.mark_all_clean();
+
+        tree.mark_all_dirty();
+        assert_eq!(tree.dirty_nodes().count(), 2);
+        assert!(tree.has_dirty_nodes());
+
+        tree.mark_all_clean();
+        assert!(!tree.has_dirty_nodes());
     }
 
     #[test]

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -111,9 +111,20 @@ impl SemanticsTree {
     }
 
     /// Set the root SemanticsNode ID.
-    #[inline]
+    ///
+    /// Changing which node is the root is a published-state change even
+    /// when no node's content moved — the flush path detects the identity
+    /// transition and escalates to a self-contained full update, but only
+    /// if its dirty gate lets it run at all. So a *changed* root marks the
+    /// new root node dirty; re-setting the same root stays free.
     pub fn set_root(&mut self, root: Option<SemanticsId>) {
+        if self.root == root {
+            return;
+        }
         self.root = root;
+        if let Some(id) = root {
+            self.mark_dirty(id);
+        }
     }
 
     // ========== Basic Operations ==========

--- a/crates/flui-semantics/tests/incremental_flush.rs
+++ b/crates/flui-semantics/tests/incremental_flush.rs
@@ -1,0 +1,295 @@
+//! The incremental-publish contract of `SemanticsOwner::flush`.
+//!
+//! Flutter's `SemanticsOwner.sendSemanticsUpdate` serializes only dirty
+//! nodes into the platform update and returns immediately when nothing is
+//! dirty. FLUI rebuilds its semantics arena every assembly pass (ADR-0014),
+//! so "dirty" alone cannot distinguish a real change from a rebuild that
+//! reproduced the same tree — the flush diffs per-node payloads, keyed by
+//! stable [`AccessibilityNodeId`], against the last delivered update. These
+//! tests pin the observable halves of that contract:
+//!
+//! - a pass that changes nothing publishes **nothing**;
+//! - a pass that changes one node publishes **that node**, not the tree.
+//!
+//! Every fixture drives the owner exactly the way the pipeline does
+//! (`rebuild_semantics_owner`): clear the arena, reinsert every node, root
+//! it, flush. The tests deliberately use only API that predates the diff so
+//! they can run — and fail — against the pre-diff implementation.
+
+use std::sync::Arc;
+
+use flui_foundation::RenderId;
+use flui_semantics::{SemanticsNode, SemanticsOwner, TreeUpdate};
+use parking_lot::Mutex;
+
+/// A render-backed node: production assembly always attaches a source
+/// render id, and it is what makes a node publishable at all. Generation 7
+/// keeps the stable id space visibly distinct from arena positions.
+fn node(index: u32, label: &str) -> SemanticsNode {
+    let mut node = SemanticsNode::new().with_source_render_id(RenderId::new_gen(
+        index,
+        core::num::NonZeroU32::new(7).expect("fixture generation is non-zero"),
+    ));
+    node.config_mut().set_label(label);
+    node
+}
+
+/// Rebuild the owner's arena the way `run_semantics` does every pass:
+/// clear, reinsert, root. `labels[i]` becomes child `i` of the root.
+fn rebuild(owner: &mut SemanticsOwner, labels: &[&str]) {
+    owner.clear();
+    let root = owner.insert(node(0, "root"));
+    for (index, label) in labels.iter().enumerate() {
+        let child = owner.insert(node(
+            u32::try_from(index).expect("fixture fits u32") + 1,
+            label,
+        ));
+        owner.add_child(root, child);
+    }
+    owner.set_root(Some(root));
+}
+
+/// An owner whose callback records every delivered update.
+fn recording_owner() -> (SemanticsOwner, Arc<Mutex<Vec<TreeUpdate>>>) {
+    let received: Arc<Mutex<Vec<TreeUpdate>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let owner = SemanticsOwner::new(Arc::new(move |update: &TreeUpdate| {
+        sink.lock().push(update.clone());
+    }));
+    (owner, received)
+}
+
+/// **The idle contract.** An assembly pass that reproduces the same tree —
+/// the shape of "something upstream was marked, nothing observable moved" —
+/// must deliver nothing to the platform. Before the diff, every such pass
+/// republished the entire tree and relied on the adapter to suppress the
+/// resulting event storm.
+#[test]
+fn a_rebuild_that_changes_nothing_publishes_nothing() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha", "beta", "gamma"]);
+    owner.flush();
+    assert_eq!(
+        received.lock().len(),
+        1,
+        "the first publish is the full tree"
+    );
+
+    rebuild(&mut owner, &["alpha", "beta", "gamma"]);
+    owner.flush();
+
+    assert_eq!(
+        received.lock().len(),
+        1,
+        "an identical rebuild must not deliver a second update"
+    );
+}
+
+/// **The O(dirty) contract.** One toggled label in the tree publishes
+/// exactly the node that changed — not its unchanged siblings, not the
+/// unchanged root. Before the diff this update carried all four nodes.
+#[test]
+fn a_single_content_change_publishes_exactly_that_node() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha", "beta", "gamma"]);
+    owner.flush();
+
+    rebuild(&mut owner, &["alpha", "CHANGED", "gamma"]);
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2, "the change itself must be delivered");
+    let diff = &updates[1];
+    assert_eq!(
+        diff.nodes.len(),
+        1,
+        "one changed node publishes one node, not the tree: got {:?}",
+        diff.nodes
+            .iter()
+            .map(|(id, node)| (id.0, node.label().map(str::to_owned)))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        diff.nodes[0].1.label(),
+        Some("CHANGED"),
+        "and it is the node whose content changed"
+    );
+}
+
+/// A structural change surfaces through the parent whose children list
+/// changed — that republished parent is also how an adapter learns the
+/// removed child is gone (AccessKit removals are implicit). The unchanged
+/// sibling must not ride along.
+#[test]
+fn removing_a_child_republishes_its_parent_and_nothing_else() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha", "beta"]);
+    owner.flush();
+
+    rebuild(&mut owner, &["alpha"]);
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2);
+    let diff = &updates[1];
+    let labels: Vec<_> = diff.nodes.iter().filter_map(|(_, n)| n.label()).collect();
+    assert_eq!(
+        labels,
+        vec!["root"],
+        "only the parent whose children changed is republished"
+    );
+    assert!(
+        !diff.nodes.iter().any(|(_, n)| n.label() == Some("beta")),
+        "a removed node never appears in the update that removes it"
+    );
+}
+
+/// A node that is removed and later returns with identical content must be
+/// republished: the adapter dropped it when its parent was republished
+/// without it, so "unchanged since last published" is no longer true of
+/// anything the adapter still holds. This is the pin on the mirror's
+/// prune-on-removal step.
+#[test]
+fn a_removed_then_restored_node_is_republished() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha", "beta"]);
+    owner.flush();
+    rebuild(&mut owner, &["alpha"]);
+    owner.flush();
+
+    rebuild(&mut owner, &["alpha", "beta"]);
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 3);
+    let restored = &updates[2];
+    assert!(
+        restored
+            .nodes
+            .iter()
+            .any(|(_, n)| n.label() == Some("beta")),
+        "the restored node must be re-sent — the adapter no longer has it"
+    );
+}
+
+/// The first delivered update is self-contained: it carries the tree
+/// metadata (`TreeUpdate::tree`) an adapter needs to initialize, and every
+/// node. Incremental follow-ups carry `tree: None` — that asymmetry is the
+/// owner's promise that any update with tree metadata stands alone, which
+/// the Linux bridge relies on to answer a late-activating screen reader.
+#[test]
+fn full_updates_carry_tree_metadata_and_diffs_do_not() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha", "beta"]);
+    owner.flush();
+    rebuild(&mut owner, &["alpha", "CHANGED"]);
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2);
+    assert!(
+        updates[0].tree.is_some(),
+        "the initial update must be adapter-initializing"
+    );
+    assert_eq!(
+        updates[0].nodes.len(),
+        3,
+        "and self-contained: root plus both children"
+    );
+    assert!(
+        updates[1].tree.is_none(),
+        "an incremental update must not claim to stand alone"
+    );
+}
+
+/// `send_full_tree` exists for a reconnecting adapter that may have
+/// forgotten everything, so it must bypass the diff even when nothing
+/// changed since the last publish.
+#[test]
+fn send_full_tree_republishes_everything_even_when_clean() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha", "beta"]);
+    owner.flush();
+
+    owner.send_full_tree();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2);
+    let full = &updates[1];
+    assert_eq!(full.nodes.len(), 3, "all nodes, not a diff");
+    assert!(full.tree.is_some(), "self-contained, adapter-initializing");
+}
+
+/// A focus movement is delivered even when it is the only change. Focus is
+/// tree-level state in AccessKit — it rides the update envelope, not any
+/// node's payload — so a focus-only frame publishes an update with **no**
+/// nodes at all. Suppressing it as "empty diff" would strand the screen
+/// reader on the old node.
+#[test]
+fn a_focus_change_is_published_even_when_no_node_payload_changed() {
+    let (mut owner, received) = recording_owner();
+
+    // Build directly (not via `rebuild`) so the fixture can set focus.
+    let build = |owner: &mut SemanticsOwner, focused: usize| {
+        owner.clear();
+        let root = owner.insert(node(0, "root"));
+        for (index, label) in ["alpha", "beta"].iter().enumerate() {
+            let mut child = node(u32::try_from(index).expect("fixture fits u32") + 1, label);
+            child.config_mut().set_focused(index == focused);
+            let child = owner.insert(child);
+            owner.add_child(root, child);
+        }
+        owner.set_root(Some(root));
+    };
+
+    build(&mut owner, 0);
+    owner.flush();
+    build(&mut owner, 1);
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2);
+    let (first, second) = (&updates[0], &updates[1]);
+    assert_ne!(
+        first.focus, second.focus,
+        "the envelope focus must track the moved flag"
+    );
+    assert!(
+        second.nodes.is_empty(),
+        "focus is envelope state — no node payload changed, none is republished"
+    );
+}
+
+/// A different root identity is a different tree to the adapter; a diff
+/// cannot express that, so it must escalate to a self-contained full
+/// update.
+#[test]
+fn a_root_identity_change_escalates_to_a_full_update() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha"]);
+    owner.flush();
+
+    // Same shape, entirely different identities (different render slots).
+    owner.clear();
+    let root = owner.insert(node(100, "root"));
+    let child = owner.insert(node(101, "alpha"));
+    owner.add_child(root, child);
+    owner.set_root(Some(root));
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2);
+    let replaced = &updates[1];
+    assert!(
+        replaced.tree.is_some(),
+        "a new root re-initializes the adapter"
+    );
+    assert_eq!(replaced.nodes.len(), 2, "and carries the whole new tree");
+}

--- a/crates/flui-semantics/tests/incremental_flush.rs
+++ b/crates/flui-semantics/tests/incremental_flush.rs
@@ -266,6 +266,82 @@ fn a_focus_change_is_published_even_when_no_node_payload_changed() {
     );
 }
 
+/// Re-pointing the root at an already-published, otherwise-untouched node
+/// is a root-identity change with zero dirty content — `set_root` itself
+/// must count as a change, or the flush gate returns before the
+/// root-escalation check ever runs and the adapter stays on the old root
+/// forever.
+#[test]
+fn repointing_the_root_at_a_clean_node_escalates_to_a_full_update() {
+    let (mut owner, received) = recording_owner();
+
+    // Two independent addressable nodes; `a` is the published root.
+    let a = owner.insert(node(1, "a"));
+    let b = owner.insert(node(2, "b"));
+    owner.set_root(Some(a));
+    owner.flush();
+    assert_eq!(received.lock().len(), 1, "the initial publish under root a");
+
+    // Only the root pointer moves; no node content is touched.
+    owner.set_root(Some(b));
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(
+        updates.len(),
+        2,
+        "a root-identity change must be delivered even with no dirty content"
+    );
+    let repointed = &updates[1];
+    let new_root = repointed
+        .tree
+        .as_ref()
+        .expect("a root change is a self-contained, adapter-initializing update")
+        .root;
+    let b_identity = owner
+        .get(b)
+        .and_then(flui_semantics::SemanticsNode::accessibility_id)
+        .expect("b is render-backed");
+    assert_eq!(
+        new_root.0,
+        b_identity.as_u64(),
+        "and it names the new root identity"
+    );
+}
+
+/// `needs_flush` is the public would-a-flush-do-anything predicate, so it
+/// must match `flush`'s own gate: a scheduled full publish is pending work
+/// even when every node is clean. A frame loop consulting the narrower
+/// predicate would never deliver the reconnect update.
+#[test]
+fn needs_flush_reports_a_scheduled_full_publish_on_a_clean_tree() {
+    let (mut owner, received) = recording_owner();
+
+    rebuild(&mut owner, &["alpha"]);
+    owner.flush();
+    assert!(
+        !owner.needs_flush(),
+        "a settled owner has nothing to deliver"
+    );
+
+    owner.schedule_full_publish();
+    assert!(
+        owner.needs_flush(),
+        "a pending full publish is pending work — the predicate must say so"
+    );
+
+    owner.flush();
+    assert!(
+        !owner.needs_flush(),
+        "delivering it settles the owner again"
+    );
+    assert_eq!(
+        received.lock().len(),
+        2,
+        "and the flush the predicate promised actually happened"
+    );
+}
+
 /// A different root identity is a different tree to the adapter; a diff
 /// cannot express that, so it must escalate to a self-contained full
 /// update.


### PR DESCRIPTION
## What

Makes the semantics publish path incremental (issue #687, slices 2 and 3 of its sequencing): an idle frame now costs O(1) and publishes nothing, and a single-node change publishes O(dirty) nodes instead of the whole tree. Built directly on #776's stable `AccessibilityNodeId` payload identity — the prerequisite that made a cross-frame diff expressible at all.

## Design: payload diff against a published mirror (and why)

Verified against `.flutter/packages/flutter/lib/src/semantics/semantics.dart`: Flutter's `SemanticsOwner` keeps a `_dirtyNodes` set filled by `_markDirty`, `sendSemanticsUpdate` early-outs in O(1) when it is empty, and only dirty nodes serialize into `SemanticsUpdateBuilder`. That is the observable contract this ports. The mechanism must diverge, because FLUI rebuilds its semantics arena every assembly pass (ADR-0014; the divergence #776 documents) — after a rebuild *every* node is freshly-inserted-dirty, so dirty bits alone cannot distinguish "changed" from "reproduced identically".

**Chosen:** `SemanticsOwner` keeps a private mirror of the last delivered update (`accesskit::NodeId → accesskit::Node`). `flush` re-translates only dirty nodes, compares against the mirror (`accesskit::Node: PartialEq`), and publishes exactly what differs. Dirty bits bound how much is re-examined; payload equality is authoritative for what is sent.

**Alternatives considered:**
- *Upstream dirty-marks only (render-tree `mark_needs_semantics` → semantics-node dirtiness, no diff):* rejected — merge/exclude boundaries mean a changed render node can fold into an ancestor's semantics node, so mapping render dirt onto published-node identity is exactly the unsolved part of the issue's slice 4 (assembly reuse); and after the arena rebuild the marks are gone anyway.
- *Per-node fingerprint hashes instead of stored `Node`s:* rejected — `accesskit::Node` implements `PartialEq` but not `Hash`; a hand-rolled hash adds a collision-correctness argument to save memory the mirror already needs for adapter-state reasoning.
- *Diffing at the adapter (bridge-side):* rejected — every consumer (AT-SPI now, Windows/macOS later per #675) would re-implement it; the owner is the one place that knows what was delivered.

### The update contract, sharpened

- **Self-contained updates** (`TreeUpdate::tree: Some`): first publish, root-identity change, `send_full_tree`, and every reconnect. The `tree` metadata is now the producer's *promise* that the update stands alone.
- **Incremental updates** (`tree: None`): changed nodes only. Structure rides along because a node's `children` list is part of its payload — the republished parent is also how AccessKit learns a removed child is gone. Focus-only changes publish an empty-nodes update (focus is envelope state). Empty diff + unchanged focus ⇒ no callback at all.
- The mirror prunes ids that left the arena, so a node removed and later restored with identical content is correctly re-sent (the adapter dropped it in between).

### O(1) idle check

`SemanticsTree::has_dirty_nodes` is now counter-backed (issue slice 3). The counter is a deliberate upper bound: `get_mut`/`iter_mut` conservatively count the borrow as dirty (the tree cannot observe mutation through `&mut`), so it can over-count — self-healing via a no-op flush — but never under-count. This is the arena-storage port of Flutter's `_dirtyNodes` set.

### Reconnect (the issue's "send_full_tree remains correct" criterion)

- AT activation (every attach, not just transitions) sets a `SemanticsHost` flag from the adapter thread; the frame reconcile consumes it on the owner thread and calls the new `PipelineOwner::request_semantics_full_publish`, which forgets the mirror and re-seeds assembly — so a (re)attached screen reader is answered with a self-contained tree even on an otherwise idle app.
- The Linux AT-SPI bridge retains only self-contained updates for `request_initial_tree`; an incremental fragment can never become the answer to a fresh activation.

## Bench: before/after

Same machine (32-core, mold+sccache dev profile), same invocation both sides (`cargo bench -p flui-semantics --bench publish_cost -- --warm-up-time 1 --measurement-time 3 --sample-size 60`), same bench code (the updated bench, where `one_dirty` toggles real content, was run against the pre-diff source for the baseline). Criterion midpoints; run-to-run variance observed on re-runs was ~±5-10%.

| scenario | n | before | after | change |
|---|---|---|---|---|
| idle | 16 | 10.6 ns | 1.24 ns | −88% |
| idle | 64 | 42.8 ns | 1.26 ns | −97% |
| idle | 256 | 157.5 ns | 1.27 ns | −99.2% |
| idle | 1024 | 880 ns | 1.23 ns | −99.9% — **flat across sizes: O(n) → O(1)** |
| one_dirty | 16 | 1.03 µs | 242 ns | 4.2× |
| one_dirty | 64 | 5.79 µs | 535 ns | 10.8× |
| one_dirty | 256 | 25.3 µs | 1.91 µs | 13.2× |
| one_dirty | 1024 | 105.0 µs | 6.59 µs | **15.9×** |
| all_dirty | 16 | 1.03 µs | 1.24 µs | +21% |
| all_dirty | 64 | 5.73 µs | 6.44 µs | +12% |
| all_dirty | 256 | 25.6 µs | 30.5 µs | +19% |
| all_dirty | 1024 | 105.7 µs | 122.2 µs | +16% |

Read honestly:
- Before, `one_dirty` tracked `all_dirty` exactly (the issue's point). Now it sits ~19× below the ceiling at 1024 nodes.
- `one_dirty` still grows with n — the flush walks the arena once for the live-id set and focus derivation — but translation and publish are O(dirty), and the delivered payload is 1 node instead of 1024 (the D-Bus serialization win downstream of the no-op bench callback is not measured here).
- `all_dirty` (= `send_full_tree`, the reconnect path) pays ~16-21% for mirror maintenance. An intermediate version paid 65%; building the mirror by consuming the delivered update instead of re-cloning it brought it down.

## Evidence

- **Born-red** (genuinely, against the pre-change source — the new integration test file deliberately uses only pre-diff API): 5/8 tests in `crates/flui-semantics/tests/incremental_flush.rs` fail on the old code, including both headline pins — `a_rebuild_that_changes_nothing_publishes_nothing` and `a_single_content_change_publishes_exactly_that_node` (old code shows all 4 nodes republished for a 1-label change).
- **Sabotage-verified:** removing the mirror prune fails exactly `a_removed_then_restored_node_is_republished`; forcing every flush down the full path fails the pipeline-level `an_identical_second_semantics_pass_publishes_nothing`; deleting the reconnect re-seed fails `request_semantics_full_publish_makes_an_idle_pass_republish_everything`.
- **Counter pins:** insert/remove/clear/`get_mut`/`iter_mut`/`mark_all_dirty` seams each pinned in `tree.rs` (red against the old scan-based code, whose `get_mut` did not mark).
- **Suites:** flui-semantics 203/203 (was 192); flui-rendering 1072/1072 (includes 868 harness + 2 new pipeline pins); flui-app 310/310 (includes the new activation-wire pin); flui-platform (`--all-features`, `FLUI_HEADLESS=1` + `xvfb-run`, the CI mechanism) 235 passed / 8 skipped (was 234 — the new bridge retention pin).
- **Full gate:** `just ci` exit 0 (workspace nextest 9089 passed / 11 skipped, doc tests, port-check, inventory-check, runtime-conformance-check; one retry after the known cargo-metadata signal-crash flake, in which the test phase itself was 9089/9089). `taplo fmt --check` and `typos` clean. No monitored export in `docs/runtime-contract.toml` moved (the root-export manifest covers neither flui-semantics nor the touched surfaces; verified by the passing conformance check).

## Part of #687 — what remains

- **Slice 4, assembly reuse:** `run_semantics` still rebuilds the whole arena O(render tree) per pass; the issue itself says this needs its own design (a merge/exclude boundary changes what a subtree collapses to). The diff makes the *publish* side O(changed); assembly is untouched.
- The `one_dirty` flush retains one O(arena) pointer walk (live-set + focus); folding that into assembly, or maintaining a stable-id index, belongs with slice 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
