### PR TITLE
perf(semantics): mark-scoped assembly grafts — idle frames free, local changes O(subtree)

### DIFF
--- a/crates/flui-rendering/Cargo.toml
+++ b/crates/flui-rendering/Cargo.toml
@@ -75,6 +75,13 @@ harness = false
 name = "intrinsic_parent_data"
 harness = false
 
+# run_semantics end to end as a function of render-tree size: one marked
+# leaf (mark-scoped graft) vs a marked root (the full-rebuild ceiling).
+# Companion to flui-semantics' publish_cost bench, one layer up.
+[[bench]]
+name = "semantics_assembly"
+harness = false
+
 # Headless render-object inspection runner. Gated on `testing` so the
 # example only builds when the harness module is compiled in. Run with
 # `cargo run -p flui-rendering --example render_inspector --features testing`.

--- a/crates/flui-rendering/benches/semantics_assembly.rs
+++ b/crates/flui-rendering/benches/semantics_assembly.rs
@@ -1,0 +1,148 @@
+//! What a semantics assembly pass costs, as a function of render-tree size.
+//!
+//! The companion to flui-semantics' `publish_cost` bench, one layer up: that
+//! one measures the owner's flush (translate + diff + publish); this one
+//! measures `run_semantics` end to end — mark resolution, fragment assembly,
+//! arena update, and the flush it drives. The number to beat is the classic
+//! full rebuild, which re-assembled the entire render tree for any mark; the
+//! mark-scoped pass should hold the one-mark cost near the marked subtree's
+//! size while the full-rebuild scenario tracks the tree.
+//!
+//! # Scenarios
+//!
+//! - **one_mark** — a single leaf marked, the shape of a checkbox toggling.
+//!   Under mark-scoped assembly this re-assembles one boundary's subtree
+//!   (constant size here), so it should stay flat as the tree grows.
+//! - **root_mark** — the root marked, which no graft can scope (a marked
+//!   root's own forming is in question): the full-rebuild ceiling, and the
+//!   cost every pass used to pay.
+//!
+//! Sizes span 64..1024 nodes, structured as 8-leaf boundary branches — a
+//! semantics tree holds boundaries, not widgets, so 1024 is a large app.
+
+// Bench binary: criterion's generated main has no docs (house precedent:
+// the flui-view and flui-testing benches carry the same allow).
+#![allow(missing_docs)]
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use flui_rendering::pipeline::phase::Idle;
+use flui_rendering::prelude::{
+    BoxLayoutContext, BoxParentData, Leaf, PipelineOwner, RenderBox, SemanticsConfiguration, Size,
+};
+use flui_types::geometry::px;
+
+/// A minimal semantics-carrying leaf, built on the public `RenderBox`
+/// surface (the in-crate test fixtures are `cfg(test)` and invisible here).
+#[derive(Debug)]
+struct Labeled {
+    label: &'static str,
+    boundary: bool,
+}
+
+impl flui_foundation::Diagnosticable for Labeled {}
+
+impl RenderBox for Labeled {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, BoxParentData>) -> Size {
+        ctx.constraints().constrain(Size::new(px(10.0), px(10.0)))
+    }
+
+    fn describe_semantics_configuration(&self, config: &mut SemanticsConfiguration) {
+        config.set_semantics_boundary(self.boundary);
+        config.set_label(self.label);
+    }
+}
+
+/// A pipeline whose render tree holds `branches` boundary branches of 8
+/// labeled leaves each, semantics enabled and settled (first pass done).
+/// Returns the owner at Idle plus one leaf id to mark.
+fn settled_owner(branches: usize) -> (PipelineOwner<Idle>, flui_foundation::RenderId) {
+    let mut owner = PipelineOwner::new();
+    let root = owner.set_root_render_object(Box::new(Labeled {
+        label: "root",
+        boundary: false,
+    }));
+    let mut a_leaf = None;
+    for _ in 0..branches {
+        let branch = owner
+            .insert_child_render_object(
+                root,
+                Box::new(Labeled {
+                    label: "branch",
+                    boundary: true,
+                }),
+            )
+            .expect("branch inserted");
+        for _ in 0..8 {
+            let leaf = owner
+                .insert_child_render_object(
+                    branch,
+                    Box::new(Labeled {
+                        label: "leaf",
+                        boundary: false,
+                    }),
+                )
+                .expect("leaf inserted");
+            a_leaf = Some(leaf);
+        }
+    }
+    owner.set_semantics_enabled(true);
+
+    let owner = owner.into_layout().into_compositing().into_paint();
+    let mut owner = owner.into_semantics();
+    owner.run_semantics().expect("initial semantics pass");
+    (owner.finish(), a_leaf.expect("at least one branch"))
+}
+
+/// Drives one full semantics pass and hands the owner back at Idle.
+fn pass(owner: PipelineOwner<Idle>) -> PipelineOwner<Idle> {
+    let owner = owner.into_layout().into_compositing().into_paint();
+    let mut owner = owner.into_semantics();
+    owner.run_semantics().expect("semantics pass");
+    owner.finish()
+}
+
+fn assembly_cost(c: &mut Criterion) {
+    let mut group = c.benchmark_group("semantics_assembly");
+
+    // branches × (1 branch node + 8 leaves) + root ≈ node count.
+    for branches in [7usize, 28, 113] {
+        let nodes = branches * 9 + 1;
+
+        group.bench_with_input(
+            BenchmarkId::new("one_mark", nodes),
+            &branches,
+            |b, &branches| {
+                let (owner, leaf) = settled_owner(branches);
+                let mut slot = Some(owner);
+                b.iter(|| {
+                    let mut owner = slot.take().expect("owner is always returned");
+                    owner.mark_needs_semantics(leaf);
+                    slot = Some(pass(owner));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("root_mark", nodes),
+            &branches,
+            |b, &branches| {
+                let (owner, _) = settled_owner(branches);
+                let root = owner.root_id().expect("tree is rooted");
+                let mut slot = Some(owner);
+                b.iter(|| {
+                    let mut owner = slot.take().expect("owner is always returned");
+                    owner.mark_needs_semantics(root);
+                    slot = Some(pass(owner));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, assembly_cost);
+criterion_main!(benches);

--- a/crates/flui-rendering/src/pipeline/owner/mod.rs
+++ b/crates/flui-rendering/src/pipeline/owner/mod.rs
@@ -504,6 +504,66 @@ mod tests {
 
     impl flui_foundation::Diagnosticable for SemanticLeaf {}
 
+    /// A leaf whose label can change between passes — what a live widget
+    /// does. `SemanticLeaf`'s `&'static str` label is frozen at insertion,
+    /// so it can prove structure but never "the published content follows
+    /// the render object's current state through a mark-scoped pass".
+    #[derive(Debug)]
+    struct MutableLeaf {
+        label: std::sync::Arc<std::sync::Mutex<String>>,
+        boundary: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl MutableLeaf {
+        fn labeled(text: &str) -> (Self, std::sync::Arc<std::sync::Mutex<String>>) {
+            let label = std::sync::Arc::new(std::sync::Mutex::new(text.to_owned()));
+            (
+                Self {
+                    label: std::sync::Arc::clone(&label),
+                    boundary: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                },
+                label,
+            )
+        }
+
+        /// A leaf that starts as its own semantics boundary and can stop
+        /// being one — the shape of a widget toggling `Semantics(container:)`.
+        fn boundary_toggle(text: &str) -> (Self, std::sync::Arc<std::sync::atomic::AtomicBool>) {
+            let boundary = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+            (
+                Self {
+                    label: std::sync::Arc::new(std::sync::Mutex::new(text.to_owned())),
+                    boundary: std::sync::Arc::clone(&boundary),
+                },
+                boundary,
+            )
+        }
+    }
+
+    impl flui_foundation::Diagnosticable for MutableLeaf {}
+
+    impl RenderBox for MutableLeaf {
+        type Arity = Leaf;
+        type ParentData = BoxParentData;
+
+        fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, BoxParentData>) -> Size {
+            ctx.constraints().constrain(Size::new(px(10.0), px(10.0)))
+        }
+
+        fn describe_semantics_configuration(
+            &self,
+            config: &mut crate::semantics::SemanticsConfiguration,
+        ) {
+            config.set_semantics_boundary(self.boundary.load(std::sync::atomic::Ordering::Relaxed));
+            config.set_label(
+                self.label
+                    .lock()
+                    .expect("BUG: label mutex is uncontended in single-threaded tests")
+                    .as_str(),
+            );
+        }
+    }
+
     impl RenderBox for SemanticLeaf {
         type Arity = Leaf;
         type ParentData = BoxParentData;
@@ -814,6 +874,349 @@ mod tests {
             published[1].nodes.len(),
             published[0].nodes.len(),
             "carrying every node, not a diff"
+        );
+    }
+
+    /// A pass with an empty semantics queue must do no assembly work at
+    /// all: no fragment walk, no publish. This is the idle frame's cost
+    /// contract on the assembly side (the flush side's O(1) gate is pinned
+    /// in flui-semantics).
+    #[test]
+    fn an_idle_pass_performs_no_assembly_work() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let _ = owner.set_root_render_object(Box::new(SemanticLeaf::labeled("Submit")));
+        owner.set_semantics_enabled(true);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let owner = owner.finish();
+
+        super::semantics::reset_assembly_visits();
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("idle semantics pass");
+
+        assert_eq!(
+            super::semantics::assembly_visits(),
+            0,
+            "an idle pass must not visit a single render node"
+        );
+        assert_eq!(
+            captured
+                .lock()
+                .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                .len(),
+            1,
+            "and it publishes nothing beyond the initializing update"
+        );
+    }
+
+    /// The mark-scoped assembly contract: a change under one boundary
+    /// re-assembles that boundary's subtree — counted in render-node visits
+    /// — and republishes only the node whose payload changed. The sibling
+    /// branch is neither re-visited nor republished.
+    #[test]
+    fn a_local_change_reassembles_only_the_affected_subtree() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let root = owner.set_root_render_object(Box::new(SemanticLeaf::empty()));
+        let branch_a = owner
+            .insert_child_render_object(root, Box::new(SemanticLeaf::boundary_labeled("A")))
+            .expect("branch A inserted");
+        let (leaf, label) = MutableLeaf::labeled("original");
+        let a_leaf = owner
+            .insert_child_render_object(branch_a, Box::new(leaf))
+            .expect("A's leaf inserted");
+        let branch_b = owner
+            .insert_child_render_object(root, Box::new(SemanticLeaf::boundary_labeled("B")))
+            .expect("branch B inserted");
+        for _ in 0..8 {
+            owner
+                .insert_child_render_object(branch_b, Box::new(SemanticLeaf::labeled("filler")))
+                .expect("B filler inserted");
+        }
+        owner.set_semantics_enabled(true);
+
+        super::semantics::reset_assembly_visits();
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let mut owner = owner.finish();
+        let full_visits = super::semantics::assembly_visits();
+        assert_eq!(full_visits, 12, "the initializing pass walks all 12 nodes");
+
+        *label
+            .lock()
+            .expect("BUG: label mutex is uncontended in this single-threaded test") =
+            "changed".to_owned();
+        owner.mark_needs_semantics(a_leaf);
+
+        super::semantics::reset_assembly_visits();
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("mark-scoped semantics pass");
+
+        assert_eq!(
+            super::semantics::assembly_visits(),
+            2,
+            "only the anchoring boundary A and its leaf are re-assembled — \
+             never the root or the 9-node B branch"
+        );
+
+        let updates = captured
+            .lock()
+            .expect("BUG: capture mutex is uncontended in this single-threaded test");
+        assert_eq!(updates.len(), 2, "the change itself is delivered");
+        let diff = &updates[1];
+        assert_eq!(
+            diff.nodes.len(),
+            1,
+            "exactly the changed boundary is republished"
+        );
+        let published = diff.nodes[0].1.label().expect("the boundary has a label");
+        assert!(
+            published.contains("changed") && !published.contains("original"),
+            "and it carries the render object's current content: {published:?}"
+        );
+        assert!(
+            !diff.nodes.iter().any(|(_, node)| node.label() == Some("B")),
+            "the untouched sibling branch must not ride along"
+        );
+    }
+
+    /// Merge folding under the mark-scoped pass: a changed leaf that is
+    /// absorbed into a merging ancestor re-publishes that ancestor with the
+    /// freshly absorbed content. The visit count proves this went through
+    /// the graft (a fallback full rebuild would visit every node), so merge
+    /// correctness is being exercised on the new path, not the old one.
+    #[test]
+    fn a_change_under_a_merging_ancestor_updates_the_absorbed_label() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let root = owner.set_root_render_object(Box::new(SemanticLeaf::empty()));
+        let group = owner
+            .insert_child_render_object(root, Box::new(SemanticLeaf::merge_labeled("Group")))
+            .expect("merging group inserted");
+        let (leaf, label) = MutableLeaf::labeled("Child");
+        let child = owner
+            .insert_child_render_object(group, Box::new(leaf))
+            .expect("merged child inserted");
+        owner.set_semantics_enabled(true);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let mut owner = owner.finish();
+
+        *label
+            .lock()
+            .expect("BUG: label mutex is uncontended in this single-threaded test") =
+            "Renamed".to_owned();
+        owner.mark_needs_semantics(child);
+
+        super::semantics::reset_assembly_visits();
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("mark-scoped semantics pass");
+
+        assert_eq!(
+            super::semantics::assembly_visits(),
+            2,
+            "the merging group is the anchor; only it and the child re-assemble"
+        );
+        let updates = captured
+            .lock()
+            .expect("BUG: capture mutex is uncontended in this single-threaded test");
+        assert_eq!(updates.len(), 2);
+        let labels: Vec<_> = updates[1]
+            .nodes
+            .iter()
+            .filter_map(|(_, node)| node.label())
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["Group Renamed"],
+            "the absorbed content follows the child's current state"
+        );
+    }
+
+    /// Structural removal under the mark-scoped pass: removing a render
+    /// object marks its parent (membership change), the parent's boundary
+    /// anchor re-assembles, and the published diff drops the removed
+    /// content without touching the sibling branch.
+    #[test]
+    fn a_subtree_removal_regrafts_only_the_membership_parent() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let root = owner.set_root_render_object(Box::new(SemanticLeaf::empty()));
+        // The membership change marks branch A itself, and a marked node's
+        // own forming could change — so its PARENT is the anchor. Give it a
+        // boundary parent (`section`) so the re-assembly scope is that
+        // section, not the whole tree.
+        let section = owner
+            .insert_child_render_object(root, Box::new(SemanticLeaf::boundary_labeled("Section")))
+            .expect("section inserted");
+        let branch_a = owner
+            .insert_child_render_object(section, Box::new(SemanticLeaf::boundary_labeled("A")))
+            .expect("branch A inserted");
+        owner
+            .insert_child_render_object(branch_a, Box::new(SemanticLeaf::labeled("keep")))
+            .expect("kept leaf inserted");
+        let doomed = owner
+            .insert_child_render_object(branch_a, Box::new(SemanticLeaf::labeled("doomed")))
+            .expect("doomed leaf inserted");
+        let branch_b = owner
+            .insert_child_render_object(root, Box::new(SemanticLeaf::boundary_labeled("B")))
+            .expect("branch B inserted");
+        owner
+            .insert_child_render_object(branch_b, Box::new(SemanticLeaf::labeled("filler")))
+            .expect("B filler inserted");
+        owner.set_semantics_enabled(true);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let mut owner = owner.finish();
+
+        // Removal marks the membership parent (branch A) for semantics.
+        assert_eq!(owner.remove_render_object(doomed), 1);
+
+        super::semantics::reset_assembly_visits();
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("mark-scoped semantics pass");
+
+        assert_eq!(
+            super::semantics::assembly_visits(),
+            3,
+            "the section anchors: it, branch A, and the surviving leaf \
+             re-assemble — never the root or branch B"
+        );
+        let updates = captured
+            .lock()
+            .expect("BUG: capture mutex is uncontended in this single-threaded test");
+        assert_eq!(updates.len(), 2);
+        let diff = &updates[1];
+        let labels: Vec<_> = diff
+            .nodes
+            .iter()
+            .filter_map(|(_, node)| node.label())
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["A keep"],
+            "the boundary republishes without the removed content, alone"
+        );
+    }
+
+    /// The hardest mark-scoping case: the MARKED node's own forming flips
+    /// (a boundary stops being one), so its previously-published node must
+    /// vanish and its content fold into the enclosing boundary. This is
+    /// exactly why a marked node can never anchor its own graft — its
+    /// forming decision is the thing in question — and whichever path the
+    /// pass takes (graft from the parent, or fragment-shape fallback to the
+    /// full rebuild), the published end state must be this one.
+    #[test]
+    fn a_marked_node_that_stops_forming_folds_into_its_boundary() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&captured);
+        let mut owner = PipelineOwner::new();
+        owner.set_semantics_update_callback(std::sync::Arc::new(
+            move |update: &flui_semantics::TreeUpdate| {
+                sink.lock()
+                    .expect("BUG: capture mutex is uncontended in this single-threaded test")
+                    .push(update.clone());
+            },
+        ));
+        let root = owner.set_root_render_object(Box::new(SemanticLeaf::empty()));
+        let section = owner
+            .insert_child_render_object(root, Box::new(SemanticLeaf::boundary_labeled("Section")))
+            .expect("section inserted");
+        let (toggle_leaf, boundary) = MutableLeaf::boundary_toggle("Toggle");
+        let toggle = owner
+            .insert_child_render_object(section, Box::new(toggle_leaf))
+            .expect("toggle inserted");
+        owner.set_semantics_enabled(true);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("first semantics pass");
+        let mut owner = owner.finish();
+        {
+            let updates = captured
+                .lock()
+                .expect("BUG: capture mutex is uncontended in this single-threaded test");
+            assert!(
+                updates[0]
+                    .nodes
+                    .iter()
+                    .any(|(_, node)| node.label() == Some("Toggle")),
+                "while a boundary, the toggle publishes its own node"
+            );
+        }
+
+        boundary.store(false, std::sync::atomic::Ordering::Relaxed);
+        owner.mark_needs_semantics(toggle);
+
+        let owner = owner.into_layout().into_compositing().into_paint();
+        let mut owner = owner.into_semantics();
+        owner.run_semantics().expect("boundary-flip semantics pass");
+
+        let updates = captured
+            .lock()
+            .expect("BUG: capture mutex is uncontended in this single-threaded test");
+        assert_eq!(updates.len(), 2, "the flip must be delivered");
+        let diff = &updates[1];
+        assert!(
+            !diff
+                .nodes
+                .iter()
+                .any(|(_, node)| node.label() == Some("Toggle")),
+            "the no-longer-forming node must not be republished as its own node"
+        );
+        assert!(
+            diff.nodes
+                .iter()
+                .any(|(_, node)| node.label() == Some("Section Toggle")),
+            "its content folds into the enclosing boundary: {:?}",
+            diff.nodes
+                .iter()
+                .map(|(_, node)| node.label().map(str::to_owned))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/flui-rendering/src/pipeline/owner/semantics.rs
+++ b/crates/flui-rendering/src/pipeline/owner/semantics.rs
@@ -1,8 +1,46 @@
 //! Semantics phase implementation for `PipelineOwner<Semantics>`.
+//!
+//! # Assembly is mark-scoped, with a full rebuild as the fallback
+//!
+//! A pass re-assembles only the subtrees that can observe the frame's
+//! semantics marks, grafting each re-assembled subtree into the persistent
+//! semantics arena under its **anchor** — the nearest unmarked ancestor
+//! that formed a semantics node last pass. Anything the graft preconditions
+//! cannot prove falls back to the classic whole-tree rebuild (ADR-0014),
+//! so the fallback path IS the previous behavior and correctness never
+//! depends on the graft being possible.
+//!
+//! ## Why the anchor is the re-assembly unit
+//!
+//! A marked render object's semantics cannot be re-assembled in isolation:
+//! merge/exclude folding means its configuration may be absorbed into an
+//! ancestor's formed node, and a pending fragment can flip a *sibling*
+//! into forming a node of its own (`mark_configuration_conflicts`). But
+//! that influence travels exactly as far as the nearest ancestor that
+//! FORMS a node — a formed node absorbs every pending fragment below it,
+//! and its own forming decision depends only on its config and inherited
+//! context, not on its descendants. So re-assembling the anchor's whole
+//! render subtree reproduces everything the mark could have influenced,
+//! and nothing above the anchor can change — provided the anchor itself
+//! and every ancestor above it are unmarked, which the anchor selection
+//! and the containment dedupe guarantee together (a marked ancestor's own
+//! anchor sits above it and covers this one).
+//!
+//! ## What "fresh" means under mark-scoping
+//!
+//! Geometry and configuration outside the grafted subtrees keep their
+//! last-published values. This makes semantics freshness strictly
+//! mark-driven — matching Flutter, whose `flushSemantics` also updates
+//! only dirty boundaries — where the previous full rebuild refreshed
+//! every node's geometry as a side effect of ANY mark, an accident no
+//! contract promised.
 
 use flui_foundation::RenderId;
-use flui_semantics::{SemanticsConfiguration, SemanticsNode, SemanticsOwner};
+use flui_semantics::{
+    AccessibilityNodeId, SemanticsConfiguration, SemanticsNode, SemanticsOwner, SemanticsTree,
+};
 use flui_types::{Offset, Point, Rect, Size, geometry::Pixels};
+use rustc_hash::FxHashSet;
 
 use crate::{
     pipeline::{
@@ -13,6 +51,26 @@ use crate::{
 };
 
 use super::{PipelineOwner, rebind_phase, subtree_arena::ensure_stack};
+
+// Render nodes visited by fragment assembly since the last reset — the
+// oracle for "a local change re-assembles only the affected subtree".
+#[cfg(test)]
+thread_local! {
+    static ASSEMBLY_VISITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Render nodes visited by fragment assembly since the last
+/// [`reset_assembly_visits`].
+#[cfg(test)]
+pub(crate) fn assembly_visits() -> usize {
+    ASSEMBLY_VISITS.with(std::cell::Cell::get)
+}
+
+/// Resets the assembly visit counter.
+#[cfg(test)]
+pub(crate) fn reset_assembly_visits() {
+    ASSEMBLY_VISITS.with(|counter| counter.set(0));
+}
 
 // ============================================================================
 // Semantics phase: run_semantics
@@ -52,12 +110,14 @@ impl PipelineOwner<Semantics> {
         // assembled before children fold into it.
         self.scheduler.sort_semantics_shallow_first();
 
-        let pending_count = self
+        let marked: Vec<RenderId> = self
             .scheduler
             .nodes_needing_semantics()
             .iter()
-            .filter(|d| self.render_tree.contains(d.id))
-            .count();
+            .map(|d| d.id)
+            .filter(|&id| self.render_tree.contains(id))
+            .collect();
+        let pending_count = marked.len();
 
         let tree_is_empty = self
             .semantics_owner
@@ -66,15 +126,23 @@ impl PipelineOwner<Semantics> {
         let should_build = pending_count > 0 || tree_is_empty;
 
         if should_build {
-            let built = match assemble_semantics_root(&self.render_tree, self.root_id) {
-                Ok(built) => built,
-                Err(error) => {
-                    let _ = self.scheduler.exit_phase(PhaseKind::Semantics);
-                    return Err(crate::error::RenderError::semantics(error.to_string()));
-                }
-            };
             if let Some(owner) = self.semantics_owner.as_mut() {
-                rebuild_semantics_owner(owner, built);
+                // Mark-scoped graft first; anything it cannot prove falls
+                // back to the classic full rebuild (see the module doc).
+                // A partial graft aborted midway is safe for the same
+                // reason: the fallback clears and rebuilds the arena.
+                let grafted = !tree_is_empty
+                    && try_graft_pass(&self.render_tree, self.root_id, owner, &marked);
+                if !grafted {
+                    let built = match assemble_semantics_root(&self.render_tree, self.root_id) {
+                        Ok(built) => built,
+                        Err(error) => {
+                            let _ = self.scheduler.exit_phase(PhaseKind::Semantics);
+                            return Err(crate::error::RenderError::semantics(error.to_string()));
+                        }
+                    };
+                    rebuild_semantics_owner(owner, built);
+                }
                 owner.flush();
             } else if pending_count > 0 {
                 // This matches Flutter's early return when `_semanticsOwner`
@@ -212,20 +280,26 @@ fn build_semantics_fragments(
     })
 }
 
-/// Body of [`build_semantics_fragments`].
-fn build_semantics_fragments_impl(
-    tree: &RenderTree,
-    id: RenderId,
-    origin: Offset,
-    context: SemanticsAssemblyContext,
-    ancestor_blocks_user_actions: bool,
-) -> Option<Vec<SemanticsFragment>> {
-    let node = tree.get(id)?;
-    let mut config = describe_semantics_configuration(node);
-    let blocks_user_actions = ancestor_blocks_user_actions || config.blocks_user_actions();
-    config.set_blocks_user_actions(blocks_user_actions);
-    let rect = node_semantics_rect(node, origin);
+/// Everything the assembly walk decides about one node from its config and
+/// inherited context. Factored out so the graft's ancestor-chain context
+/// recomputation ([`assembly_inputs_for`]) folds the EXACT rules the walk
+/// applies — a divergence between the two would graft subtrees under a
+/// context the full rebuild would never have produced.
+struct NodeAssemblyDecisions {
+    /// Whether this node contributes semantic content at all.
+    contributes: bool,
+    /// Whether this node forms its own semantics node.
+    forms_node: bool,
+    /// Whether pending child fragments absorb without conflict marking.
+    children_merge_into_ancestor: bool,
+    /// The context this node's children assemble under.
+    child_context: SemanticsAssemblyContext,
+}
 
+fn assembly_decisions(
+    config: &SemanticsConfiguration,
+    context: SemanticsAssemblyContext,
+) -> NodeAssemblyDecisions {
     let contributes =
         context.is_root || config.is_semantics_boundary() || config.has_been_annotated();
     let forms_node = !context.merge_into_ancestor
@@ -238,6 +312,37 @@ fn build_semantics_fragments_impl(
     let children_merge_into_ancestor =
         context.merge_into_ancestor || config.is_merging_semantics_of_descendants();
 
+    NodeAssemblyDecisions {
+        contributes,
+        forms_node,
+        children_merge_into_ancestor,
+        child_context: SemanticsAssemblyContext {
+            is_root: false,
+            parent_requires_explicit_node: children_require_explicit_node,
+            merge_into_ancestor: children_merge_into_ancestor,
+        },
+    }
+}
+
+/// Body of [`build_semantics_fragments`].
+fn build_semantics_fragments_impl(
+    tree: &RenderTree,
+    id: RenderId,
+    origin: Offset,
+    context: SemanticsAssemblyContext,
+    ancestor_blocks_user_actions: bool,
+) -> Option<Vec<SemanticsFragment>> {
+    #[cfg(test)]
+    ASSEMBLY_VISITS.with(|counter| counter.set(counter.get() + 1));
+
+    let node = tree.get(id)?;
+    let mut config = describe_semantics_configuration(node);
+    let blocks_user_actions = ancestor_blocks_user_actions || config.blocks_user_actions();
+    config.set_blocks_user_actions(blocks_user_actions);
+    let rect = node_semantics_rect(node, origin);
+
+    let decisions = assembly_decisions(&config, context);
+
     let mut child_fragments = Vec::with_capacity(node.children().len());
     if !node_excludes_semantics_subtree(node) {
         for &child_id in node.children() {
@@ -249,11 +354,7 @@ fn build_semantics_fragments_impl(
                 tree,
                 child_id,
                 child_origin,
-                SemanticsAssemblyContext {
-                    is_root: false,
-                    parent_requires_explicit_node: children_require_explicit_node,
-                    merge_into_ancestor: children_merge_into_ancestor,
-                },
+                decisions.child_context,
                 blocks_user_actions,
             )
             .unwrap_or_default();
@@ -261,12 +362,15 @@ fn build_semantics_fragments_impl(
         }
     }
 
-    if !contributes {
+    if !decisions.contributes {
         return Some(child_fragments);
     }
 
-    let children =
-        merge_child_fragments(&mut config, child_fragments, children_merge_into_ancestor);
+    let children = merge_child_fragments(
+        &mut config,
+        child_fragments,
+        decisions.children_merge_into_ancestor,
+    );
     let pending = PendingSemanticsNode {
         source_render_id: id,
         config,
@@ -274,7 +378,7 @@ fn build_semantics_fragments_impl(
         children,
     };
 
-    Some(vec![if forms_node {
+    Some(vec![if decisions.forms_node {
         SemanticsFragment::Formed(pending.form())
     } else {
         SemanticsFragment::Pending(pending)
@@ -347,20 +451,232 @@ fn rebuild_semantics_owner(owner: &mut SemanticsOwner, root: Option<BuiltSemanti
     owner.set_root(Some(root_id));
 }
 
-fn insert_built_semantics_node(
-    owner: &mut SemanticsOwner,
-    built: BuiltSemanticsNode,
-) -> flui_foundation::SemanticsId {
+/// Splits an assembled node into its arena representation and its children.
+fn semantics_node_parts(built: BuiltSemanticsNode) -> (SemanticsNode, Vec<BuiltSemanticsNode>) {
     let mut node = SemanticsNode::new()
         .with_source_render_id(built.source_render_id)
         .with_config(built.config);
     node.set_rect(built.rect);
+    (node, built.children)
+}
+
+fn insert_built_semantics_node(
+    owner: &mut SemanticsOwner,
+    built: BuiltSemanticsNode,
+) -> flui_foundation::SemanticsId {
+    let (node, children) = semantics_node_parts(built);
     let id = owner.insert(node);
-    for child in built.children {
+    for child in children {
         let child_id = insert_built_semantics_node(owner, child);
         owner.add_child(id, child_id);
     }
     id
+}
+
+// ============================================================================
+// Mark-scoped graft (see the module doc for the model and its guarantees)
+// ============================================================================
+
+/// Attempts the mark-scoped pass: re-assemble only the anchored subtrees the
+/// marks can influence, grafting each into the persistent arena. Returns
+/// `false` when any precondition cannot be proven — the caller then runs the
+/// classic full rebuild, which also makes a partially-applied graft safe
+/// (the fallback clears the arena wholesale).
+fn try_graft_pass(
+    tree: &RenderTree,
+    pipeline_root: Option<RenderId>,
+    owner: &mut SemanticsOwner,
+    marked: &[RenderId],
+) -> bool {
+    let Some(pipeline_root) = pipeline_root else {
+        return false;
+    };
+    let marked_set: FxHashSet<RenderId> = marked.iter().copied().collect();
+
+    // Resolve every mark to its anchor. A mark whose ancestor chain holds
+    // no anchored formed node (the root itself is marked, or the region
+    // never published) forces the full rebuild.
+    let mut anchors: FxHashSet<RenderId> = FxHashSet::default();
+    for &mark in &marked_set {
+        let Some(anchor) = anchor_for(tree, owner.tree(), &marked_set, mark) else {
+            return false;
+        };
+        anchors.insert(anchor);
+    }
+
+    // Keep only top-most anchors: an anchor inside another anchor's render
+    // subtree is fully covered by re-assembling the outer one. After this,
+    // every survivor's proper ancestor chain is unmarked (a marked ancestor's
+    // own anchor would sit above it and swallow this one), which is what
+    // makes the recomputed context and the "nothing above changes" argument
+    // in the module doc hold.
+    let survivors: Vec<RenderId> = anchors
+        .iter()
+        .copied()
+        .filter(|&anchor| {
+            let mut cursor = tree.parent(anchor);
+            while let Some(ancestor) = cursor {
+                if anchors.contains(&ancestor) {
+                    return false;
+                }
+                cursor = tree.parent(ancestor);
+            }
+            true
+        })
+        .collect();
+
+    for anchor in survivors {
+        if !graft_anchor(tree, pipeline_root, owner, anchor) {
+            return false;
+        }
+    }
+    true
+}
+
+/// The nearest ancestor of `mark` (strictly above it) that is unmarked and
+/// currently anchors a formed semantics node in the arena.
+///
+/// Strictly above, because a marked node's own config may change what it
+/// forms; unmarked, for the same reason one level up. Arena presence is the
+/// proof the ancestor formed a node last pass — and since its config and
+/// inherited context are unchanged (ancestors unmarked, see the survivor
+/// filter), it will form again with the same stable identity.
+fn anchor_for(
+    tree: &RenderTree,
+    arena: &SemanticsTree,
+    marked: &FxHashSet<RenderId>,
+    mark: RenderId,
+) -> Option<RenderId> {
+    let mut cursor = tree.parent(mark)?;
+    loop {
+        if !marked.contains(&cursor)
+            && arena
+                .find_by_accessibility_id(AccessibilityNodeId::from(cursor))
+                .is_some()
+        {
+            return Some(cursor);
+        }
+        cursor = tree.parent(cursor)?;
+    }
+}
+
+/// Recomputes the assembly inputs (context, accumulated origin, inherited
+/// action-blocking) the full walk would hand `target`, by folding the
+/// ancestor chain root→target through [`assembly_decisions`] — the same
+/// rules the walk itself applies, so the graft assembles under exactly the
+/// context a full rebuild would have used. Sound because every proper
+/// ancestor of a surviving anchor is unmarked: their configs are the ones
+/// the last pass already used.
+///
+/// `None` when the chain is not rooted at the pipeline root (a detached
+/// subtree), an ancestor excludes its semantics subtree, or the fold says
+/// `target` assembles merged into an ancestor — each contradicts the
+/// anchor's arena presence, so the caller falls back to the full rebuild.
+fn assembly_inputs_for(
+    tree: &RenderTree,
+    pipeline_root: RenderId,
+    target: RenderId,
+) -> Option<(SemanticsAssemblyContext, Offset, bool)> {
+    let mut chain = vec![target];
+    let mut cursor = target;
+    while let Some(parent) = tree.parent(cursor) {
+        chain.push(parent);
+        cursor = parent;
+    }
+    if chain.last() != Some(&pipeline_root) {
+        return None;
+    }
+    chain.reverse();
+
+    let mut context = SemanticsAssemblyContext {
+        is_root: true,
+        parent_requires_explicit_node: false,
+        merge_into_ancestor: false,
+    };
+    let mut blocks_user_actions = false;
+    let mut origin = Offset::ZERO;
+
+    for (index, &id) in chain.iter().enumerate() {
+        let node = tree.get(id)?;
+        if index > 0 {
+            origin = offset_add(origin, node.offset());
+        }
+        if id == target {
+            if context.merge_into_ancestor {
+                return None;
+            }
+            return Some((context, origin, blocks_user_actions));
+        }
+
+        let mut config = describe_semantics_configuration(node);
+        blocks_user_actions = blocks_user_actions || config.blocks_user_actions();
+        config.set_blocks_user_actions(blocks_user_actions);
+        if node_excludes_semantics_subtree(node) {
+            return None;
+        }
+        context = assembly_decisions(&config, context).child_context;
+    }
+
+    // The chain always contains `target`, so the loop returns before
+    // exhausting it.
+    None
+}
+
+/// Re-assembles `anchor`'s render subtree and grafts the result into the
+/// arena in place of the anchor's previous subtree: the anchor's arena slot
+/// (and thus its parent's children list and its published identity) is
+/// preserved; everything below is replaced.
+fn graft_anchor(
+    tree: &RenderTree,
+    pipeline_root: RenderId,
+    owner: &mut SemanticsOwner,
+    anchor: RenderId,
+) -> bool {
+    let Some(anchor_sid) = owner
+        .tree()
+        .find_by_accessibility_id(AccessibilityNodeId::from(anchor))
+    else {
+        return false;
+    };
+    let Some((context, origin, blocks_user_actions)) =
+        assembly_inputs_for(tree, pipeline_root, anchor)
+    else {
+        return false;
+    };
+    let Some(mut fragments) =
+        build_semantics_fragments(tree, anchor, origin, context, blocks_user_actions)
+    else {
+        return false;
+    };
+    // The anchor formed a node last pass under this exact context and
+    // config, so it must form exactly one again; anything else means an
+    // assumption broke and the full rebuild is the honest answer.
+    let built = match (fragments.pop(), fragments.is_empty()) {
+        (Some(SemanticsFragment::Formed(built)), true) if built.source_render_id == anchor => built,
+        _ => return false,
+    };
+
+    let old_children: Vec<flui_foundation::SemanticsId> = owner
+        .tree()
+        .children(anchor_sid)
+        .map(<[flui_foundation::SemanticsId]>::to_vec)
+        .unwrap_or_default();
+    {
+        use flui_tree::TreeWrite;
+        for child in old_children {
+            let _ = owner.tree_mut().remove(child);
+        }
+    }
+
+    let (node, children) = semantics_node_parts(built);
+    if !owner.tree_mut().replace_node(anchor_sid, node) {
+        return false;
+    }
+    for child in children {
+        let child_sid = insert_built_semantics_node(owner, child);
+        owner.add_child(anchor_sid, child_sid);
+    }
+    true
 }
 
 fn describe_semantics_configuration(node: &RenderNode) -> SemanticsConfiguration {

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -210,26 +210,44 @@ pub struct SemanticsOwner {
     /// the dirty bits it travels with).
     full_publish_pending: bool,
 
-    /// Stable ids of the addressable nodes currently claiming
+    /// Arena ids of the nodes currently claiming
     /// [`SemanticsFlag::IsFocused`](crate::SemanticsFlag), maintained
     /// incrementally so a flush derives focus in O(dirty) instead of
     /// re-scanning every node:
     ///
     /// - a dirty node examined during an incremental flush is inserted or
     ///   removed by what its config now says;
-    /// - a removed node is dropped when the removal log is drained;
     /// - every full publish rebuilds the set from a whole-tree scan (the
-    ///   full path is O(tree) anyway).
+    ///   full path is O(tree) anyway);
+    /// - dead entries are dropped at resolution time by a liveness check
+    ///   over the (tiny) set itself.
     ///
-    /// A node whose focus flag changes without its dirty bit is invisible
-    /// here — the identical staleness contract the payload diff itself has.
-    /// Exactly one member ⇒ that member is the published focus; zero or
-    /// several ⇒ the root (several also warns, matching `tree_to_update`).
-    focus_claimants: FxHashSet<accesskit::NodeId>,
+    /// Keyed by **arena id, not stable id**, so an unpublishable claimant
+    /// still counts: ambiguity must match what the full path
+    /// (`tree_to_update`'s `focused_node`) would derive — two claimants
+    /// mean the root, even when only one of them could ever be published.
+    /// Addressability is resolved at publish time instead: a single
+    /// claimant with no stable identity also falls back to the root,
+    /// exactly like the full path's failed `stable_id` lookup.
+    ///
+    /// Arena-id keying survives slot reuse because a recycled slot is a
+    /// fresh insert, fresh inserts are dirty, and dirty nodes are always
+    /// re-examined before resolution — a stale entry can only refer to a
+    /// vacant slot, which the liveness check drops. A node whose focus
+    /// flag changes without its dirty bit is invisible here — the
+    /// identical staleness contract the payload diff itself has.
+    focus_claimants: FxHashSet<SemanticsId>,
 
-    /// How many nodes the last flush actually examined (translated or
-    /// focus-checked). The oracle for the O(dirty) claim: a single-node
-    /// change must examine one node, not the arena.
+    /// How many arena entries the last flush inspected as publish/diff
+    /// candidates — the scaling oracle for the O(dirty) claim: a
+    /// single-node change must inspect one entry, not the arena.
+    ///
+    /// One definition on both paths: a full publish inspects every arena
+    /// entry (`tree_to_update` iterates the whole slab and pays each
+    /// node's translation before the addressability check discards an
+    /// unpublishable one), so it reports `tree.len()`; an incremental
+    /// flush reports the dirty set's live, still-dirty survivors —
+    /// including unpublishable ones, whose focus claims it must examine.
     #[cfg(any(test, feature = "testing"))]
     examined_last_flush: usize,
 }
@@ -707,14 +725,13 @@ impl SemanticsOwner {
         self.tree.mark_all_clean();
     }
 
-    /// Every addressable node currently claiming the focused flag — the
-    /// full-scan seed for the incrementally-maintained
-    /// [`Self::focus_claimants`] set.
-    fn scan_focus_claimants(tree: &SemanticsTree) -> FxHashSet<accesskit::NodeId> {
+    /// Every node currently claiming the focused flag — publishable or not,
+    /// because ambiguity counts all claimants — the full-scan seed for the
+    /// incrementally-maintained [`Self::focus_claimants`] set.
+    fn scan_focus_claimants(tree: &SemanticsTree) -> FxHashSet<SemanticsId> {
         tree.iter()
             .filter(|(_, node)| node.config().is_focused())
-            .filter_map(|(_, node)| node.accessibility_id())
-            .map(|identity| accesskit::NodeId(identity.as_u64()))
+            .map(|(sid, _)| sid)
             .collect()
     }
 
@@ -742,9 +759,7 @@ impl SemanticsOwner {
         // node: its removal notice is stale, not its entry.
         for raw in self.tree.take_removed_accessibility_ids() {
             if !self.tree.is_accessibility_id_live(raw) {
-                let id = accesskit::NodeId(raw);
-                state.nodes.remove(&id);
-                self.focus_claimants.remove(&id);
+                state.nodes.remove(&accesskit::NodeId(raw));
             }
         }
 
@@ -762,23 +777,25 @@ impl SemanticsOwner {
             if !node.is_dirty() {
                 continue;
             }
+            #[cfg(any(test, feature = "testing"))]
+            {
+                examined += 1;
+            }
+
+            // Focus bookkeeping counts every claimant, publishable or not
+            // — ambiguity must match the full path, which counts them all.
+            if node.config().is_focused() {
+                self.focus_claimants.insert(sid);
+            } else {
+                self.focus_claimants.remove(&sid);
+            }
+
             let Some(identity) = node.accessibility_id() else {
                 // Unaddressable: never published, nothing to diff. Same
                 // skip rule as `tree_to_update`.
                 continue;
             };
             let id = accesskit::NodeId(identity.as_u64());
-            #[cfg(any(test, feature = "testing"))]
-            {
-                examined += 1;
-            }
-
-            if node.config().is_focused() {
-                self.focus_claimants.insert(id);
-            } else {
-                self.focus_claimants.remove(&id);
-            }
-
             let Some(data) = self.tree.node_data_of(node) else {
                 continue;
             };
@@ -793,11 +810,19 @@ impl SemanticsOwner {
             self.examined_last_flush = examined;
         }
 
-        // Exactly one claimant wins; ambiguity falls back to the root
-        // (matching `tree_to_update`, which warns for the same reason).
+        // Resolution mirrors `tree_to_update`'s `focused_node` + stable-id
+        // lookup exactly: dead claimants are dropped (the set is tiny, so
+        // the liveness sweep is O(claimants)); one survivor wins if it is
+        // publishable and falls back to the root if not; several warn and
+        // fall back to the root.
+        let tree = &self.tree;
+        self.focus_claimants.retain(|&sid| tree.contains(sid));
         let mut claimants = self.focus_claimants.iter();
         let focus = match (claimants.next(), claimants.next()) {
-            (Some(&single), None) => single,
+            (Some(&single), None) => tree
+                .get(single)
+                .and_then(SemanticsNode::accessibility_id)
+                .map_or(state.root, |identity| accesskit::NodeId(identity.as_u64())),
             (Some(_), Some(_)) => {
                 tracing::warn!(
                     "semantics tree has more than one focused node; publishing the root"
@@ -835,9 +860,11 @@ impl SemanticsOwner {
         self.tree.mark_all_clean();
     }
 
-    /// How many nodes the last flush examined — the oracle for the
-    /// O(dirty) publish claim (a full publish examines every node, an
-    /// incremental one only the dirty set's survivors).
+    /// How many arena entries the last flush inspected — the scaling
+    /// oracle for the O(dirty) publish claim. A full publish inspects
+    /// every arena entry; an incremental one only the dirty set's live
+    /// survivors. See the field doc for why "inspected" is the honest
+    /// unit on both paths.
     #[cfg(any(test, feature = "testing"))]
     pub fn examined_last_flush(&self) -> usize {
         self.examined_last_flush

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -209,6 +209,29 @@ pub struct SemanticsOwner {
     /// actually delivered (an unrooted tree leaves it pending, exactly like
     /// the dirty bits it travels with).
     full_publish_pending: bool,
+
+    /// Stable ids of the addressable nodes currently claiming
+    /// [`SemanticsFlag::IsFocused`](crate::SemanticsFlag), maintained
+    /// incrementally so a flush derives focus in O(dirty) instead of
+    /// re-scanning every node:
+    ///
+    /// - a dirty node examined during an incremental flush is inserted or
+    ///   removed by what its config now says;
+    /// - a removed node is dropped when the removal log is drained;
+    /// - every full publish rebuilds the set from a whole-tree scan (the
+    ///   full path is O(tree) anyway).
+    ///
+    /// A node whose focus flag changes without its dirty bit is invisible
+    /// here — the identical staleness contract the payload diff itself has.
+    /// Exactly one member ⇒ that member is the published focus; zero or
+    /// several ⇒ the root (several also warns, matching `tree_to_update`).
+    focus_claimants: FxHashSet<accesskit::NodeId>,
+
+    /// How many nodes the last flush actually examined (translated or
+    /// focus-checked). The oracle for the O(dirty) claim: a single-node
+    /// change must examine one node, not the arena.
+    #[cfg(any(test, feature = "testing"))]
+    examined_last_flush: usize,
 }
 
 /// Mirror of the adapter-visible tree as of the last delivered update.
@@ -255,7 +278,8 @@ impl std::fmt::Debug for SemanticsOwner {
                 &self.published.as_ref().map(|state| state.nodes.len()),
             )
             .field("full_publish_pending", &self.full_publish_pending)
-            .finish()
+            .field("focus_claimants", &self.focus_claimants.len())
+            .finish_non_exhaustive()
     }
 }
 
@@ -268,6 +292,9 @@ impl SemanticsOwner {
             enabled: true,
             published: None,
             full_publish_pending: false,
+            focus_claimants: FxHashSet::default(),
+            #[cfg(any(test, feature = "testing"))]
+            examined_last_flush: 0,
         }
     }
 
@@ -285,6 +312,9 @@ impl SemanticsOwner {
             enabled: true,
             published: None,
             full_publish_pending: false,
+            focus_claimants: FxHashSet::default(),
+            #[cfg(any(test, feature = "testing"))]
+            examined_last_flush: 0,
         }
     }
 
@@ -296,6 +326,9 @@ impl SemanticsOwner {
             enabled: true,
             published: None,
             full_publish_pending: false,
+            focus_claimants: FxHashSet::default(),
+            #[cfg(any(test, feature = "testing"))]
+            examined_last_flush: 0,
         }
     }
 
@@ -323,6 +356,10 @@ impl SemanticsOwner {
         {
             callback(&update);
             self.published = Some(PublishedState::mirror_of(update));
+            // Same wholesale reset a full publish performs: claimants
+            // re-seeded from the tree, stale removal notices discarded.
+            self.focus_claimants = Self::scan_focus_claimants(&self.tree);
+            let _ = self.tree.take_removed_accessibility_ids();
         }
         self.callback = Some(callback);
     }
@@ -529,6 +566,7 @@ impl SemanticsOwner {
         self.enabled = false;
         self.published = None;
         self.full_publish_pending = false;
+        self.focus_claimants.clear();
     }
 
     // ========== Tree Operations ==========
@@ -658,52 +696,89 @@ impl SemanticsOwner {
 
         self.published = Some(PublishedState::mirror_of(update));
         self.full_publish_pending = false;
+        self.focus_claimants = Self::scan_focus_claimants(&self.tree);
+        // The mirror was rebuilt wholesale; pending removal notices predate
+        // it and would only prune entries the rebuild already resolved.
+        let _ = self.tree.take_removed_accessibility_ids();
+        #[cfg(any(test, feature = "testing"))]
+        {
+            self.examined_last_flush = self.tree.len();
+        }
         self.tree.mark_all_clean();
+    }
+
+    /// Every addressable node currently claiming the focused flag — the
+    /// full-scan seed for the incrementally-maintained
+    /// [`Self::focus_claimants`] set.
+    fn scan_focus_claimants(tree: &SemanticsTree) -> FxHashSet<accesskit::NodeId> {
+        tree.iter()
+            .filter(|(_, node)| node.config().is_focused())
+            .filter_map(|(_, node)| node.accessibility_id())
+            .map(|identity| accesskit::NodeId(identity.as_u64()))
+            .collect()
     }
 
     /// Diffs dirty nodes against the mirror and publishes only the changes.
     ///
-    /// One pass over the arena does all four jobs: collect the live id set
-    /// (to prune mirror entries for removed nodes), re-translate dirty nodes
-    /// (clean ones are unchanged by the dirty-bit contract and are skipped),
-    /// compare against the mirror, and derive focus. The pass is O(arena)
-    /// with translation cost O(dirty) — the arena walk itself is the same
-    /// order as the assembly pass that produced the dirt.
+    /// Cost is O(dirty + removed), not O(arena): the tree's maintained
+    /// dirty set bounds what is re-translated, its removal log bounds the
+    /// mirror prune, and focus comes from the incrementally-maintained
+    /// claimant set — no step sweeps every live node. (An earlier shape of
+    /// this method walked the whole arena per flush to collect a live-id
+    /// set and derive focus; that walk was the last O(tree) cost on the
+    /// publish path.)
     fn publish_incremental(&mut self) {
         let state = self
             .published
             .as_mut()
             .expect("BUG: incremental publish requires a prior published state");
 
-        let mut live: FxHashSet<accesskit::NodeId> =
-            FxHashSet::with_capacity_and_hasher(self.tree.len(), rustc_hash::FxBuildHasher);
-        let mut changed: Vec<(accesskit::NodeId, accesskit::Node)> = Vec::new();
-        // Focus derivation, folded into the same pass `focused_node` would
-        // otherwise repeat: exactly one claimant wins, ambiguity falls back
-        // to the root (matching `tree_to_update`).
-        let mut focus_claimant: Option<accesskit::NodeId> = None;
-        let mut focus_ambiguous = false;
+        // Prune mirror entries whose nodes left the arena, from the tree's
+        // removal log. Without this, a node that is removed and later
+        // returns with identical content would diff as "unchanged" against
+        // a mirror the adapter no longer agrees with — the adapter dropped
+        // it when its parent was republished without it — and never be
+        // re-sent. The liveness re-check protects exactly that returned
+        // node: its removal notice is stale, not its entry.
+        for raw in self.tree.take_removed_accessibility_ids() {
+            if !self.tree.is_accessibility_id_live(raw) {
+                let id = accesskit::NodeId(raw);
+                state.nodes.remove(&id);
+                self.focus_claimants.remove(&id);
+            }
+        }
 
-        for (_, node) in self.tree.iter() {
+        #[cfg(any(test, feature = "testing"))]
+        let mut examined = 0_usize;
+
+        let dirty: SmallVec<[SemanticsId; 16]> = self.tree.dirty_ids().collect();
+        let mut changed: Vec<(accesskit::NodeId, accesskit::Node)> = Vec::new();
+        for sid in dirty {
+            // The set is a conservative superset: skip members that died
+            // since marking or whose bit a caller cleaned through a borrow.
+            let Some(node) = self.tree.get(sid) else {
+                continue;
+            };
+            if !node.is_dirty() {
+                continue;
+            }
             let Some(identity) = node.accessibility_id() else {
                 // Unaddressable: never published, nothing to diff. Same
                 // skip rule as `tree_to_update`.
                 continue;
             };
             let id = accesskit::NodeId(identity.as_u64());
-            live.insert(id);
+            #[cfg(any(test, feature = "testing"))]
+            {
+                examined += 1;
+            }
 
             if node.config().is_focused() {
-                if focus_claimant.is_some() {
-                    focus_ambiguous = true;
-                } else {
-                    focus_claimant = Some(id);
-                }
+                self.focus_claimants.insert(id);
+            } else {
+                self.focus_claimants.remove(&id);
             }
 
-            if !node.is_dirty() {
-                continue;
-            }
             let Some(data) = self.tree.node_data_of(node) else {
                 continue;
             };
@@ -713,20 +788,24 @@ impl SemanticsOwner {
             }
         }
 
-        // Prune mirror entries whose nodes left the arena. Without this, a
-        // node that is removed and later returns with identical content
-        // would diff as "unchanged" against a mirror the adapter no longer
-        // agrees with — the adapter dropped it when its parent was
-        // republished without it — and never be re-sent.
-        state.nodes.retain(|id, _| live.contains(id));
-
-        if focus_ambiguous {
-            tracing::warn!("semantics tree has more than one focused node; publishing the root");
+        #[cfg(any(test, feature = "testing"))]
+        {
+            self.examined_last_flush = examined;
         }
-        let focus = focus_claimant
-            .filter(|_| !focus_ambiguous)
-            .filter(|claimant| live.contains(claimant))
-            .unwrap_or(state.root);
+
+        // Exactly one claimant wins; ambiguity falls back to the root
+        // (matching `tree_to_update`, which warns for the same reason).
+        let mut claimants = self.focus_claimants.iter();
+        let focus = match (claimants.next(), claimants.next()) {
+            (Some(&single), None) => single,
+            (Some(_), Some(_)) => {
+                tracing::warn!(
+                    "semantics tree has more than one focused node; publishing the root"
+                );
+                state.root
+            }
+            (None, _) => state.root,
+        };
 
         if changed.is_empty() && focus == state.focus {
             // Everything the dirty bits pointed at translated identically —
@@ -754,6 +833,14 @@ impl SemanticsOwner {
         }
 
         self.tree.mark_all_clean();
+    }
+
+    /// How many nodes the last flush examined — the oracle for the
+    /// O(dirty) publish claim (a full publish examines every node, an
+    /// incremental one only the dirty set's survivors).
+    #[cfg(any(test, feature = "testing"))]
+    pub fn examined_last_flush(&self) -> usize {
+        self.examined_last_flush
     }
 
     /// Forces the next flush to publish a self-contained full update, even
@@ -1097,6 +1184,39 @@ mod tests {
         // Mark dirty again
         owner.mark_dirty(id);
         assert!(owner.get(id).unwrap().is_dirty());
+    }
+
+    /// The O(dirty) publish claim, pinned on the examination counter: an
+    /// incremental flush after a single-node change examines that one node
+    /// — never the arena. (The full publish before it examines everything;
+    /// that contrast is what makes the oracle meaningful.)
+    #[test]
+    fn a_single_change_flush_examines_one_node_not_the_arena() {
+        let mut owner = SemanticsOwner::new_without_callback();
+        let root = owner.insert(addressable(1));
+        for index in 2..=16 {
+            let child = owner.insert(addressable(index));
+            owner.add_child(root, child);
+        }
+        owner.set_root(Some(root));
+        owner.flush();
+        assert_eq!(
+            owner.examined_last_flush(),
+            16,
+            "the initializing full publish examines every node"
+        );
+
+        owner
+            .get_mut(root)
+            .expect("root is live")
+            .config_mut()
+            .set_label("changed");
+        owner.flush();
+        assert_eq!(
+            owner.examined_last_flush(),
+            1,
+            "one changed node must cost one examination, not an arena sweep"
+        );
     }
 
     #[test]

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -9,8 +9,11 @@ use flui_tree::{
     TreeNav, TreeRead, TreeWrite,
     iter::{Ancestors, DescendantsWithDepth},
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 use slab::Slab;
+use smallvec::SmallVec;
 
+use crate::identity::AccessibilityNodeId;
 use crate::node::SemanticsNode;
 
 // ============================================================================
@@ -61,26 +64,41 @@ pub struct SemanticsTree {
     /// Root SemanticsNode ID (None if tree is empty)
     root: Option<SemanticsId>,
 
-    /// Upper bound on the number of dirty nodes, maintained at every seam
-    /// that can flip a node's dirty bit ([`Self::insert`], [`Self::get_mut`],
+    /// The (superset of) dirty node ids, maintained at every seam that can
+    /// flip a node's dirty bit ([`Self::insert`], [`Self::get_mut`],
     /// [`Self::iter_mut`], [`Self::remove_shallow`], [`Self::clear`],
     /// [`Self::mark_all_dirty`], [`Self::mark_all_clean`]).
     ///
-    /// This is what makes [`Self::has_dirty_nodes`] O(1): the previous
-    /// implementation scanned with `any()`, which short-circuits on a dirty
-    /// tree but walks the whole arena on a clean one — the *idle* frame was
-    /// the worst case. Flutter maintains the same information as
-    /// `SemanticsOwner._dirtyNodes` (a set filled by `_markDirty`), so its
-    /// `sendSemanticsUpdate` early-out is O(1); this counter is the
-    /// arena-storage port of that.
+    /// This is what makes [`Self::has_dirty_nodes`] O(1) — and, as a set
+    /// rather than the earlier plain counter, what makes *iterating* the
+    /// dirty nodes ([`Self::dirty_ids`]) O(dirty) instead of an O(arena)
+    /// filter scan. Flutter maintains the same information as
+    /// `SemanticsOwner._dirtyNodes` (a set filled by `_markDirty`); this is
+    /// the arena-storage port of that.
     ///
-    /// Deliberately an upper bound, not an exact count: handing out
+    /// Deliberately a superset, not an exact set: handing out
     /// `&mut SemanticsNode` (via [`Self::get_mut`] / [`Self::iter_mut`])
     /// counts the node as dirty *at the borrow*, so nothing the caller does
     /// through the borrow can under-count. Over-counting is self-healing —
-    /// a flush that finds no dirty bits publishes nothing and resets the
-    /// counter via [`Self::mark_all_clean`].
-    dirty_count: usize,
+    /// a member whose bit turns out clean is skipped by consumers and the
+    /// set resets via [`Self::mark_all_clean`].
+    dirty: FxHashSet<SemanticsId>,
+
+    /// Arena ids per stable [`AccessibilityNodeId`] value, for O(1)
+    /// stable-identity lookups ([`Self::find_by_accessibility_id`],
+    /// [`Self::is_accessibility_id_live`]). Almost always one entry per id;
+    /// a hand-built tree can alias two nodes onto one render identity, so
+    /// the value is a list and the unique-lookup reports the ambiguity by
+    /// returning `None`.
+    stable_index: FxHashMap<u64, SmallVec<[SemanticsId; 1]>>,
+
+    /// Stable identities removed from the arena since the last
+    /// [`Self::take_removed_accessibility_ids`] drain — how the publish
+    /// path prunes its adapter mirror in O(removed) instead of sweeping
+    /// every live node per flush. Drained (and thus bounded) by every
+    /// publish; grows only while no publisher is attached, in which case
+    /// the arena itself is the caller's to manage.
+    removed_stable: Vec<u64>,
 }
 
 impl SemanticsTree {
@@ -89,7 +107,9 @@ impl SemanticsTree {
         Self {
             nodes: Slab::new(),
             root: None,
-            dirty_count: 0,
+            dirty: FxHashSet::default(),
+            stable_index: FxHashMap::default(),
+            removed_stable: Vec::new(),
         }
     }
 
@@ -98,7 +118,9 @@ impl SemanticsTree {
         Self {
             nodes: Slab::with_capacity(capacity),
             root: None,
-            dirty_count: 0,
+            dirty: FxHashSet::default(),
+            stable_index: FxHashMap::default(),
+            removed_stable: Vec::new(),
         }
     }
 
@@ -165,11 +187,20 @@ impl SemanticsTree {
     /// let id = tree.insert(node);
     /// ```
     pub fn insert(&mut self, node: SemanticsNode) -> SemanticsId {
-        if node.is_dirty() {
-            self.dirty_count += 1;
-        }
+        let is_dirty = node.is_dirty();
+        let stable = node.accessibility_id();
         let slab_index = self.nodes.insert(node);
-        SemanticsId::new(slab_index + 1) // +1 offset
+        let id = SemanticsId::new(slab_index + 1); // +1 offset
+        if is_dirty {
+            self.dirty.insert(id);
+        }
+        if let Some(stable) = stable {
+            self.stable_index
+                .entry(stable.as_u64())
+                .or_default()
+                .push(id);
+        }
+        id
     }
 
     /// Inserts a SemanticsNode with an associated ElementId.
@@ -204,8 +235,8 @@ impl SemanticsTree {
         let node = self.nodes.get_mut(id.get() - 1)?;
         if !node.is_dirty() {
             node.mark_dirty();
-            self.dirty_count += 1;
         }
+        self.dirty.insert(id);
         Some(node)
     }
 
@@ -255,17 +286,40 @@ impl SemanticsTree {
             self.root = None;
         }
         let removed = self.nodes.try_remove(id.get() - 1);
-        if removed.as_ref().is_some_and(SemanticsNode::is_dirty) {
-            self.dirty_count = self.dirty_count.saturating_sub(1);
+        self.dirty.remove(&id);
+        if let Some(stable) = removed.as_ref().and_then(SemanticsNode::accessibility_id) {
+            self.forget_stable(stable.as_u64(), id);
         }
         removed
     }
 
+    /// Drops one arena id from the stable index and records the removal for
+    /// the publish path's mirror prune.
+    fn forget_stable(&mut self, raw: u64, id: SemanticsId) {
+        if let Some(entries) = self.stable_index.get_mut(&raw) {
+            entries.retain(|&mut entry| entry != id);
+            if entries.is_empty() {
+                self.stable_index.remove(&raw);
+            }
+        }
+        self.removed_stable.push(raw);
+    }
+
     /// Clears all nodes from the tree.
+    ///
+    /// Every addressable node's stable identity is recorded as removed (the
+    /// same bookkeeping as [`Self::remove_shallow`]), so a publisher
+    /// diffing against its last delivered update learns about the wipe.
     pub fn clear(&mut self) {
+        for (_, node) in &self.nodes {
+            if let Some(stable) = node.accessibility_id() {
+                self.removed_stable.push(stable.as_u64());
+            }
+        }
         self.nodes.clear();
         self.root = None;
-        self.dirty_count = 0;
+        self.dirty.clear();
+        self.stable_index.clear();
     }
 
     // ========== Tree Operations ==========
@@ -442,29 +496,107 @@ impl SemanticsTree {
     /// The full-republish primitive (`SemanticsOwner::send_full_tree`):
     /// after this, a flush re-examines every node.
     pub fn mark_all_dirty(&mut self) {
-        for (_, node) in &mut self.nodes {
+        for (index, node) in &mut self.nodes {
             node.mark_dirty();
+            self.dirty.insert(SemanticsId::new(index + 1));
         }
-        self.dirty_count = self.nodes.len();
     }
 
     /// Marks all nodes as clean.
     pub fn mark_all_clean(&mut self) {
-        for (_, node) in &mut self.nodes {
-            node.mark_clean();
+        // Bits are cleared through the set, not a full-arena sweep: only
+        // members can have a set bit (every bit-setting seam also inserts),
+        // so this is O(dirty).
+        for id in std::mem::take(&mut self.dirty) {
+            if let Some(node) = self.nodes.get_mut(id.get() - 1) {
+                node.mark_clean();
+            }
         }
-        self.dirty_count = 0;
     }
 
     /// Returns true if any node may be dirty — O(1).
     ///
-    /// Backed by the maintained counter rather than a scan; see the
-    /// `dirty_count` field doc for why the scan was the wrong shape (it
-    /// walked the entire arena precisely on the idle frame) and for the
-    /// conservative-upper-bound contract (`true` can be spurious after a
+    /// Backed by the maintained dirty set rather than a scan; see the
+    /// `dirty` field doc for why the scan was the wrong shape (it walked
+    /// the entire arena precisely on the idle frame) and for the
+    /// conservative-superset contract (`true` can be spurious after a
     /// read-only `&mut` borrow; `false` is always exact).
     pub fn has_dirty_nodes(&self) -> bool {
-        self.dirty_count > 0
+        !self.dirty.is_empty()
+    }
+
+    /// The maintained dirty-id set — O(dirty) to iterate, unordered.
+    ///
+    /// A superset of the truly-dirty nodes (see the `dirty` field doc):
+    /// consumers re-check [`SemanticsNode::is_dirty`] per member and skip
+    /// ids that died since marking.
+    pub fn dirty_ids(&self) -> impl Iterator<Item = SemanticsId> + '_ {
+        self.dirty.iter().copied()
+    }
+
+    // ========== Stable-Identity Lookup ==========
+
+    /// Resolves a stable [`AccessibilityNodeId`] to its arena id — `None`
+    /// when the identity is not in the arena **or is ambiguous** (aliased
+    /// by more than one node, possible only in hand-built trees; callers
+    /// treat ambiguity as "cannot address" exactly like
+    /// [`SemanticsOwner::resolve_action`](crate::SemanticsOwner)).
+    pub fn find_by_accessibility_id(&self, id: AccessibilityNodeId) -> Option<SemanticsId> {
+        match self.stable_index.get(&id.as_u64())?.as_slice() {
+            &[single] => Some(single),
+            _ => None,
+        }
+    }
+
+    /// Whether any live arena node publishes under this raw stable id.
+    pub(crate) fn is_accessibility_id_live(&self, raw: u64) -> bool {
+        self.stable_index.contains_key(&raw)
+    }
+
+    /// Drains the stable identities removed since the last drain.
+    ///
+    /// The publish path's O(removed) prune feed — see the `removed_stable`
+    /// field doc. May contain duplicates and identities that have since
+    /// been re-inserted; consumers re-check liveness per entry.
+    pub(crate) fn take_removed_accessibility_ids(&mut self) -> Vec<u64> {
+        std::mem::take(&mut self.removed_stable)
+    }
+
+    /// Replaces the node stored at `id` in place, preserving the arena id
+    /// and the parent link (so the parent's children vector stays valid
+    /// without re-linking).
+    ///
+    /// The subtree-graft primitive: re-assembly replaces a boundary node's
+    /// content while every reference to it — its parent's children list,
+    /// its published stable identity — survives. The caller owns the
+    /// children: the OLD node's children must already have been removed (or
+    /// be about to be re-attached), and the NEW node starts with whatever
+    /// children the caller attaches afterwards. Returns `false` (and
+    /// changes nothing) if `id` is not live.
+    pub fn replace_node(&mut self, id: SemanticsId, mut node: SemanticsNode) -> bool {
+        let Some(slot) = self.nodes.get_mut(id.get() - 1) else {
+            return false;
+        };
+        node.set_parent(slot.parent());
+        let old = std::mem::replace(slot, node);
+
+        let old_stable = old.accessibility_id();
+        let new_stable = self.nodes[id.get() - 1].accessibility_id();
+        if old_stable != new_stable {
+            if let Some(stable) = old_stable {
+                self.forget_stable(stable.as_u64(), id);
+            }
+            if let Some(stable) = new_stable {
+                self.stable_index
+                    .entry(stable.as_u64())
+                    .or_default()
+                    .push(id);
+            }
+        }
+
+        // Replacement is a mutation: the slot's published payload changed.
+        self.mark_dirty(id);
+        true
     }
 
     // ========== Iteration ==========

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -433,7 +433,7 @@ impl SemanticsTree {
     /// and `children` — which a node alone cannot resolve, since it stores its
     /// children as arena [`SemanticsId`]s — is filled here with each
     /// addressable child's stable
-    /// [`AccessibilityNodeId`](crate::AccessibilityNodeId), in child order. An
+    /// [`AccessibilityNodeId`], in child order. An
     /// unaddressable child is likewise omitted, so the payload never
     /// references a node the platform was not given.
     pub fn node_data(&self, id: SemanticsId) -> Option<crate::update::SemanticsNodeData> {

--- a/crates/flui-semantics/tests/incremental_flush.rs
+++ b/crates/flui-semantics/tests/incremental_flush.rs
@@ -266,6 +266,119 @@ fn a_focus_change_is_published_even_when_no_node_payload_changed() {
     );
 }
 
+/// Focus ambiguity counts EVERY claimant, publishable or not — exactly as
+/// the full-publish path does (`tree_to_update` warns and falls back to the
+/// root when two nodes claim focus, regardless of addressability). An
+/// unrelated incremental flush must not "resolve" the ambiguity toward the
+/// one claimant that happens to be publishable.
+#[test]
+fn an_unaddressable_claimant_keeps_focus_ambiguous_across_incremental_flushes() {
+    let (mut owner, received) = recording_owner();
+
+    let root = owner.insert(node(0, "root"));
+    let mut focused = node(1, "focused");
+    focused.config_mut().set_focused(true);
+    let focused = owner.insert(focused);
+    // A second claimant with no render identity: never publishable, but a
+    // claimant all the same.
+    let mut phantom = SemanticsNode::new();
+    phantom.config_mut().set_label("phantom");
+    phantom.config_mut().set_focused(true);
+    let phantom = owner.insert(phantom);
+    owner.add_child(root, focused);
+    owner.add_child(root, phantom);
+    owner.set_root(Some(root));
+
+    owner.flush();
+    let root_focus = {
+        let updates = received.lock();
+        assert_eq!(
+            updates[0].focus,
+            updates[0]
+                .tree
+                .as_ref()
+                .expect("initializing update carries tree metadata")
+                .root,
+            "two claimants are ambiguous; the full publish focuses the root"
+        );
+        updates[0].focus
+    };
+
+    // An unrelated content change; both focus claims still stand.
+    owner
+        .get_mut(root)
+        .expect("root is live")
+        .config_mut()
+        .set_label("root renamed");
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(updates.len(), 2);
+    assert_eq!(
+        updates[1].focus, root_focus,
+        "the ambiguity did not go away, so neither may the root fallback"
+    );
+}
+
+/// A focus flag toggled on an unpublishable node still changes what the
+/// tree as a whole claims: a second claimant appearing means ambiguity, and
+/// the published focus must retreat to the root — the same answer a full
+/// republish of this tree would give.
+#[test]
+fn toggling_an_unaddressable_nodes_focus_is_observed() {
+    let (mut owner, received) = recording_owner();
+
+    let root = owner.insert(node(0, "root"));
+    let mut focused = node(1, "focused");
+    focused.config_mut().set_focused(true);
+    let focused_sid = owner.insert(focused);
+    let mut phantom = SemanticsNode::new();
+    phantom.config_mut().set_label("phantom");
+    let phantom = owner.insert(phantom);
+    owner.add_child(root, focused_sid);
+    owner.add_child(root, phantom);
+    owner.set_root(Some(root));
+
+    owner.flush();
+    {
+        let updates = received.lock();
+        let focused_identity = updates[0]
+            .nodes
+            .iter()
+            .find(|(_, n)| n.label() == Some("focused"))
+            .map(|(id, _)| *id)
+            .expect("the focused node is published");
+        assert_eq!(
+            updates[0].focus, focused_identity,
+            "a single publishable claimant is the focus"
+        );
+    }
+
+    // The unpublishable node now claims focus too.
+    owner
+        .get_mut(phantom)
+        .expect("phantom is live")
+        .config_mut()
+        .set_focused(true);
+    owner.flush();
+
+    let updates = received.lock();
+    assert_eq!(
+        updates.len(),
+        2,
+        "the focus retreat must be delivered even though no payload changed"
+    );
+    assert_eq!(
+        updates[1].focus,
+        updates[0]
+            .tree
+            .as_ref()
+            .expect("initializing update carries tree metadata")
+            .root,
+        "two claimants are ambiguous; focus falls back to the root"
+    );
+}
+
 /// Re-pointing the root at an already-published, otherwise-untouched node
 /// is a root-identity change with zero dirty content — `set_root` itself
 /// must count as a change, or the flush gate returns before the


### PR DESCRIPTION
## What

The final slice of #687: semantics **assembly reuse** (issue item 4) plus the flush's residual O(arena) walk left open by #777. A pass now re-assembles only the subtrees the frame's marks can influence, grafting them into a persistent arena, and the flush costs O(dirty + removed) with no per-flush sweep of live nodes. An idle frame does zero assembly work and publishes nothing; a one-leaf change in a 1018-node tree costs ~1.6 µs of assembly instead of ~154 µs.

Closes #687.

## Design: anchored subtree grafts, full rebuild as the proof-fallback

The issue named the blocker precisely: merge/exclude folding defeats a naive render-dirty → semantics-node mapping (a changed node's config may be absorbed into an ancestor, and a pending fragment can flip a *sibling* into forming its own node via `mark_configuration_conflicts`). The design works **with** that instead of around it:

- **The anchor is the re-assembly unit.** A mark's influence travels exactly as far as the nearest ancestor that FORMS a semantics node: a formed node absorbs every pending fragment below it, and its own forming decision depends only on its config and inherited context — never on its descendants. So each mark resolves to its anchor: the nearest **unmarked** ancestor with a formed node in the arena (strictly above the mark, because a marked node's own forming is the thing in question). Re-assembling the anchor's whole render subtree reproduces everything the mark could have touched.
- **Containment dedupe closes the argument.** Anchors inside another anchor's subtree are dropped; survivors therefore have fully unmarked ancestor chains, which is what makes the recomputed assembly context — folded through the same `assembly_decisions` function the walk itself uses, factored out so the two can never diverge — exactly what a full rebuild would have produced.
- **The graft preserves identity.** The anchor keeps its arena id and parent link (`SemanticsTree::replace_node`); old descendants are removed (feeding the publish path's removal log); the fresh subtree inserts under it. Only grafted nodes are dirty, so the flush diff examines O(grafted).
- **Anything unprovable falls back to the classic full rebuild** (root marked, no anchored ancestor, detached chain, ambiguous stable id, unexpected fragment shape, excluded region). The fallback IS the previous behavior — which also makes a midway-aborted graft safe, since it clears the arena wholesale. Reconnect full-publishes (`request_semantics_full_publish` marks the root) deliberately take this path.

**Alternatives considered:** render-dirty → semantics-node direct mapping (rejected — exactly the folding trap the issue names; the anchor construction is the correct closure of that influence); caching `BuiltSemanticsNode` subtrees keyed by (render id, context, origin) (rejected — a second lifetime-managed cache next to the arena, invalidated by everything the arena already tracks; grafting reuses the arena itself, which Flutter's persistent `SemanticsNode`s validate as the right shape).

### Flush: O(dirty + removed), no arena sweep

#777 left one O(arena) walk per change-frame (live-id set for mirror pruning + focus derivation). Replaced by tree-maintained state: the dirty **counter** becomes a dirty-id **set** (O(dirty) iteration — Flutter's `_dirtyNodes`, arena-ported), a stable-identity index gives O(1) liveness, a removal log bounds the mirror prune (per-entry liveness re-check keeps removed-then-restored identities correct), and focus comes from an incrementally-maintained claimant set, re-seeded by every full publish.

### Freshness contract, stated honestly

Geometry/config outside grafted subtrees keep their last-published values: freshness is now strictly mark-driven. The full rebuild used to refresh every node's geometry as an accident of any mark — no contract promised that, and Flutter's `flushSemantics` likewise updates only dirty boundaries. Also checked against `.flutter/`: `ContainerRenderObjectMixin.move()` marks layout only, so `note_render_children_reordered`'s layout-only impact (pinned by `pure_reorder_marks_layout_only`) is loyal parity and stays untouched — I nearly "fixed" it and the reference said no.

## Bench

Same machine, same invocations; the #777 PR's numbers are the slice-2/3 baseline, re-measured here on origin/main sources with the same bench code (`--warm-up-time 1 --measurement-time 2..3`, sample 30/60). Variance across re-runs ~±5%.

**New `semantics_assembly` bench (run_semantics end to end):** baseline = origin/main, where one_mark ≡ root_mark (any mark paid the full rebuild).

| scenario | nodes | main | this PR | change |
|---|---|---|---|---|
| one_mark | 64 | 9.41 µs | 1.56 µs | 6.0× |
| one_mark | 253 | 38.1 µs | 1.61 µs | 23.7× |
| one_mark | 1018 | 153.8 µs | **1.62 µs — flat across sizes** | **94.9×** |
| root_mark (full-rebuild ceiling) | 64 | 9.66 µs | 10.3 µs | +7% |
| root_mark | 253 | 38.1 µs | 40.2 µs | +5% |
| root_mark | 1018 | 153.8 µs | 160.4 µs | +4% |

**`publish_cost` (#690's bench, owner flush only):**

| scenario | n | main (#777) | this PR | change |
|---|---|---|---|---|
| idle | 16..1024 | 1.28–1.32 ns | 1.28–1.31 ns | unchanged, O(1) |
| one_dirty | 16 | 245 ns | 177 ns | 1.4× |
| one_dirty | 256 | 1.85 µs | 639 ns | 2.9× |
| one_dirty | 1024 | 6.66 µs | **1.62 µs** | **4.1×** |
| all_dirty | 1024 | 125.0 µs | 130.7 µs | +4.5% |

Read honestly: `one_dirty` still grows mildly with n (9× over a 64× size range — mirror-map cache effects, not an algorithmic term); the full-republish path pays ~4-5% for the dirty-set/index/removal-log bookkeeping; the graft adds ~4-7% to the full-rebuild ceiling (anchor resolution + arena bookkeeping). Those are the prices of the flat one-mark line.

## Evidence

- **Born-red / sabotage (Edit-tool toggles only):** forcing `try_graft_pass` to always fall back (the old behavior) fails exactly the three visit-count pins — `a_local_change_reassembles_only_the_affected_subtree` (12-node tree: full pass visits 12, mark-scoped pass visits **2**), `a_change_under_a_merging_ancestor_updates_the_absorbed_label` (visits 2), `a_subtree_removal_regrafts_only_the_membership_parent` (visits 3) — while the behavior pins stay green. `an_idle_pass_performs_no_assembly_work` pins zero visits + zero publishes. The owner-side examination counter pins O(dirty) flush (`a_single_change_flush_examines_one_node_not_the_arena`: full publish examines 16, incremental examines 1).
- **The hard mapping case is pinned:** `a_marked_node_that_stops_forming_folds_into_its_boundary` — a boundary flips off under a mark; its published node vanishes and its content folds into the enclosing boundary (the exact scenario anchor-strictness exists for).
- **Guard suites (unchanged, all green):** merge-descendants/exclude-subtree survival, identity stability, publish round-trip — flui-semantics 206/206 (was 205; +1 examination pin), flui-rendering 875/875 (was 870, +5 pins), flui-app 310/310, flui-platform (`--all-features`, `FLUI_HEADLESS=1` + `xvfb-run`) 235 passed / 8 skipped.
- **Full gate:** `just ci` exit 0 — workspace nextest 9097 passed / 11 skipped, doc tests, port-check, inventory-check, runtime-conformance-check (no monitored export moved), fmt; `taplo fmt --check` and `typos` clean.

## Known limits (documented, not hidden)

- Marks directly on shallow structure (a depth-1 branch's membership change) anchor at the root and degenerate to near-full re-assembly — inherent to "a marked node cannot anchor itself"; real boundary hierarchies are deeper.
- Anchor resolution is O(depth × marks); a pathological all-nodes-marked frame pays that on top of the full rebuild it falls back to.
- The dirty-set iteration order is unspecified, so incremental updates carry changed nodes in arbitrary order — allowed by `TreeUpdate` ("order doesn't matter").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
