### PR TITLE
feat(platform): UIA and NSAccessibility bridges — the Windows/macOS half of the a11y seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -895,14 +895,19 @@ jobs:
       - name: Add cross targets to the pinned toolchain
         run: rustup target add x86_64-pc-windows-msvc aarch64-apple-darwin aarch64-linux-android
 
+      # `--features a11y` on every line: the UIA/NSAccessibility bridges are
+      # feature-gated and this job is the ONLY gate that compiles them at all
+      # (the a11y-off configuration is a strict subset — no cfg(not(a11y))
+      # code exists — so checking with the feature supersedes checking
+      # without; on Android the feature enables nothing target-gated).
       - name: cargo clippy (windows backend)
-        run: cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings
+        run: cargo clippy -p flui-platform --locked --all-targets --features a11y --target x86_64-pc-windows-msvc -- -D warnings
 
       - name: cargo clippy (macos backend)
-        run: cargo clippy -p flui-platform --locked --all-targets --target aarch64-apple-darwin -- -D warnings
+        run: cargo clippy -p flui-platform --locked --all-targets --features a11y --target aarch64-apple-darwin -- -D warnings
 
       - name: cargo clippy (android backend)
-        run: cargo clippy -p flui-platform --locked --all-targets --target aarch64-linux-android -- -D warnings
+        run: cargo clippy -p flui-platform --locked --all-targets --features a11y --target aarch64-linux-android -- -D warnings
 
   # ─────────────────────────────────────────────────────────────────────────
   # ci — aggregator over every job above (tokio pattern). Branch protection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "accesskit_unix"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +81,20 @@ dependencies = [
  "futures-util",
  "serde",
  "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -2015,7 +2043,9 @@ name = "flui-platform"
 version = "0.2.0"
 dependencies = [
  "accesskit",
+ "accesskit_macos",
  "accesskit_unix",
+ "accesskit_windows",
  "android-activity",
  "anyhow",
  "arboard",

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -153,15 +153,33 @@ console_error_panic_hook = "0.1"
 [target.'cfg(target_os = "linux")'.dependencies]
 accesskit_unix = { version = "0.22", optional = true }
 
+# UIA bridge for Windows, same `a11y` feature. Version cohort must match the
+# workspace `accesskit` (0.24) -- 0.34 is that cohort -- and its `windows`
+# dependency (0.62) matches the backend's own, so no duplicate windows-rs
+# stack is linked.
+[target.'cfg(target_os = "windows")'.dependencies.accesskit_windows]
+version = "0.34"
+optional = true
+
+# NSAccessibility bridge for macOS, same `a11y` feature and the same 0.24
+# accesskit cohort. Uses objc2 internally; independent of the backend's
+# `cocoa`/`objc` stack.
+[target.'cfg(target_os = "macos")'.dependencies.accesskit_macos]
+version = "0.26"
+optional = true
+
 [features]
 default = ["desktop"]
 
 # Platform features
 desktop = ["dep:winit"]
 
-# AT-SPI accessibility bridge (Linux). Off by default: see the dependency note
-# above for why ~66 crates should be an opt-in rather than a default.
-a11y = ["dep:accesskit_unix"]
+# Per-OS accessibility bridges (AT-SPI on Linux, UIA on Windows,
+# NSAccessibility on macOS) -- one feature, target-gated dependencies, so a
+# build only ever links its own OS's stack. Off by default: see the Linux
+# dependency note above for why ~66 crates should be an opt-in rather than a
+# default.
+a11y = ["dep:accesskit_unix", "dep:accesskit_windows", "dep:accesskit_macos"]
 
 # winit fallback backend — primary on Linux until native Wayland/X11 lands
 # (roadmap Cross.P); optional on Windows/macOS.

--- a/crates/flui-platform/src/platforms/linux/accessibility.rs
+++ b/crates/flui-platform/src/platforms/linux/accessibility.rs
@@ -31,67 +31,24 @@
 //! next [`publish`](PlatformAccessibility::publish) delivers the tree once
 //! assembly has produced one.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::Arc;
 
 use accesskit::{ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, TreeUpdate};
 use parking_lot::Mutex;
 
+use crate::shared::accessibility_bridge::BridgeShared;
 use crate::traits::{
     AccessibilityActionListener, AccessibilityActivationListener, PlatformAccessibility,
 };
 
-/// State shared between the capability and the three handlers the adapter owns.
-///
-/// The handlers are moved into `Adapter::new` and thereafter live on the
-/// adapter's own thread, so everything they touch has to be reachable from both
-/// sides. This is that shared middle.
-#[derive(Default)]
-struct Shared {
-    /// Whether assistive technology is currently attached.
-    active: AtomicBool,
-    /// The most recent **self-contained** update (one carrying
-    /// [`TreeUpdate::tree`] metadata — the producer's promise that it stands
-    /// alone), kept so a late activation can be answered immediately rather
-    /// than showing an empty application until the next frame happens to
-    /// dirty something.
-    ///
-    /// Incremental updates (`tree: None`) are deliberately not retained:
-    /// applied in isolation they describe a handful of changed nodes, and
-    /// answering a fresh screen reader with one would present a fragment as
-    /// the whole interface. The composition root re-publishes a full tree on
-    /// every activation, so this retained answer is at worst one full
-    /// publish behind and is corrected within a frame.
-    latest: Mutex<Option<TreeUpdate>>,
-    activation_listener: Mutex<Option<AccessibilityActivationListener>>,
-    action_listener: Mutex<Option<AccessibilityActionListener>>,
-}
+// The state shared between the capability and the three handlers the adapter
+// owns lives in `crate::shared::accessibility_bridge`: the handlers are moved
+// into `Adapter::new` and thereafter live on the adapter's own thread, so
+// everything they touch has to be reachable from both sides — and the
+// retention/dispatch rules are common to every OS adapter, so they are
+// written and unit-tested once there rather than re-derived per OS.
 
-impl Shared {
-    /// Clone the listener out of its lock, then call it.
-    ///
-    /// A listener re-entering this type (the composition root's natural
-    /// response to "attached" is to publish) would deadlock against a held
-    /// guard. Same discipline as the semantics owner's callback dispatch.
-    fn notify_activation(&self, active: bool) {
-        self.active.store(active, Ordering::SeqCst);
-        let listener = self.activation_listener.lock().clone();
-        if let Some(listener) = listener {
-            listener(active);
-        }
-    }
-
-    fn notify_action(&self, request: ActionRequest) {
-        let listener = self.action_listener.lock().clone();
-        if let Some(listener) = listener {
-            listener(request);
-        }
-    }
-}
-
-struct Activation(Arc<Shared>);
+struct Activation(Arc<BridgeShared>);
 
 impl ActivationHandler for Activation {
     fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
@@ -101,11 +58,11 @@ impl ActivationHandler for Activation {
         // first would answer `None` even when a synchronous listener could
         // have supplied one.
         self.0.notify_activation(true);
-        self.0.latest.lock().clone()
+        self.0.retained()
     }
 }
 
-struct Deactivation(Arc<Shared>);
+struct Deactivation(Arc<BridgeShared>);
 
 impl DeactivationHandler for Deactivation {
     fn deactivate_accessibility(&mut self) {
@@ -113,7 +70,7 @@ impl DeactivationHandler for Deactivation {
     }
 }
 
-struct Action(Arc<Shared>);
+struct Action(Arc<BridgeShared>);
 
 impl ActionHandler for Action {
     fn do_action(&mut self, request: ActionRequest) {
@@ -123,7 +80,7 @@ impl ActionHandler for Action {
 
 /// AT-SPI accessibility for one window.
 pub struct UnixAccessibility {
-    shared: Arc<Shared>,
+    shared: Arc<BridgeShared>,
     /// The adapter needs `&mut` to publish, and the capability is shared behind
     /// an `Arc`, so the mutability lives here rather than in the trait.
     adapter: Mutex<accesskit_unix::Adapter>,
@@ -137,7 +94,7 @@ impl UnixAccessibility {
     /// activates, which is exactly the state a headless CI machine is in.
     #[must_use]
     pub fn new() -> Self {
-        let shared = Arc::new(Shared::default());
+        let shared = Arc::new(BridgeShared::new());
         let adapter = accesskit_unix::Adapter::new(
             Activation(Arc::clone(&shared)),
             Action(Arc::clone(&shared)),
@@ -160,7 +117,7 @@ impl Default for UnixAccessibility {
 impl std::fmt::Debug for UnixAccessibility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnixAccessibility")
-            .field("active", &self.shared.active.load(Ordering::SeqCst))
+            .field("active", &self.shared.is_active())
             .finish_non_exhaustive()
     }
 }
@@ -171,34 +128,34 @@ impl PlatformAccessibility for UnixAccessibility {
         // reader started later asks for an initial tree, and answering it
         // from here shows the real interface immediately instead of an empty
         // window until something next changes. Incremental updates are not
-        // retained — see the field doc for why a fragment must never answer
+        // retained — see `BridgeShared` for why a fragment must never answer
         // an activation.
         //
         // Exactly one clone, and it buys that retention. `update_if_active`
         // takes a factory, so the owned value moves into the adapter only when
         // something is attached; with nobody listening the closure never runs
         // and the value is simply dropped.
-        if update.tree.is_some() {
-            *self.shared.latest.lock() = Some(update.clone());
-        }
+        self.shared.retain_if_self_contained(&update);
         self.adapter.lock().update_if_active(move || update);
     }
 
     fn is_active(&self) -> bool {
-        self.shared.active.load(Ordering::SeqCst)
+        self.shared.is_active()
     }
 
     fn set_activation_listener(&self, listener: AccessibilityActivationListener) {
-        *self.shared.activation_listener.lock() = Some(listener);
+        self.shared.set_activation_listener(listener);
     }
 
     fn set_action_listener(&self, listener: AccessibilityActionListener) {
-        *self.shared.action_listener.lock() = Some(listener);
+        self.shared.set_action_listener(listener);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use accesskit::{Node, NodeId, Role, Tree, TreeId};
 
     use super::*;
@@ -237,8 +194,10 @@ mod tests {
 
         accessibility.publish(tree_update("Submit"));
 
-        let retained = accessibility.shared.latest.lock().clone();
-        let retained = retained.expect("the tree is kept for a late activation");
+        let retained = accessibility
+            .shared
+            .retained()
+            .expect("the tree is kept for a late activation");
         let (_, node) = retained.nodes.first().expect("one node");
         assert_eq!(node.label(), Some("Submit"));
     }
@@ -256,8 +215,10 @@ mod tests {
         fragment.tree = None;
         accessibility.publish(fragment);
 
-        let retained = accessibility.shared.latest.lock().clone();
-        let retained = retained.expect("the earlier full update stays retained");
+        let retained = accessibility
+            .shared
+            .retained()
+            .expect("the earlier full update stays retained");
         let (_, node) = retained.nodes.first().expect("one node");
         assert_eq!(
             node.label(),

--- a/crates/flui-platform/src/platforms/macos/accessibility.rs
+++ b/crates/flui-platform/src/platforms/macos/accessibility.rs
@@ -1,0 +1,176 @@
+//! NSAccessibility for macOS, via `accesskit_macos`.
+//!
+//! Implements [`PlatformAccessibility`] by wrapping
+//! [`accesskit_macos::SubclassingAdapter`], which dynamically subclasses the
+//! window's content `NSView` to implement the `NSAccessibility` protocol
+//! VoiceOver queries. Subclassing is chosen for the same reason as on
+//! Windows: it needs no edits to the backend's own view class, keeping the
+//! integration additive to a backend this repository can only type-check.
+//!
+//! # The activation model differs from AT-SPI
+//!
+//! Like UIA, NSAccessibility has no attach/detach session: the activation
+//! handler fires the first time VoiceOver (or any client) asks for the
+//! tree, and nothing ever fires a deactivation. Once asked, semantics
+//! assembly stays enabled for the window's lifetime — the platform's shape,
+//! not an oversight.
+//!
+//! # Known gap: view focus state
+//!
+//! [`MacosAccessibility::update_view_focus_state`] exists and forwards to
+//! the adapter, but no backend seam calls it yet — the AppKit backend has
+//! no per-window key-state delegate wired through to this capability.
+//! VoiceOver still queries the tree; what suffers until it is wired is
+//! focus-follows announcement fidelity when the window gains or loses key
+//! status.
+//!
+//! # Honesty note: type-checked, never executed
+//!
+//! Like the whole AppKit backend, this module is covered only by the
+//! `cross-typecheck` gate (clippy, no link, no tests). The retention and
+//! dispatch rules it relies on are executed on Linux via
+//! [`BridgeShared`]'s own tests; the adapter shell around them has not run
+//! on a real macOS machine yet.
+
+use std::sync::Arc;
+
+use accesskit::{ActionHandler, ActionRequest, ActivationHandler, TreeUpdate};
+use accesskit_macos::SubclassingAdapter;
+use parking_lot::Mutex;
+
+use crate::shared::accessibility_bridge::BridgeShared;
+use crate::traits::{
+    AccessibilityActionListener, AccessibilityActivationListener, PlatformAccessibility,
+};
+
+struct Activation(Arc<BridgeShared>);
+
+impl ActivationHandler for Activation {
+    fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+        // Order matters: mark active and tell the composition root *before*
+        // reading the retained tree — see the Windows twin for the cold-start
+        // rationale.
+        self.0.notify_activation(true);
+        self.0.retained()
+    }
+}
+
+struct Action(Arc<BridgeShared>);
+
+impl ActionHandler for Action {
+    fn do_action(&mut self, request: ActionRequest) {
+        self.0.notify_action(request);
+    }
+}
+
+/// NSAccessibility for one window.
+pub struct MacosAccessibility {
+    shared: Arc<BridgeShared>,
+    /// The adapter needs `&mut` to publish, and the capability is shared
+    /// behind an `Arc`, so the mutability lives here rather than in the
+    /// trait.
+    adapter: Mutex<SubclassingAdapter>,
+}
+
+// SAFETY, per field: `shared` is `Arc<BridgeShared>`, `Send + Sync` by
+// construction. The `Mutex<SubclassingAdapter>` serializes every touch of
+// the adapter, whose auto-trait opt-outs come from (a) the type-erased
+// handler boxes, filled here only with `Activation`/`Action` over
+// `Arc<BridgeShared>` — concrete `Send + Sync` types — and (b) the raw
+// NSView-adjacent subclass state, which is main-thread-AFFINE AppKit state
+// the same way `MacOSWindow`'s own `unsafe impl`s document: the
+// accessibility-protocol overrides run where AppKit delivers them (the
+// main thread), and `update_if_active` hands the update to AccessKit's
+// adapter, which serializes internally.
+//
+// NOT claimed — the same gap `MacOSWindow` documents: dropping this value
+// unhooks the dynamic subclass, which AppKit wants done on the main
+// thread. The window owns this capability, so drop follows window
+// teardown; a teardown path that drops the last `Arc` elsewhere inherits
+// the identical, already-documented affinity obligation.
+unsafe impl Send for MacosAccessibility {}
+// SAFETY: see `Send` above — all interior mutability is `Mutex`-guarded.
+unsafe impl Sync for MacosAccessibility {}
+
+impl MacosAccessibility {
+    /// Subclass `view` (a live `NSView*`) and answer VoiceOver for it.
+    ///
+    /// # Safety
+    ///
+    /// `view` must be a valid, live `NSView` pointer, and it must outlive
+    /// the returned value — the adapter unhooks its dynamic subclass on
+    /// drop, which dereferences the view. The window constructor satisfies
+    /// both: it passes the content view it just installed, and the window
+    /// owns this capability so drop order follows window teardown. Must be
+    /// called on the main thread (AppKit affinity), which the window
+    /// constructor also is.
+    #[must_use]
+    pub unsafe fn new(view: *mut std::ffi::c_void) -> Self {
+        let shared = Arc::new(BridgeShared::new());
+        // SAFETY: forwarded contract — see this function's own `# Safety`.
+        let adapter = unsafe {
+            SubclassingAdapter::new(
+                view,
+                Activation(Arc::clone(&shared)),
+                Action(Arc::clone(&shared)),
+            )
+        };
+
+        Self {
+            shared,
+            adapter: Mutex::new(adapter),
+        }
+    }
+
+    /// Tell VoiceOver whether the subclassed view is in the key window.
+    ///
+    /// Not yet called from any backend seam — see the module's known-gap
+    /// note. Kept public so the wiring lands as a one-line delegate call.
+    pub fn update_view_focus_state(&self, is_focused: bool) {
+        let events = {
+            let mut adapter = self.adapter.lock();
+            adapter.update_view_focus_state(is_focused)
+        };
+        if let Some(events) = events {
+            events.raise();
+        }
+    }
+}
+
+impl std::fmt::Debug for MacosAccessibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MacosAccessibility")
+            .field("active", &self.shared.is_active())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PlatformAccessibility for MacosAccessibility {
+    fn publish(&self, update: TreeUpdate) {
+        // Same retention contract as the AT-SPI bridge: only self-contained
+        // updates may answer a late activation — see `BridgeShared`.
+        self.shared.retain_if_self_contained(&update);
+        // AccessKit's contract: `QueuedEvents` are raised OUTSIDE the
+        // adapter lock, because NSAccessibility notification handlers can
+        // re-enter.
+        let events = {
+            let mut adapter = self.adapter.lock();
+            adapter.update_if_active(move || update)
+        };
+        if let Some(events) = events {
+            events.raise();
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        self.shared.is_active()
+    }
+
+    fn set_activation_listener(&self, listener: AccessibilityActivationListener) {
+        self.shared.set_activation_listener(listener);
+    }
+
+    fn set_action_listener(&self, listener: AccessibilityActionListener) {
+        self.shared.set_action_listener(listener);
+    }
+}

--- a/crates/flui-platform/src/platforms/macos/accessibility.rs
+++ b/crates/flui-platform/src/platforms/macos/accessibility.rs
@@ -15,14 +15,13 @@
 //! assembly stays enabled for the window's lifetime — the platform's shape,
 //! not an oversight.
 //!
-//! # Known gap: view focus state
+//! # View focus state
 //!
-//! [`MacosAccessibility::update_view_focus_state`] exists and forwards to
-//! the adapter, but no backend seam calls it yet — the AppKit backend has
-//! no per-window key-state delegate wired through to this capability.
-//! VoiceOver still queries the tree; what suffers until it is wired is
-//! focus-follows announcement fidelity when the window gains or loses key
-//! status.
+//! [`MacosAccessibility::update_view_focus_state`] is wired from the
+//! window's key-status delegate path (`handle_focus_gained` /
+//! `handle_focus_lost` in `window.rs`), so VoiceOver's notion of the
+//! focused view tracks the key window — load-bearing in any multi-window
+//! application.
 //!
 //! # Honesty note: type-checked, never executed
 //!
@@ -68,29 +67,63 @@ pub struct MacosAccessibility {
     shared: Arc<BridgeShared>,
     /// The adapter needs `&mut` to publish, and the capability is shared
     /// behind an `Arc`, so the mutability lives here rather than in the
-    /// trait.
-    adapter: Mutex<SubclassingAdapter>,
+    /// trait. `Option` because the adapter's lifetime is deliberately
+    /// shorter than the capability's: [`Self::shutdown`] (window teardown,
+    /// **before** the content view is released) or a same-thread [`Drop`]
+    /// takes it out, and every later call through a still-live `Arc` clone
+    /// is a guarded no-op instead of a dereference of a dead view.
+    adapter: Mutex<Option<SubclassingAdapter>>,
+    /// The thread that owns the subclass (the main thread, where the window
+    /// constructor runs) — the only thread allowed to run the adapter's
+    /// destructor, since unhooking dereferences the view.
+    owner_thread: std::thread::ThreadId,
 }
 
 // SAFETY, per field: `shared` is `Arc<BridgeShared>`, `Send + Sync` by
-// construction. The `Mutex<SubclassingAdapter>` serializes every touch of
-// the adapter, whose auto-trait opt-outs come from (a) the type-erased
-// handler boxes, filled here only with `Activation`/`Action` over
+// construction; `owner_thread` is a plain `ThreadId`. The
+// `Mutex<Option<SubclassingAdapter>>` serializes every touch of the
+// adapter, whose auto-trait opt-outs come from (a) the type-erased handler
+// boxes, filled here only with `Activation`/`Action` over
 // `Arc<BridgeShared>` — concrete `Send + Sync` types — and (b) the raw
-// NSView-adjacent subclass state, which is main-thread-AFFINE AppKit state
-// the same way `MacOSWindow`'s own `unsafe impl`s document: the
-// accessibility-protocol overrides run where AppKit delivers them (the
-// main thread), and `update_if_active` hands the update to AccessKit's
-// adapter, which serializes internally.
+// NSView-adjacent subclass state, which is main-thread-AFFINE AppKit
+// state: the accessibility-protocol overrides run where AppKit delivers
+// them (the main thread), and `update_if_active` hands the update to
+// AccessKit's adapter, which serializes internally.
 //
-// NOT claimed — the same gap `MacOSWindow` documents: dropping this value
-// unhooks the dynamic subclass, which AppKit wants done on the main
-// thread. The window owns this capability, so drop follows window
-// teardown; a teardown path that drops the last `Arc` elsewhere inherits
-// the identical, already-documented affinity obligation.
+// The remaining affinity + lifetime obligations — the destructor unhooks
+// the dynamic subclass, which dereferences the view and must happen on the
+// main thread while the view is alive — are ENFORCED, not merely
+// documented: the window's own teardown calls [`MacosAccessibility::shutdown`]
+// before releasing the view, and `Self::drop` runs the destructor only on
+// `owner_thread`, otherwise leaking (with a warning) rather than touching
+// AppKit state cross-thread. Safe code can therefore move or drop the last
+// `Arc` anywhere without reaching an unsound path.
 unsafe impl Send for MacosAccessibility {}
 // SAFETY: see `Send` above — all interior mutability is `Mutex`-guarded.
 unsafe impl Sync for MacosAccessibility {}
+
+impl Drop for MacosAccessibility {
+    fn drop(&mut self) {
+        let Some(adapter) = self.adapter.get_mut().take() else {
+            return;
+        };
+        if std::thread::current().id() == self.owner_thread {
+            drop(adapter);
+        } else {
+            // Unhooking the dynamic subclass dereferences the view and
+            // must happen on the main thread; leaking the hook is safe
+            // (the view is on its way down with its window) and sound, so
+            // it is the only acceptable fallback. Reaching here at all
+            // means the window's own teardown (which calls `shutdown`
+            // first) was bypassed.
+            tracing::warn!(
+                "leaking an NSAccessibility subclass adapter dropped off the \
+                 main thread (unhooking would touch AppKit state cross-thread)"
+            );
+            std::mem::forget(adapter);
+        }
+    }
+}
 
 impl MacosAccessibility {
     /// Subclass `view` (a live `NSView*`) and answer VoiceOver for it.
@@ -118,18 +151,32 @@ impl MacosAccessibility {
 
         Self {
             shared,
-            adapter: Mutex::new(adapter),
+            adapter: Mutex::new(Some(adapter)),
+            owner_thread: std::thread::current().id(),
         }
+    }
+
+    /// Unhook and drop the adapter now, on the caller's (main) thread —
+    /// the deterministic half of teardown, called by the window's own
+    /// `Drop` **before** it releases the window (and with it the content
+    /// view the subclass dereferences on unhook). Every later call through
+    /// a still-live capability `Arc` is a no-op. Idempotent.
+    pub(crate) fn shutdown(&self) {
+        let adapter = self.adapter.lock().take();
+        drop(adapter);
     }
 
     /// Tell VoiceOver whether the subclassed view is in the key window.
     ///
-    /// Not yet called from any backend seam — see the module's known-gap
-    /// note. Kept public so the wiring lands as a one-line delegate call.
+    /// Called from the window's `windowDidBecomeKey:` /
+    /// `windowDidResignKey:` delegate path (`handle_focus_gained` /
+    /// `handle_focus_lost`), on the main thread.
     pub fn update_view_focus_state(&self, is_focused: bool) {
         let events = {
             let mut adapter = self.adapter.lock();
-            adapter.update_view_focus_state(is_focused)
+            adapter
+                .as_mut()
+                .and_then(|adapter| adapter.update_view_focus_state(is_focused))
         };
         if let Some(events) = events {
             events.raise();
@@ -152,10 +199,13 @@ impl PlatformAccessibility for MacosAccessibility {
         self.shared.retain_if_self_contained(&update);
         // AccessKit's contract: `QueuedEvents` are raised OUTSIDE the
         // adapter lock, because NSAccessibility notification handlers can
-        // re-enter.
+        // re-enter. A shut-down capability (adapter taken by teardown)
+        // drops the update instead — see the `adapter` field doc.
         let events = {
             let mut adapter = self.adapter.lock();
-            adapter.update_if_active(move || update)
+            adapter
+                .as_mut()
+                .and_then(|adapter| adapter.update_if_active(move || update))
         };
         if let Some(events) = events {
             events.raise();

--- a/crates/flui-platform/src/platforms/macos/mod.rs
+++ b/crates/flui-platform/src/platforms/macos/mod.rs
@@ -43,6 +43,8 @@
 // the module boundary, rather than for the whole crate (see `lib.rs`).
 #![allow(unsafe_code)]
 
+#[cfg(feature = "a11y")]
+mod accessibility;
 mod clipboard;
 mod display;
 mod events;
@@ -54,6 +56,8 @@ mod window_ext;
 mod window_manager;
 mod window_tiling;
 
+#[cfg(feature = "a11y")]
+pub use accessibility::MacosAccessibility;
 pub use clipboard::MacOSClipboard;
 pub use display::MacOSDisplay;
 pub use events::convert_ns_event;

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -589,6 +589,17 @@ impl Drop for MacOSWindow {
         if Arc::strong_count(&self.state) == 1 {
             tracing::debug!("Closing NSWindow {:p}", self.ns_window);
 
+            // Unhook the NSAccessibility subclass BEFORE releasing the
+            // window: unhooking dereferences the content view, which dies
+            // with the window's last retain below. This runs on the main
+            // thread (AppKit teardown); any capability `Arc` still held
+            // elsewhere degrades to a no-op afterwards, and the wrapper's
+            // own later drop finds nothing left to unhook.
+            #[cfg(feature = "a11y")]
+            if let Some(bridge) = self.accessibility.get() {
+                bridge.shutdown();
+            }
+
             // Remove from windows map
             let window_id = self.ns_window as u64;
             self.windows_map.lock().remove(&window_id);
@@ -1355,12 +1366,22 @@ impl MacOSWindow {
     /// Handle focus gained event
     fn handle_focus_gained(&self) {
         self.callbacks.dispatch_active_status_change(true);
+        // Key-window status is what VoiceOver treats as view focus; the
+        // delegate delivers this on the main thread.
+        #[cfg(feature = "a11y")]
+        if let Some(bridge) = self.accessibility.get() {
+            bridge.update_view_focus_state(true);
+        }
         tracing::debug!("Window gained focus");
     }
 
     /// Handle focus lost event
     fn handle_focus_lost(&self) {
         self.callbacks.dispatch_active_status_change(false);
+        #[cfg(feature = "a11y")]
+        if let Some(bridge) = self.accessibility.get() {
+            bridge.update_view_focus_state(false);
+        }
         tracing::debug!("Window lost focus");
     }
 

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -48,6 +48,14 @@ pub struct MacOSWindow {
 
     /// Window configuration
     config: WindowConfiguration,
+
+    /// This window's NSAccessibility bridge, subclassed onto the content
+    /// view. A `OnceLock` slot rather than a plain field because the window
+    /// value is constructed *before* its content view exists (the view
+    /// holds a `Weak` back-reference to the window's callbacks); the
+    /// constructor fills it immediately after installing the view.
+    #[cfg(feature = "a11y")]
+    accessibility: std::sync::OnceLock<Arc<super::accessibility::MacosAccessibility>>,
 }
 
 // SAFETY: the NSWindow pointer is only messaged from the main thread (AppKit
@@ -172,12 +180,28 @@ impl MacOSWindow {
                 windows_map: Arc::clone(&windows_map),
                 callbacks,
                 config,
+                #[cfg(feature = "a11y")]
+                accessibility: std::sync::OnceLock::new(),
             });
 
             // Create content view for input events
             let content_view =
                 view::create_content_view(frame, scale, Arc::downgrade(&window.callbacks));
             let _: () = msg_send![ns_window, setContentView: content_view];
+
+            // Subclass the freshly installed content view for VoiceOver.
+            // SAFETY: `content_view` is the live NSView this window just
+            // created and installed; the window owns the capability, so the
+            // adapter cannot outlive the view; and window construction runs
+            // on the main thread (AppKit affinity, asserted by this whole
+            // `unsafe` block's contract).
+            #[cfg(feature = "a11y")]
+            {
+                let bridge = super::accessibility::MacosAccessibility::new(
+                    content_view.cast::<std::ffi::c_void>(),
+                );
+                let _ = window.accessibility.set(Arc::new(bridge));
+            }
 
             // Enable mouse tracking for mouse moved events
             view::enable_mouse_tracking(content_view);
@@ -219,6 +243,17 @@ impl MacOSWindow {
 impl PlatformWindow for MacOSWindow {
     fn id(&self) -> WindowId {
         WindowId(self.ns_window as u64)
+    }
+
+    /// The window's own NSAccessibility bridge — the capability the
+    /// composition root's accessibility wire discovers. Without this
+    /// override the trait default (`None`) leaves every real macOS window
+    /// silently invisible to VoiceOver.
+    #[cfg(feature = "a11y")]
+    fn accessibility(&self) -> Option<Arc<dyn crate::traits::PlatformAccessibility>> {
+        self.accessibility
+            .get()
+            .map(|bridge| Arc::clone(bridge) as _)
     }
 
     fn physical_size(&self) -> Size<DevicePixels> {
@@ -536,6 +571,11 @@ impl Clone for MacOSWindow {
             windows_map: Arc::clone(&self.windows_map),
             callbacks: Arc::clone(&self.callbacks),
             config: self.config.clone(),
+            // The clone shares the same window, so it shares the same
+            // NSAccessibility bridge — one subclass per content view,
+            // never two (`OnceLock<Arc<_>>` clones the shared handle).
+            #[cfg(feature = "a11y")]
+            accessibility: self.accessibility.clone(),
         }
     }
 }

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -200,7 +200,10 @@ impl MacOSWindow {
                 let bridge = super::accessibility::MacosAccessibility::new(
                     content_view.cast::<std::ffi::c_void>(),
                 );
-                let _ = window.accessibility.set(Arc::new(bridge));
+                window
+                    .accessibility
+                    .set(Arc::new(bridge))
+                    .expect("BUG: the accessibility slot was created empty in this constructor and nothing else can fill it");
             }
 
             // Enable mouse tracking for mouse moved events

--- a/crates/flui-platform/src/platforms/windows/accessibility.rs
+++ b/crates/flui-platform/src/platforms/windows/accessibility.rs
@@ -64,30 +64,59 @@ pub struct WindowsAccessibility {
     shared: Arc<BridgeShared>,
     /// The adapter needs `&mut` to publish, and the capability is shared
     /// behind an `Arc`, so the mutability lives here rather than in the
-    /// trait.
-    adapter: Mutex<SubclassingAdapter>,
+    /// trait. `Option` because the adapter's lifetime is deliberately
+    /// shorter than the capability's: [`Self::shutdown`] (window teardown)
+    /// or a same-thread [`Drop`] takes it out, and every later call through
+    /// a still-live `Arc` clone is a guarded no-op instead of a touch of
+    /// torn-down subclass state.
+    adapter: Mutex<Option<SubclassingAdapter>>,
+    /// The thread that owns the subclass hook (the window's creating
+    /// thread) — the only thread allowed to run the adapter's destructor.
+    owner_thread: std::thread::ThreadId,
 }
 
 // SAFETY, per field: `shared` is `Arc<BridgeShared>`, itself `Send + Sync`
-// by construction (atomics + `Mutex`es over `Send + Sync` payloads). The
-// `Mutex<SubclassingAdapter>` serializes every touch of the adapter, whose
-// auto-trait opt-outs come from (a) the type-erased handler boxes, which
-// this module only ever fills with `Activation`/`Action` over
-// `Arc<BridgeShared>` — concrete `Send + Sync` types — and (b) the raw
-// HWND-adjacent subclass state, which is thread-AFFINE Win32 state the
-// same way `WindowsWindow`'s own `unsafe impl`s document: the subclass
-// hook itself only runs on the window's owning thread (inside its message
-// loop), and `update_if_active` delegates to the inner UIA adapter, which
-// AccessKit documents as callable from any thread.
+// by construction (atomics + `Mutex`es over `Send + Sync` payloads);
+// `owner_thread` is a plain `ThreadId`. The `Mutex<Option<SubclassingAdapter>>`
+// serializes every touch of the adapter, whose auto-trait opt-outs come
+// from (a) the type-erased handler boxes, which this module only ever
+// fills with `Activation`/`Action` over `Arc<BridgeShared>` — concrete
+// `Send + Sync` types — and (b) the raw HWND-adjacent subclass state,
+// which is thread-AFFINE Win32 state: the hook itself only runs on the
+// window's owning thread (inside its message loop), and `update_if_active`
+// delegates to the inner UIA adapter, which AccessKit documents as
+// callable from any thread.
 //
-// NOT claimed — the same gap `WindowsWindow` documents: dropping this
-// value unhooks the subclass, which Win32 wants done on the owning
-// thread. The window owns this capability, so drop follows window
-// teardown; a teardown path that drops the last `Arc` on a foreign thread
-// inherits the identical, already-documented affinity obligation.
+// The remaining affinity obligation — the destructor unhooks the subclass,
+// which Win32 requires on the owning thread — is ENFORCED, not merely
+// documented: `Self::drop` runs the adapter's destructor only when the
+// current thread is `owner_thread`, and otherwise leaks it (with a warning)
+// rather than unhooking cross-thread. Safe code can therefore move or drop
+// the last `Arc` anywhere without reaching an unsound path.
 unsafe impl Send for WindowsAccessibility {}
 // SAFETY: see `Send` above — all interior mutability is `Mutex`-guarded.
 unsafe impl Sync for WindowsAccessibility {}
+
+impl Drop for WindowsAccessibility {
+    fn drop(&mut self) {
+        let Some(adapter) = self.adapter.get_mut().take() else {
+            return;
+        };
+        if std::thread::current().id() == self.owner_thread {
+            drop(adapter);
+        } else {
+            // Unhooking a Win32 subclass from a foreign thread races the
+            // owner thread's message dispatch; leaking the hook is safe
+            // (the window is on its way down with it) and sound, so it is
+            // the only acceptable fallback.
+            tracing::warn!(
+                "leaking a UIA subclass adapter dropped off its owner thread \
+                 (unhooking cross-thread would race message dispatch)"
+            );
+            std::mem::forget(adapter);
+        }
+    }
+}
 
 impl WindowsAccessibility {
     /// Subclass `hwnd` and answer UIA clients for it.
@@ -107,8 +136,19 @@ impl WindowsAccessibility {
 
         Self {
             shared,
-            adapter: Mutex::new(adapter),
+            adapter: Mutex::new(Some(adapter)),
+            owner_thread: std::thread::current().id(),
         }
+    }
+
+    /// Unhook and drop the adapter now, on the caller's (owner) thread —
+    /// the deterministic half of teardown, called by the window's own
+    /// `Drop` **before** it destroys the HWND, so the subclass is removed
+    /// while the window still exists. Every later call through a still-live
+    /// capability `Arc` is a no-op. Idempotent.
+    pub(crate) fn shutdown(&self) {
+        let adapter = self.adapter.lock().take();
+        drop(adapter);
     }
 }
 
@@ -127,10 +167,14 @@ impl PlatformAccessibility for WindowsAccessibility {
         self.shared.retain_if_self_contained(&update);
         // AccessKit's contract: `QueuedEvents` must be raised OUTSIDE any
         // lock the tree state lives behind, because UIA event handlers can
-        // re-enter. Hence the explicit guard drop before `raise`.
+        // re-enter. Hence the explicit guard drop before `raise`. A
+        // shut-down capability (adapter taken by teardown) drops the update
+        // instead — see the `adapter` field doc.
         let events = {
             let mut adapter = self.adapter.lock();
-            adapter.update_if_active(move || update)
+            adapter
+                .as_mut()
+                .and_then(|adapter| adapter.update_if_active(move || update))
         };
         if let Some(events) = events {
             events.raise();

--- a/crates/flui-platform/src/platforms/windows/accessibility.rs
+++ b/crates/flui-platform/src/platforms/windows/accessibility.rs
@@ -1,0 +1,151 @@
+//! UIA accessibility for Windows, via `accesskit_windows`.
+//!
+//! Implements [`PlatformAccessibility`] by wrapping
+//! [`accesskit_windows::SubclassingAdapter`], which subclasses the window
+//! procedure to answer `WM_GETOBJECT` — the message UI Automation clients
+//! (Narrator, NVDA, JAWS) send to discover a window's accessibility tree.
+//! The subclassing variant is chosen deliberately: it needs no edits to the
+//! backend's own `window_proc`, so the integration stays additive to a
+//! backend this repository can only type-check (see the honesty note below).
+//!
+//! # The activation model differs from AT-SPI
+//!
+//! UIA has no attach/detach session: the adapter's activation handler fires
+//! the first time any client asks for the tree, and **nothing ever fires a
+//! deactivation** — there is no "the screen reader left" signal to stop
+//! semantics assembly on. Once a client has asked, assembly stays enabled
+//! for the window's lifetime. That is the platform's shape, not an
+//! oversight; AT-SPI's explicit deactivation is the outlier.
+//!
+//! # Honesty note: type-checked, never executed
+//!
+//! Like the whole Win32 backend, this module is covered only by the
+//! `cross-typecheck` gate (clippy, no link, no tests). The retention and
+//! dispatch rules it relies on are executed on Linux via
+//! [`BridgeShared`]'s own tests; the adapter shell around them has not run
+//! on a real Windows machine yet.
+
+use std::sync::Arc;
+
+use accesskit::{ActionHandler, ActionRequest, ActivationHandler, TreeUpdate};
+use accesskit_windows::SubclassingAdapter;
+use parking_lot::Mutex;
+use windows::Win32::Foundation::HWND;
+
+use crate::shared::accessibility_bridge::BridgeShared;
+use crate::traits::{
+    AccessibilityActionListener, AccessibilityActivationListener, PlatformAccessibility,
+};
+
+struct Activation(Arc<BridgeShared>);
+
+impl ActivationHandler for Activation {
+    fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+        // Order matters: mark active and tell the composition root *before*
+        // reading the retained tree. The listener typically enables
+        // semantics, and on a cold start that is what will produce the first
+        // tree at all — reading first would answer `None` even when a
+        // synchronous listener could have supplied one.
+        self.0.notify_activation(true);
+        self.0.retained()
+    }
+}
+
+struct Action(Arc<BridgeShared>);
+
+impl ActionHandler for Action {
+    fn do_action(&mut self, request: ActionRequest) {
+        self.0.notify_action(request);
+    }
+}
+
+/// UIA accessibility for one window.
+pub struct WindowsAccessibility {
+    shared: Arc<BridgeShared>,
+    /// The adapter needs `&mut` to publish, and the capability is shared
+    /// behind an `Arc`, so the mutability lives here rather than in the
+    /// trait.
+    adapter: Mutex<SubclassingAdapter>,
+}
+
+// SAFETY, per field: `shared` is `Arc<BridgeShared>`, itself `Send + Sync`
+// by construction (atomics + `Mutex`es over `Send + Sync` payloads). The
+// `Mutex<SubclassingAdapter>` serializes every touch of the adapter, whose
+// auto-trait opt-outs come from (a) the type-erased handler boxes, which
+// this module only ever fills with `Activation`/`Action` over
+// `Arc<BridgeShared>` — concrete `Send + Sync` types — and (b) the raw
+// HWND-adjacent subclass state, which is thread-AFFINE Win32 state the
+// same way `WindowsWindow`'s own `unsafe impl`s document: the subclass
+// hook itself only runs on the window's owning thread (inside its message
+// loop), and `update_if_active` delegates to the inner UIA adapter, which
+// AccessKit documents as callable from any thread.
+//
+// NOT claimed — the same gap `WindowsWindow` documents: dropping this
+// value unhooks the subclass, which Win32 wants done on the owning
+// thread. The window owns this capability, so drop follows window
+// teardown; a teardown path that drops the last `Arc` on a foreign thread
+// inherits the identical, already-documented affinity obligation.
+unsafe impl Send for WindowsAccessibility {}
+// SAFETY: see `Send` above — all interior mutability is `Mutex`-guarded.
+unsafe impl Sync for WindowsAccessibility {}
+
+impl WindowsAccessibility {
+    /// Subclass `hwnd` and answer UIA clients for it.
+    ///
+    /// Must be called on the thread that owns `hwnd` (Win32 subclassing is
+    /// thread-affine); the window constructor is that thread. Constructing
+    /// with no assistive technology running is inert — the adapter answers
+    /// `WM_GETOBJECT` only when a client actually asks.
+    #[must_use]
+    pub fn new(hwnd: HWND) -> Self {
+        let shared = Arc::new(BridgeShared::new());
+        let adapter = SubclassingAdapter::new(
+            hwnd,
+            Activation(Arc::clone(&shared)),
+            Action(Arc::clone(&shared)),
+        );
+
+        Self {
+            shared,
+            adapter: Mutex::new(adapter),
+        }
+    }
+}
+
+impl std::fmt::Debug for WindowsAccessibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WindowsAccessibility")
+            .field("active", &self.shared.is_active())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PlatformAccessibility for WindowsAccessibility {
+    fn publish(&self, update: TreeUpdate) {
+        // Same retention contract as the AT-SPI bridge: only self-contained
+        // updates may answer a late activation — see `BridgeShared`.
+        self.shared.retain_if_self_contained(&update);
+        // AccessKit's contract: `QueuedEvents` must be raised OUTSIDE any
+        // lock the tree state lives behind, because UIA event handlers can
+        // re-enter. Hence the explicit guard drop before `raise`.
+        let events = {
+            let mut adapter = self.adapter.lock();
+            adapter.update_if_active(move || update)
+        };
+        if let Some(events) = events {
+            events.raise();
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        self.shared.is_active()
+    }
+
+    fn set_activation_listener(&self, listener: AccessibilityActivationListener) {
+        self.shared.set_activation_listener(listener);
+    }
+
+    fn set_action_listener(&self, listener: AccessibilityActionListener) {
+        self.shared.set_action_listener(listener);
+    }
+}

--- a/crates/flui-platform/src/platforms/windows/mod.rs
+++ b/crates/flui-platform/src/platforms/windows/mod.rs
@@ -11,6 +11,8 @@
 // that makes it sound.
 #![allow(unsafe_code)]
 
+#[cfg(feature = "a11y")]
+mod accessibility;
 mod clipboard;
 mod display;
 mod events;
@@ -19,6 +21,8 @@ mod util;
 mod window;
 mod window_ext;
 
+#[cfg(feature = "a11y")]
+pub use accessibility::WindowsAccessibility;
 pub use clipboard::WindowsClipboard;
 pub use display::{WindowsDisplay, enumerate_displays};
 pub use platform::WindowsPlatform;

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -1849,6 +1849,13 @@ impl Drop for WindowsWindow {
         if Arc::strong_count(&self.state) == 1 {
             tracing::debug!("Destroying window HWND {:?}", self.hwnd);
 
+            // Unhook the UIA subclass BEFORE destroying the window — Win32
+            // wants subclasses removed while the window still exists, and
+            // this wrapper's drop is the owner-thread teardown path. Any
+            // capability `Arc` still held elsewhere degrades to a no-op.
+            #[cfg(feature = "a11y")]
+            self.accessibility.shutdown();
+
             // SAFETY: `DestroyWindow` takes `self.hwnd` by value; the
             // `is_invalid()` guard skips the call for a handle that was
             // never successfully created, and `WM_DESTROY` (handled in

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -60,6 +60,13 @@ pub struct WindowsWindow {
 
     /// Reference to platform's window map (for cleanup)
     windows_map: Arc<Mutex<HashMap<isize, Arc<WindowsWindow>>>>,
+
+    /// This window's UIA bridge, subclassed onto `hwnd` at construction so
+    /// a UI Automation client that asks at any later point is answered.
+    /// Inert until one does — see
+    /// [`WindowsAccessibility::new`](super::accessibility::WindowsAccessibility::new).
+    #[cfg(feature = "a11y")]
+    accessibility: Arc<super::accessibility::WindowsAccessibility>,
 }
 
 // SAFETY, per field: `state` and `callbacks` are `Arc<Mutex<..>>`/`Arc<..>`
@@ -216,6 +223,10 @@ impl WindowsWindow {
                 state,
                 callbacks: Arc::clone(&callbacks),
                 windows_map,
+                // On the creating (owning) thread, as Win32 subclassing
+                // requires; `hwnd` was validated just above.
+                #[cfg(feature = "a11y")]
+                accessibility: Arc::new(super::accessibility::WindowsAccessibility::new(hwnd)),
             });
 
             // Create and store WindowContext for event dispatch
@@ -652,6 +663,15 @@ impl WindowsWindow {
 impl PlatformWindow for WindowsWindow {
     fn id(&self) -> WindowId {
         WindowId(self.hwnd.0 as u64)
+    }
+
+    /// The window's own UIA bridge — the capability the composition root's
+    /// accessibility wire discovers. Without this override the trait
+    /// default (`None`) leaves every real Windows window silently invisible
+    /// to UI Automation clients.
+    #[cfg(feature = "a11y")]
+    fn accessibility(&self) -> Option<Arc<dyn crate::traits::PlatformAccessibility>> {
+        Some(Arc::clone(&self.accessibility) as _)
     }
 
     fn physical_size(&self) -> Size<DevicePixels> {
@@ -1128,6 +1148,10 @@ impl Clone for WindowsWindow {
             state: Arc::clone(&self.state),
             callbacks: Arc::clone(&self.callbacks),
             windows_map: Arc::clone(&self.windows_map),
+            // The clone shares the same window, so it shares the same UIA
+            // bridge — one subclass hook per HWND, never two.
+            #[cfg(feature = "a11y")]
+            accessibility: Arc::clone(&self.accessibility),
         }
     }
 }

--- a/crates/flui-platform/src/shared/accessibility_bridge.rs
+++ b/crates/flui-platform/src/shared/accessibility_bridge.rs
@@ -1,0 +1,217 @@
+//! State shared between a platform accessibility adapter and its handlers.
+//!
+//! Every OS adapter (AT-SPI on Linux, UIA on Windows, NSAccessibility on
+//! macOS) has the same shape: the platform library owns handler objects that
+//! live on its own thread(s), while the [`PlatformAccessibility`] capability
+//! is called from the composition root. What both sides share — the
+//! active flag, the retained self-contained update, and the two listeners —
+//! is this struct, extracted so the retention and dispatch rules are written
+//! (and unit-tested, on Linux, where tests actually execute) exactly once
+//! instead of re-derived per OS.
+//!
+//! [`PlatformAccessibility`]: crate::traits::PlatformAccessibility
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use accesskit::{ActionRequest, TreeUpdate};
+use parking_lot::Mutex;
+
+use crate::traits::{AccessibilityActionListener, AccessibilityActivationListener};
+
+/// The adapter-side shared state: activation, retention, listeners.
+#[derive(Default)]
+pub(crate) struct BridgeShared {
+    /// Whether assistive technology is currently attached.
+    active: AtomicBool,
+    /// The most recent **self-contained** update (one carrying
+    /// [`TreeUpdate::tree`] metadata — the producer's promise that it stands
+    /// alone), kept so a late activation can be answered immediately rather
+    /// than showing an empty application until the next frame happens to
+    /// dirty something.
+    ///
+    /// Incremental updates (`tree: None`) are deliberately not retained:
+    /// applied in isolation they describe a handful of changed nodes, and
+    /// answering a fresh screen reader with one would present a fragment as
+    /// the whole interface. The composition root re-publishes a full tree on
+    /// every activation, so this retained answer is at worst one full
+    /// publish behind and is corrected within a frame.
+    latest: Mutex<Option<TreeUpdate>>,
+    activation_listener: Mutex<Option<AccessibilityActivationListener>>,
+    action_listener: Mutex<Option<AccessibilityActionListener>>,
+}
+
+impl BridgeShared {
+    /// Fresh state: inactive, nothing retained, no listeners.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the attachment state and tell the composition root.
+    ///
+    /// The flag is stored **before** the listener runs: the listener's
+    /// natural response to "attached" is to enable semantics and publish,
+    /// and a publish that consulted a stale `false` would be dropped by the
+    /// adapter it was meant to initialize.
+    ///
+    /// The listener is cloned out of its lock, then called — a listener
+    /// re-entering the adapter (publishing is the expected re-entry) would
+    /// deadlock against a held guard. Same discipline as the semantics
+    /// owner's callback dispatch.
+    pub(crate) fn notify_activation(&self, active: bool) {
+        self.active.store(active, Ordering::SeqCst);
+        let listener = self.activation_listener.lock().clone();
+        if let Some(listener) = listener {
+            listener(active);
+        }
+    }
+
+    /// Forward an inbound action request (clone-and-release, as above).
+    pub(crate) fn notify_action(&self, request: ActionRequest) {
+        let listener = self.action_listener.lock().clone();
+        if let Some(listener) = listener {
+            listener(request);
+        }
+    }
+
+    /// Retain `update` for late activations **iff it is self-contained**
+    /// (carries tree metadata). A fragment must never become the answer to
+    /// a fresh screen reader — see the `latest` field doc.
+    pub(crate) fn retain_if_self_contained(&self, update: &TreeUpdate) {
+        if update.tree.is_some() {
+            *self.latest.lock() = Some(update.clone());
+        }
+    }
+
+    /// The retained self-contained update, if any — the immediate answer to
+    /// a late activation.
+    pub(crate) fn retained(&self) -> Option<TreeUpdate> {
+        self.latest.lock().clone()
+    }
+
+    /// Whether assistive technology is currently attached.
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    /// Register the attach/detach listener, replacing any previous one.
+    pub(crate) fn set_activation_listener(&self, listener: AccessibilityActivationListener) {
+        *self.activation_listener.lock() = Some(listener);
+    }
+
+    /// Register the inbound-action listener, replacing any previous one.
+    pub(crate) fn set_action_listener(&self, listener: AccessibilityActionListener) {
+        *self.action_listener.lock() = Some(listener);
+    }
+}
+
+impl std::fmt::Debug for BridgeShared {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BridgeShared")
+            .field("active", &self.is_active())
+            .field("has_retained", &self.latest.lock().is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use accesskit::{Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+
+    use super::*;
+
+    fn full_update(label: &str) -> TreeUpdate {
+        let root = NodeId(1);
+        let mut node = Node::new(Role::Button);
+        node.set_label(label.to_string());
+        TreeUpdate {
+            nodes: vec![(root, node)],
+            tree: Some(Tree::new(root)),
+            tree_id: TreeId::ROOT,
+            focus: root,
+        }
+    }
+
+    /// The retention rule, in one place for every OS adapter: a
+    /// self-contained update is retained; a fragment never overwrites it.
+    #[test]
+    fn only_self_contained_updates_are_retained() {
+        let shared = BridgeShared::new();
+        assert!(shared.retained().is_none(), "nothing retained initially");
+
+        shared.retain_if_self_contained(&full_update("Submit"));
+        let mut fragment = full_update("Changed");
+        fragment.tree = None;
+        shared.retain_if_self_contained(&fragment);
+
+        let retained = shared.retained().expect("the full update is retained");
+        let (_, node) = retained.nodes.first().expect("one node");
+        assert_eq!(
+            node.label(),
+            Some("Submit"),
+            "the fragment must not replace the self-contained answer"
+        );
+    }
+
+    /// The flag must be observable from INSIDE the activation listener —
+    /// the listener's natural response is to publish, and a publish that
+    /// reads a stale `false` is dropped by the very adapter it initializes.
+    #[test]
+    fn activation_is_visible_before_the_listener_runs() {
+        let shared = Arc::new(BridgeShared::new());
+        let observed = Arc::new(AtomicBool::new(false));
+
+        let inner = Arc::clone(&shared);
+        let observed_in_listener = Arc::clone(&observed);
+        shared.set_activation_listener(Arc::new(move |_active| {
+            observed_in_listener.store(inner.is_active(), Ordering::SeqCst);
+        }));
+
+        shared.notify_activation(true);
+        assert!(
+            observed.load(Ordering::SeqCst),
+            "the listener must already see active == true"
+        );
+    }
+
+    /// A listener that re-enters the shared state (retaining, re-registering)
+    /// must not deadlock — clone-and-release is the contract every adapter
+    /// inherits from here.
+    #[test]
+    fn a_reentrant_listener_does_not_deadlock() {
+        let shared = Arc::new(BridgeShared::new());
+
+        let inner = Arc::clone(&shared);
+        shared.set_activation_listener(Arc::new(move |active| {
+            if active {
+                inner.retain_if_self_contained(&full_update("Submit"));
+                inner.set_action_listener(Arc::new(|_request| {}));
+            }
+        }));
+
+        shared.notify_activation(true);
+        assert!(shared.retained().is_some(), "the listener completed");
+    }
+
+    /// Actions forward to the registered listener with their payload intact.
+    #[test]
+    fn actions_reach_the_listener() {
+        let shared = BridgeShared::new();
+        let seen: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let sink = Arc::clone(&seen);
+        shared.set_action_listener(Arc::new(move |request: ActionRequest| {
+            sink.lock().push(request.target_node.0);
+        }));
+
+        shared.notify_action(ActionRequest {
+            action: accesskit::Action::Click,
+            target_tree: TreeId::ROOT,
+            target_node: NodeId(7),
+            data: None,
+        });
+
+        assert_eq!(*seen.lock(), vec![7]);
+    }
+}

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -3,6 +3,14 @@
 //! Components shared between platform implementations to reduce code
 //! duplication.
 
+// Adapter-side accessibility state, shared by the AT-SPI / UIA /
+// NSAccessibility bridges. Gated to the targets that have one so the
+// module is never dead code on Android or wasm.
+#[cfg(all(
+    feature = "a11y",
+    any(target_os = "linux", target_os = "windows", target_os = "macos")
+))]
+pub(crate) mod accessibility_bridge;
 pub mod gestures;
 mod handlers;
 pub mod keys;

--- a/justfile
+++ b/justfile
@@ -125,9 +125,13 @@ wasm-link-check:
 [group("build")]
 [doc("Clippy flui-platform's Windows, macOS, and Android backends from this host (mirrors the CI cross-typecheck job)")]
 cross-typecheck:
-    cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings
-    cargo clippy -p flui-platform --locked --all-targets --target aarch64-apple-darwin -- -D warnings
-    cargo clippy -p flui-platform --locked --all-targets --target aarch64-linux-android -- -D warnings
+    # `--features a11y` on every line: the UIA/NSAccessibility bridges are
+    # feature-gated and this job is the ONLY gate that compiles them at all
+    # (the a11y-off configuration is a strict subset — no cfg(not(a11y))
+    # code exists — so checking with the feature supersedes checking without).
+    cargo clippy -p flui-platform --locked --all-targets --features a11y --target x86_64-pc-windows-msvc -- -D warnings
+    cargo clippy -p flui-platform --locked --all-targets --features a11y --target aarch64-apple-darwin -- -D warnings
+    cargo clippy -p flui-platform --locked --all-targets --features a11y --target aarch64-linux-android -- -D warnings
 
 # =============================================================================
 # Testing


### PR DESCRIPTION
## What

The Windows UIA and macOS NSAccessibility halves of #675's OS bridge: `WindowsAccessibility` (via `accesskit_windows::SubclassingAdapter`, answering `WM_GETOBJECT` through Win32 subclassing — zero edits to the backend's own wndproc) and `MacosAccessibility` (via `accesskit_macos::SubclassingAdapter`, a dynamic `NSView` subclass for VoiceOver). Both implement the existing `PlatformAccessibility` capability, are constructed with their window, and surface through `PlatformWindow::accessibility` — so the composition root's activation/action/full-republish wire (built and tested for AT-SPI) works unchanged on all three desktop OSes, consuming the stable-identity + incremental-flush pipeline from #687.

Part of #675.

## How the issue's slices map, honestly

Re-audited against the issue's own text before slicing — much of it landed while the issue sat open:

- **Slice 1 (translation + headless query-by-role)** — already shipped: `tree_to_update` translation with merge/exclude pins, `flui_testing::a11y::A11yTree` (`find`/`find_all`/`find_by_label`/`focus`/`describe`) reached via `HeadlessBinding::a11y_tree`, with its own integration suite and a widget-suite consumer. Nothing left to build there.
- **Slice 2 (OS bridge)** — Linux landed in #686; **this PR is the Windows/macOS remainder.**
- **Slice 3 (agent surface)** — the issue itself marks it out of scope ("named so the seam is not designed in a way that forecloses it"); the seam here doesn't foreclose it: an agent surface consumes the same `TreeUpdate`s the testing surface already exposes.

## Design

- **One shared brain, three thin shells.** The rules every adapter must share — mark-active-*before*-listener ordering (a listener's natural response is to publish, and it must not read a stale `false`), clone-and-release listener dispatch, and retain-only-self-contained-updates for late activations — are extracted from the Linux bridge into `shared::accessibility_bridge::BridgeShared` and unit-tested there, **where tests execute**. The per-OS adapters are shells: handler structs over `Arc<BridgeShared>` plus the platform library's `update_if_active`, with AccessKit's `QueuedEvents` raised outside the adapter lock (re-entrancy contract).
- **Subclassing adapters deliberately**, on both OSes: additive to backends this repository can only type-check, no message-loop or view-class surgery.
- **Platform-shape divergences documented, not hidden:** UIA and NSAccessibility have no detach session — activation fires on the first client query and *nothing ever deactivates*, so semantics assembly stays on once asked (AT-SPI's explicit detach is the outlier). macOS `update_view_focus_state` exists and forwards, but no backend key-window delegate calls it yet (named gap; a one-line call once the delegate seam exists).
- **`Send`/`Sync` via affinity-argued `unsafe impl`s** mirroring `WindowsWindow`/`MacOSWindow`'s own documented pattern, including the same NOT-claimed drop-thread gap those impls document.
- **Dependencies:** `accesskit_windows` 0.34 / `accesskit_macos` 0.26 — the exact `accesskit` 0.24.1 cohort the workspace locks; `accesskit_windows` shares the backend's `windows` 0.62 (no duplicate windows-rs stack). Target-gated optional deps under the one `a11y` feature; `cargo deny` green (advisories/bans/licenses/sources).

## Evidence (with the honest denominator up front)

- **What executes:** `BridgeShared`'s 4 unit pins + the Linux bridge's existing 8 behavior pins, now running through the shared code — flui-platform **239 passed / 8 skipped** (`--all-features`, `FLUI_HEADLESS=1` + `xvfb-run`, the CI mechanism; was 235). **Sabotage-verified** (Edit-toggle: retain fragments too): fails exactly `only_self_contained_updates_are_retained` AND the Linux bridge's `an_incremental_update_is_not_retained_for_activation` — the extraction genuinely carries the load the Linux pins used to test locally.
- **What is type-checked only:** the Windows/macOS adapter shells — like the entire Win32/AppKit backends they live in. `cross-typecheck` (justfile + CI job, both updated) now runs all three targets **with `--features a11y`**, closing the hole where the bridges would otherwise be compiled by no gate at all; clippy `-D warnings` clean on `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, `aarch64-linux-android`. Nothing links or executes them; green means "compiles clean under workspace lints", nothing more.
- **Full gate:** `just ci` exit 0 (workspace nextest 9101 passed / 11 skipped, doc tests, port-check, inventory-check, runtime-conformance-check — no monitored export moved); `taplo fmt --check`, `typos` clean.

## Remainder on #675

- **On-OS validation** of both adapters (Narrator/NVDA on Windows, VoiceOver on macOS) — cannot be run from this environment; the shells are deliberately thin so that validation exercises AccessKit's adapters, not bespoke logic.
- **macOS key-window focus forwarding** — wire `update_view_focus_state` from a window delegate (named gap above).
- **Slice 3, the agent surface** — explicitly out of the issue's own scope; the seam (published `TreeUpdate`s + `A11yTree`) is where it would attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
