### PR TITLE
fix(platform): Win32 wndproc panic boundary + HWND thread-affinity discharge

### DIFF
--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -82,6 +82,7 @@ windows = { version = "0.62", features = [
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",
+    "Win32_System_Threading",
 ] }
 
 # macOS platform

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -44,7 +44,7 @@ use crate::{
     config::WindowConfiguration,
     data_transfer::{DataTransferSource, NullDataTransferSource},
     executor::BackgroundExecutor,
-    shared::{PlatformHandlers, WindowCallbacks},
+    shared::{PlatformHandlers, WindowCallbacks, hwnd_affinity::ContextLedger},
     traits::{
         Clipboard, DesktopCapabilities, OwnerPlatform, Platform, PlatformCapabilities,
         PlatformDisplay, PlatformExecutor, PlatformReadyCallback, PlatformWindow, WindowAppearance,
@@ -97,6 +97,14 @@ pub(super) struct WindowContext {
     /// path in `window_proc` uses this; the `WM_KEYDOWN` drain sees a whole
     /// burst at once and never needs cross-message state.
     pub pending_high_surrogate: std::cell::Cell<Option<u16>>,
+    /// Borrow ledger deferring this context's free past every live borrow
+    /// on the owner thread — see [`ContextLedger`] for the reentrancy
+    /// hazard (a framework callback closing the window from inside a
+    /// dispatch) this exists to survive, and [`ContextGuard`] for the RAII
+    /// half. `RefCell`, not a lock: only the owning thread ever touches it
+    /// (the affinity gates enforce that), and every borrow is a short
+    /// non-reentrant method call.
+    pub ledger: std::cell::RefCell<ContextLedger>,
 }
 
 impl WindowContext {
@@ -105,6 +113,12 @@ impl WindowContext {
     /// This method extracts the handler, releases the lock, calls the handler,
     /// then re-acquires the lock to restore it. This prevents deadlocks when
     /// the handler tries to acquire the same lock.
+    ///
+    /// The restore touches `self` AFTER the handler returns, and the handler
+    /// may have closed this very window — that is sound only because every
+    /// caller holds a [`ContextGuard`] over `self`, which defers the
+    /// context's free past the borrow even when the handler's close runs a
+    /// nested `WM_DESTROY` (which merely retires it).
     #[inline]
     pub(super) fn dispatch_event(&self, event: WindowEvent) {
         // Take the handler out of the lock
@@ -129,16 +143,69 @@ fn hwnd_names_flui_class(hwnd: HWND) -> bool {
     let mut name = [0_u16; 256];
     // SAFETY: `GetClassNameW` writes at most `name.len()` UTF-16 units
     // (including the terminator) into the live stack buffer the slice
-    // points at, and returns the count written (0 on failure — a dead or
-    // foreign handle simply reports "not our class" here).
-    // `WINDOW_CLASS_NAME.as_wide()` walks our own `w!(..)` static literal,
-    // which is NUL-terminated by construction.
-    unsafe {
-        let len = GetClassNameW(hwnd, &mut name);
-        if len <= 0 {
-            return false;
+    // points at, and returns the count copied EXCLUDING the terminator (0
+    // on failure — a dead or foreign handle simply reports "not our class"
+    // here). `WINDOW_CLASS_NAME.as_wide()` walks our own `w!(..)` static
+    // literal, which is NUL-terminated by construction, and measures it
+    // with `wcslen` — so it also EXCLUDES the terminator, matching the
+    // length convention `class_name_matches` documents and its Linux tests
+    // pin.
+    let (copied, expected) =
+        unsafe { (GetClassNameW(hwnd, &mut name), WINDOW_CLASS_NAME.as_wide()) };
+    crate::shared::hwnd_affinity::class_name_matches(&name, copied, expected)
+}
+
+/// RAII borrow of a [`WindowContext`]: counts itself in the context's
+/// [`ContextLedger`] on acquisition and, on release, frees the allocation
+/// iff it was the outermost borrow of a retired context. This is what makes
+/// holding `&WindowContext` across reentrant message dispatch sound — a
+/// nested `WM_DESTROY` (a framework callback closing the window from inside
+/// a dispatch) only *retires* the context; the memory outlives every frame
+/// still borrowing it.
+struct ContextGuard {
+    context: *mut WindowContext,
+}
+
+impl ContextGuard {
+    /// Registers a borrow of `context`.
+    ///
+    /// # Safety
+    ///
+    /// `context` must be the live (not yet freed) allocation installed in a
+    /// FLUI window's `GWLP_USERDATA` slot, and the caller must be on that
+    /// window's owning thread — both established by the gate or dispatch
+    /// provenance at every call site. Single-threadedness is what makes the
+    /// non-atomic ledger sound.
+    unsafe fn acquire(context: *mut WindowContext) -> Self {
+        // SAFETY: `context` is valid per the contract above.
+        unsafe { (*context).ledger.borrow_mut().acquire() };
+        Self { context }
+    }
+
+    /// The borrowed context, lifetime-bound to this guard.
+    fn context(&self) -> &WindowContext {
+        // SAFETY: `acquire`'s contract established validity, and the ledger
+        // defers the only free (a retired context's outermost release) past
+        // this guard's own `Drop` — so the allocation outlives `&self`.
+        unsafe { &*self.context }
+    }
+}
+
+impl Drop for ContextGuard {
+    fn drop(&mut self) {
+        // The allocation is still live here — it is freed only by the
+        // outermost release of a retired context, which is at the earliest
+        // THIS statement (`Self::context` carries that argument). The
+        // `RefCell` borrow is a temporary that ends before the free below.
+        let must_free = self.context().ledger.borrow_mut().release();
+        if must_free {
+            // SAFETY: this was the outermost borrow of a retired context:
+            // the slot was cleared before retirement (no new borrow can be
+            // minted), no other guard exists, and the pointer is the
+            // `Box::into_raw` allocation `WindowsWindow::new` installed —
+            // reclaiming it here is the unique free.
+            drop(unsafe { Box::from_raw(self.context) });
         }
-        name[..len as usize] == *WINDOW_CLASS_NAME.as_wide()
     }
 }
 
@@ -156,14 +223,15 @@ fn hwnd_names_flui_class(hwnd: HWND) -> bool {
 /// Linux-tested rules in [`crate::shared::hwnd_affinity`]; this shell only
 /// performs the OS queries.
 ///
-/// `f` must not retrieve queued messages, and must not reach
-/// `DestroyWindow` for this same window — directly or through a dispatched
-/// callback — while the reference is live: `WM_DESTROY` dispatched inside
-/// `f` would free the context under it. This is the same discipline
-/// `window_proc`'s own arms already rely on when they hold the context
-/// across callback dispatch; a callback that closes its own window
-/// mid-dispatch is the documented residual (same-thread reentrancy)
-/// exposure, unchanged by this gate, which closes the *cross-thread* race.
+/// The borrow is guarded, not fragile: `f` may make calls that re-enter
+/// `window_proc` on this same thread (an `SetWindowPos` inside the
+/// fullscreen toggle, a dispatched framework callback that closes the
+/// window). If such reentrancy reaches `WM_DESTROY`, the context is only
+/// *retired* — its free is deferred, via the [`ContextLedger`], to the
+/// outermost [`ContextGuard`] release — so the reference stays valid for
+/// the whole closure; post-retirement it merely describes a window that is
+/// already gone, and the remaining Win32 calls against the dead `hwnd`
+/// fail cleanly instead of dangling.
 pub(super) fn with_window_context<R>(
     hwnd: HWND,
     op: &'static str,
@@ -196,14 +264,14 @@ pub(super) fn with_window_context<R>(
             // class (so the non-null slot value is the `Box::into_raw`
             // pointer `WindowsWindow::new` installed, not a foreign
             // protocol's), and the slot is non-null (so `WM_DESTROY` has
-            // not cleared+freed it). The only path that frees the box is
-            // `WM_DESTROY`, dispatched on this same thread — and neither
-            // the queries above nor `f` (per this function's contract)
-            // dispatch messages, so the free cannot interleave between the
-            // slot read and the last use of the reference, which is
-            // confined to the closure call below.
-            let context = unsafe { &*(slot as *mut WindowContext) };
-            Some(f(context))
+            // not retired it). Between the slot read above and this
+            // acquisition no message dispatch happens on this thread, so
+            // the context cannot have been retired-and-freed in between;
+            // once the guard is held, any reentrant `WM_DESTROY` inside
+            // `f` defers the free past the guard's drop (see
+            // `ContextGuard`).
+            let guard = unsafe { ContextGuard::acquire(slot as *mut WindowContext) };
+            Some(f(guard.context()))
         }
         UserDataVerdict::Refuse(reason) => {
             tracing::debug!(
@@ -218,17 +286,37 @@ pub(super) fn with_window_context<R>(
 }
 
 /// Routes a teardown request (`close()`, last `Drop`) for `hwnd` by thread
-/// identity: `DestroyWindow` directly on the owning thread, `PostMessageW
+/// identity — `DestroyWindow` directly on the owning thread, `PostMessageW
 /// (WM_CLOSE)` from any other ("a thread cannot use `DestroyWindow` to
-/// destroy a window created by a different thread" — MSDN), nothing at all
-/// for a dead handle. Pure rule in [`crate::shared::hwnd_affinity`]; this
-/// shell only queries the two thread ids.
-pub(super) fn teardown_route(hwnd: HWND) -> crate::shared::hwnd_affinity::TeardownRoute {
+/// destroy a window created by a different thread" — MSDN), nothing for a
+/// dead handle — **and by window identity**: `expected_context` is the
+/// context pointer the calling wrapper installed at creation, compared (as
+/// a value, never dereferenced, hence safe from any thread) against the
+/// window's current class + `GWLP_USERDATA` slot, so a wrapper that
+/// outlived its native window can never destroy or close whatever
+/// unrelated window the OS recycled the handle value for. Pure rule in
+/// [`crate::shared::hwnd_affinity::route_teardown`], which also states the
+/// pointer-ABA residual; this shell only performs the OS queries.
+pub(super) fn teardown_route(
+    hwnd: HWND,
+    expected_context: *const WindowContext,
+) -> crate::shared::hwnd_affinity::TeardownRoute {
     // SAFETY: see the identical queries in `with_window_context` — no
     // pointers dereferenced, no messages pumped.
-    let (owner_thread, current_thread) =
-        unsafe { (GetWindowThreadProcessId(hwnd, None), GetCurrentThreadId()) };
-    crate::shared::hwnd_affinity::route_teardown(owner_thread, current_thread)
+    let (owner_thread, current_thread, slot) = unsafe {
+        (
+            GetWindowThreadProcessId(hwnd, None),
+            GetCurrentThreadId(),
+            GetWindowLongPtrW(hwnd, GWLP_USERDATA),
+        )
+    };
+    crate::shared::hwnd_affinity::route_teardown(
+        owner_thread,
+        current_thread,
+        hwnd_names_flui_class(hwnd),
+        slot,
+        expected_context as isize,
+    )
 }
 
 /// Windows platform state
@@ -481,12 +569,13 @@ impl WindowsPlatform {
     /// The body dispatches framework-supplied callbacks (`ctx.callbacks.*`,
     /// `ctx.dispatch_event`) that can panic. A panic must not unwind across
     /// this `extern "system"` frame: unwinding across a non-unwind ABI
-    /// boundary aborts the process (Rust Reference, *Panic* chapter,
-    /// "unwinding across FFI boundaries"; undefined behavior before Rust
-    /// 1.81 made the abort guaranteed) — and that language-imposed abort
+    /// boundary is a guaranteed process abort since Rust 1.81, and was
+    /// undefined behavior before that (Rust Reference, *Panic* chapter,
+    /// "unwinding across FFI boundaries") — and that language-imposed abort
     /// reports nothing through this framework's diagnostics. So the panic
     /// is caught here, its payload logged via `tracing`, and the process
-    /// terminated deliberately with the same outcome. Deliberately NOT
+    /// terminated deliberately — the same outcome, made deterministic and
+    /// observable on every toolchain. Deliberately NOT
     /// swallowed-and-continued (`DefWindowProcW` as a fallback answer): a
     /// panic mid-`WM_DESTROY` or mid-dispatch leaves framework state torn,
     /// and pumping further messages over torn state converts one crash into
@@ -548,18 +637,28 @@ impl WindowsPlatform {
         // `TrackMouseEvent` (`WM_MOUSEMOVE`) and `BeginPaint`/`EndPaint`
         // (`WM_PAINT`, its own SAFETY note below) take `&raw` pointers to
         // stack-local, correctly-sized structs; `DestroyWindow` calls are
-        // individually commented where they appear; `Box::from_raw(ctx_ptr)`
-        // (`WM_DESTROY`) has its own SAFETY note where it appears;
-        // `DefWindowProcW` forwards unhandled messages verbatim with no
-        // pointer arguments of its own.
+        // individually commented where they appear; `DefWindowProcW`
+        // forwards unhandled messages verbatim with no pointer arguments of
+        // its own.
         unsafe {
-            // Get window context from GWLP_USERDATA
+            // Get window context from GWLP_USERDATA. The guard makes `ctx`
+            // survive reentrant dispatch: arms below hold it across
+            // framework callbacks, and a callback may close this window —
+            // running a nested `WM_DESTROY` frame on this same thread that
+            // RETIRES the context (clears the slot, marks the ledger)
+            // without freeing it; the free happens when the outermost
+            // guard, possibly this frame's, releases (see `ContextGuard`).
+            //
+            // SAFETY(acquire): this frame is Win32's dispatch for `hwnd` on
+            // its owning thread, and a non-null slot means the context is
+            // not yet retired — exactly `ContextGuard::acquire`'s contract.
             let ctx_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut WindowContext;
-            let ctx = if ctx_ptr.is_null() {
+            let guard = if ctx_ptr.is_null() {
                 None
             } else {
-                Some(&*ctx_ptr)
+                Some(ContextGuard::acquire(ctx_ptr))
             };
+            let ctx = guard.as_ref().map(ContextGuard::context);
 
             match msg {
                 WM_CREATE => {
@@ -605,24 +704,24 @@ impl WindowsPlatform {
                         // Dispatch Closed event to global handlers
                         ctx.dispatch_event(WindowEvent::Closed(ctx.window_id));
 
-                        // Clean up context - IMPORTANT: Clear pointer BEFORE dropping to avoid
-                        // dangling pointer
-                        //
-                        // SAFETY: `ctx_ptr` is the same pointer `WindowsWindow::new`
-                        // produced via `Box::into_raw` and stored in this HWND's
-                        // `GWLP_USERDATA` — `ctx` (the shared reference used just
-                        // above) is derived from that same allocation, and its
-                        // last use is the `dispatch_event` call above, so no
-                        // reference into the box outlives this reclaim. The slot
-                        // is zeroed with `SetWindowLongPtrW` *before* `Box::from_raw`
-                        // runs, so if `dispatch_close`/`dispatch_event` above had
-                        // re-entrantly queried `GWLP_USERDATA` (they don't), they
-                        // would see null rather than a pointer about to be freed.
-                        // `window_proc` never runs concurrently with itself for
-                        // the same `hwnd` (Win32 serializes message dispatch per
-                        // queue), so this is the only path that can free `ctx_ptr`.
+                        // Retire the context: clear the slot FIRST, so no
+                        // new borrow can be minted (`with_window_context`
+                        // and this function's own entry both refuse a null
+                        // slot), then mark the ledger. The allocation is
+                        // NOT freed here — this frame's own `guard` still
+                        // borrows it, and so may outer frames when this
+                        // `WM_DESTROY` arrived reentrantly (a framework
+                        // callback closing the window from inside another
+                        // arm's dispatch). The free happens exactly once,
+                        // at the outermost `ContextGuard` release — in the
+                        // common case, this frame's own guard dropping at
+                        // the end of this function (see `ContextGuard`).
+                        // `window_proc` never runs concurrently with itself
+                        // for the same `hwnd` (Win32 dispatches on the one
+                        // owning thread), so slot clear + retire need no
+                        // further ordering.
                         SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
-                        drop(Box::from_raw(ctx_ptr));
+                        ctx.ledger.borrow_mut().retire();
                     }
 
                     LRESULT(0)

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -10,22 +10,25 @@ use windows::{
     Win32::{
         Foundation::{ERROR_CANCELLED, HWND, LPARAM, LRESULT, RECT, WPARAM},
         Graphics::Gdi::{BeginPaint, EndPaint, HBRUSH, PAINTSTRUCT},
-        System::LibraryLoader::{GetModuleFileNameW, GetModuleHandleW},
+        System::{
+            LibraryLoader::{GetModuleFileNameW, GetModuleHandleW},
+            Threading::GetCurrentThreadId,
+        },
         UI::{
             HiDpi::{DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetProcessDpiAwarenessContext},
             Input::KeyboardAndMouse::{TME_LEAVE, TRACKMOUSEEVENT, TrackMouseEvent},
             WindowsAndMessaging::{
                 CS_HREDRAW, CS_OWNDC, CS_VREDRAW, CreateWindowExW, DefWindowProcW, DestroyWindow,
-                DispatchMessageW, GWLP_USERDATA, GetForegroundWindow, GetMessageW,
-                GetWindowLongPtrW, HICON, HTCLIENT, HWND_MESSAGE, IDC_ARROW, MSG, PM_REMOVE,
-                PeekMessageW, PostQuitMessage, RegisterClassW, SW_SHOWNORMAL, SWP_NOACTIVATE,
-                SWP_NOZORDER, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
-                TranslateMessage, WINDOW_EX_STYLE, WINDOW_STYLE, WM_CHAR, WM_CLOSE, WM_CREATE,
-                WM_DESTROY, WM_DPICHANGED, WM_ERASEBKGND, WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP,
-                WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP,
-                WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_MOVE, WM_PAINT, WM_RBUTTONDOWN,
-                WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN,
-                WM_SYSKEYUP, WNDCLASSW,
+                DispatchMessageW, GWLP_USERDATA, GetClassNameW, GetForegroundWindow, GetMessageW,
+                GetWindowLongPtrW, GetWindowThreadProcessId, HICON, HTCLIENT, HWND_MESSAGE,
+                IDC_ARROW, MSG, PM_REMOVE, PeekMessageW, PostQuitMessage, RegisterClassW,
+                SW_SHOWNORMAL, SWP_NOACTIVATE, SWP_NOZORDER, SetForegroundWindow,
+                SetWindowLongPtrW, SetWindowPos, TranslateMessage, WINDOW_EX_STYLE, WINDOW_STYLE,
+                WM_CHAR, WM_CLOSE, WM_CREATE, WM_DESTROY, WM_DPICHANGED, WM_ERASEBKGND,
+                WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN,
+                WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE,
+                WM_MOUSEWHEEL, WM_MOVE, WM_PAINT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR,
+                WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WNDCLASSW,
             },
         },
     },
@@ -117,6 +120,117 @@ impl WindowContext {
     }
 }
 
+/// Whether the live window behind `hwnd` is of this backend's registered
+/// window class — the only class whose `GWLP_USERDATA` slot holds a
+/// [`WindowContext`] pointer. Guards against OS handle recycling: a dead
+/// handle value can be reissued for an unrelated window whose user-data
+/// slot follows someone else's protocol entirely.
+fn hwnd_names_flui_class(hwnd: HWND) -> bool {
+    let mut name = [0_u16; 256];
+    // SAFETY: `GetClassNameW` writes at most `name.len()` UTF-16 units
+    // (including the terminator) into the live stack buffer the slice
+    // points at, and returns the count written (0 on failure — a dead or
+    // foreign handle simply reports "not our class" here).
+    // `WINDOW_CLASS_NAME.as_wide()` walks our own `w!(..)` static literal,
+    // which is NUL-terminated by construction.
+    unsafe {
+        let len = GetClassNameW(hwnd, &mut name);
+        if len <= 0 {
+            return false;
+        }
+        name[..len as usize] == *WINDOW_CLASS_NAME.as_wide()
+    }
+}
+
+/// Runs `f` against the [`WindowContext`] stored in `hwnd`'s `GWLP_USERDATA`
+/// slot — if, and only if, dereferencing it is sound for the calling thread.
+/// Returns `None` (after tracing why) whenever it is not; callers fall back
+/// to a safe default instead of touching the slot.
+///
+/// This is the gate that discharges the HWND thread-affinity obligation on
+/// `WindowsWindow`'s `Send`/`Sync` impls: the context box is freed exactly
+/// once, by `WM_DESTROY` on the window's owning thread, so a dereference is
+/// sound only when made **on that same thread** (where it is serialized with
+/// the free by same-thread message dispatch) against a live window of our
+/// own class with a non-null slot. Every decision is delegated to the pure,
+/// Linux-tested rules in [`crate::shared::hwnd_affinity`]; this shell only
+/// performs the OS queries.
+///
+/// `f` must not retrieve queued messages, and must not reach
+/// `DestroyWindow` for this same window — directly or through a dispatched
+/// callback — while the reference is live: `WM_DESTROY` dispatched inside
+/// `f` would free the context under it. This is the same discipline
+/// `window_proc`'s own arms already rely on when they hold the context
+/// across callback dispatch; a callback that closes its own window
+/// mid-dispatch is the documented residual (same-thread reentrancy)
+/// exposure, unchanged by this gate, which closes the *cross-thread* race.
+pub(super) fn with_window_context<R>(
+    hwnd: HWND,
+    op: &'static str,
+    f: impl FnOnce(&WindowContext) -> R,
+) -> Option<R> {
+    use crate::shared::hwnd_affinity::{UserDataVerdict, classify_user_data_access};
+
+    // SAFETY: `GetWindowThreadProcessId(hwnd, None)` takes an optional out
+    // pointer (`None` — the process id is not needed) and returns 0 for a
+    // dead handle; `GetCurrentThreadId` takes no arguments;
+    // `GetWindowLongPtrW` reads a pointer-sized value with no dereference.
+    // None of these calls pump this thread's message queue.
+    let (owner_thread, current_thread, slot) = unsafe {
+        (
+            GetWindowThreadProcessId(hwnd, None),
+            GetCurrentThreadId(),
+            GetWindowLongPtrW(hwnd, GWLP_USERDATA),
+        )
+    };
+
+    match classify_user_data_access(
+        owner_thread,
+        current_thread,
+        hwnd_names_flui_class(hwnd),
+        slot,
+    ) {
+        UserDataVerdict::Deref => {
+            // SAFETY: the verdict established that this thread owns the
+            // window (owner == current, both live), the window is of our
+            // class (so the non-null slot value is the `Box::into_raw`
+            // pointer `WindowsWindow::new` installed, not a foreign
+            // protocol's), and the slot is non-null (so `WM_DESTROY` has
+            // not cleared+freed it). The only path that frees the box is
+            // `WM_DESTROY`, dispatched on this same thread — and neither
+            // the queries above nor `f` (per this function's contract)
+            // dispatch messages, so the free cannot interleave between the
+            // slot read and the last use of the reference, which is
+            // confined to the closure call below.
+            let context = unsafe { &*(slot as *mut WindowContext) };
+            Some(f(context))
+        }
+        UserDataVerdict::Refuse(reason) => {
+            tracing::debug!(
+                op,
+                hwnd = ?hwnd,
+                ?reason,
+                "refusing to touch this window's native context"
+            );
+            None
+        }
+    }
+}
+
+/// Routes a teardown request (`close()`, last `Drop`) for `hwnd` by thread
+/// identity: `DestroyWindow` directly on the owning thread, `PostMessageW
+/// (WM_CLOSE)` from any other ("a thread cannot use `DestroyWindow` to
+/// destroy a window created by a different thread" — MSDN), nothing at all
+/// for a dead handle. Pure rule in [`crate::shared::hwnd_affinity`]; this
+/// shell only queries the two thread ids.
+pub(super) fn teardown_route(hwnd: HWND) -> crate::shared::hwnd_affinity::TeardownRoute {
+    // SAFETY: see the identical queries in `with_window_context` — no
+    // pointers dereferenced, no messages pumped.
+    let (owner_thread, current_thread) =
+        unsafe { (GetWindowThreadProcessId(hwnd, None), GetCurrentThreadId()) };
+    crate::shared::hwnd_affinity::route_teardown(owner_thread, current_thread)
+}
+
 /// Windows platform state
 pub struct WindowsPlatform {
     /// Message-only window for platform messages
@@ -152,8 +266,14 @@ pub struct WindowsPlatform {
 // belongs to the creating thread, and `DestroyWindow` must run there), and that
 // the struct is itself just a handle. Sending the struct is sound because the
 // address alone aliases nothing; any Win32 call made through it still owes the
-// thread-affinity obligation, which these impls do not discharge. See the
-// event-loop affinity gap in `docs/audits/2026-07-25-upgrade-pack-audit.md`.
+// thread-affinity obligation. The soundness-relevant slice of that obligation
+// — dereferencing per-window `GWLP_USERDATA` contexts, and `DestroyWindow` —
+// is discharged by the `with_window_context`/`teardown_route` gates above
+// (see `WindowsWindow`'s `Send`/`Sync` docs); the remaining affine calls here
+// (`quit`'s `PostQuitMessage`, `open_window`'s queue binding) are logic-level
+// rather than memory-safety and stay guarded by `affinity.debug_assert_owner`
+// — see the event-loop affinity gap in
+// `docs/audits/2026-07-25-upgrade-pack-audit.md`.
 unsafe impl Send for WindowsPlatform {}
 // SAFETY: as for `Send` — `&WindowsPlatform` grants no more than shared access
 // to already-synchronized members plus a never-dereferenced address.
@@ -355,33 +475,72 @@ impl WindowsPlatform {
         }
     }
 
-    /// Main window procedure for all FLUI windows
+    /// Main window procedure for all FLUI windows: a panic boundary around
+    /// [`Self::window_proc_body`], which holds the actual message handling.
+    ///
+    /// The body dispatches framework-supplied callbacks (`ctx.callbacks.*`,
+    /// `ctx.dispatch_event`) that can panic. A panic must not unwind across
+    /// this `extern "system"` frame: unwinding across a non-unwind ABI
+    /// boundary aborts the process (Rust Reference, *Panic* chapter,
+    /// "unwinding across FFI boundaries"; undefined behavior before Rust
+    /// 1.81 made the abort guaranteed) — and that language-imposed abort
+    /// reports nothing through this framework's diagnostics. So the panic
+    /// is caught here, its payload logged via `tracing`, and the process
+    /// terminated deliberately with the same outcome. Deliberately NOT
+    /// swallowed-and-continued (`DefWindowProcW` as a fallback answer): a
+    /// panic mid-`WM_DESTROY` or mid-dispatch leaves framework state torn,
+    /// and pumping further messages over torn state converts one crash into
+    /// arbitrary later misbehavior — per `docs/PANIC-POLICY.md`, a panic is
+    /// a bug report, never control flow.
     ///
     /// # Safety
     ///
     /// Called by Win32 as a `WNDPROC` for windows of `WINDOW_CLASS_NAME`,
-    /// registered as this exact function in `register_window_class`. Win32
-    /// guarantees `hwnd`/`msg`/`wparam`/`lparam` are well-formed for the
-    /// message being delivered, and always dispatches on the thread that
-    /// owns the window's message queue — the `GWLP_USERDATA` read below does
-    /// not race `WM_DESTROY`'s clear+free precisely because both run here,
-    /// serialized by that same-thread dispatch guarantee.
-    ///
-    /// Known gap (not fixed by this comment, not UB — flagged for the
-    /// audit): none of the callback dispatches below (`ctx.callbacks.*`,
-    /// `ctx.dispatch_event`) are wrapped in `catch_unwind`. A panic inside a
-    /// framework-supplied callback unwinds into this `extern "system"`
-    /// frame; stable Rust aborts the process rather than invoking UB when
-    /// that happens (FFI boundaries are implicitly `nounwind`), but that is
-    /// still whole-process termination from a single window's callback,
-    /// unlike the `winit` backend's `window_proc`-equivalent path, which
-    /// does guard its callback boundary with `catch_unwind`.
+    /// registered as this exact function in `register_window_class`; that
+    /// provenance is exactly what [`Self::window_proc_body`]'s own `# Safety`
+    /// contract requires, so forwarding the arguments verbatim discharges it.
     unsafe extern "system" fn window_proc(
         hwnd: HWND,
         msg: u32,
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> LRESULT {
+        // `AssertUnwindSafe` is sound here: on `Err` the process aborts
+        // before any code can observe whatever state the unwind tore.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: arguments forwarded verbatim from Win32's dispatch of
+            // this registered `WNDPROC` — see `# Safety` above.
+            unsafe { Self::window_proc_body(hwnd, msg, wparam, lparam) }
+        }));
+        match outcome {
+            Ok(result) => result,
+            Err(payload) => {
+                tracing::error!(
+                    msg,
+                    hwnd = ?hwnd,
+                    panic = crate::shared::panic_boundary::panic_payload_message(&*payload),
+                    "panic in a window-procedure callback; aborting — it must not \
+                     unwind across the extern \"system\" boundary, and the framework \
+                     state behind this message may be torn"
+                );
+                std::process::abort();
+            }
+        }
+    }
+
+    /// The message handling behind [`Self::window_proc`]. Every dispatch of
+    /// user callbacks stays inside that caller's panic boundary.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called with arguments Win32 delivered to this class's
+    /// `WNDPROC` for the message being handled — Win32 guarantees
+    /// `hwnd`/`msg`/`wparam`/`lparam` are well-formed for that message, and
+    /// always dispatches on the thread that owns the window's message queue,
+    /// so the `GWLP_USERDATA` read below does not race `WM_DESTROY`'s
+    /// clear+free precisely because both run here, serialized by that
+    /// same-thread dispatch guarantee.
+    unsafe fn window_proc_body(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
         // SAFETY: see the `# Safety` section above for the `GWLP_USERDATA`
         // contract this read relies on. The rest of this single `unsafe`
         // block covers every Win32 call in the `match` below: `GetWindowLongPtrW`/

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -61,6 +61,17 @@ pub struct WindowsWindow {
     /// Reference to platform's window map (for cleanup)
     windows_map: Arc<Mutex<HashMap<isize, Arc<WindowsWindow>>>>,
 
+    /// The context allocation this wrapper installed in `hwnd`'s
+    /// `GWLP_USERDATA` slot at creation, kept ONLY as an identity token:
+    /// teardown compares it (as a value, never dereferencing through this
+    /// field) against the window's current slot so a wrapper that outlived
+    /// its native window cannot destroy or close whatever unrelated window
+    /// the OS recycled the handle value for — see
+    /// [`teardown_route`](super::platform::teardown_route). Dangling as a
+    /// VALUE once `WM_DESTROY` has run; that is fine for comparison and
+    /// exactly why it must never be dereferenced here.
+    context: *const super::platform::WindowContext,
+
     /// This window's UIA bridge, subclassed onto `hwnd` at construction so
     /// a UI Automation client that asks at any later point is answered.
     /// Inert until one does — see
@@ -71,13 +82,16 @@ pub struct WindowsWindow {
 
 // SAFETY, per field: `state` and `callbacks` are `Arc<Mutex<..>>`/`Arc<..>`
 // with their own synchronization; `windows_map` is likewise an
-// `Arc<Mutex<..>>`. The only non-`Sync` member is `hwnd: HWND`, a bare
-// address — sending or sharing the address itself aliases nothing, so `Send`
-// and `Sync` are sound for the struct.
+// `Arc<Mutex<..>>`. The non-`Sync`/non-`Send` members are `hwnd: HWND` and
+// `context: *const WindowContext`, both bare addresses that this type never
+// dereferences through these fields (`context` is an identity token for
+// value comparison only — see its field doc) — sending or sharing an
+// address itself aliases nothing, so `Send` and `Sync` are sound for the
+// struct.
 //
 // The HWND behind that address is thread-AFFINE, not "thread-safe by
 // design": its message queue belongs to the thread that created it, Win32
-// dispatches `window_proc` (including the `WM_DESTROY` arm that frees the
+// dispatches `window_proc` (including the `WM_DESTROY` arm that retires the
 // `WindowContext` stored in `GWLP_USERDATA`) on that thread, and
 // `DestroyWindow` refuses to run anywhere else. That obligation is
 // DISCHARGED — not merely documented — by routing every affine touch on
@@ -87,12 +101,16 @@ pub struct WindowsWindow {
 //   `with_window_context`, which refuses (safe fallback, traced) unless the
 //   calling thread is the window's owning thread and the window is live, of
 //   our class, with a non-null slot — on the owning thread the deref cannot
-//   race the free, because the only freeing path (`WM_DESTROY`) is
-//   dispatched on that same thread;
+//   race the free: the only retiring path (`WM_DESTROY`) is dispatched on
+//   that same thread, and the borrow-ledger (`ContextGuard`/`ContextLedger`)
+//   defers the actual free past every live borrow, including across
+//   reentrant dispatch;
 // - every teardown (`close()`, the last wrapper `Drop`) goes through
-//   `teardown_route`, which calls `DestroyWindow` only on the owning thread
-//   and otherwise posts `WM_CLOSE` to the owner's queue (`PostMessageW`,
-//   the documented cross-thread mechanism).
+//   `teardown_route`, which verifies the handle still names THIS wrapper's
+//   window (class + context identity, guarding against OS handle
+//   recycling), calls `DestroyWindow` only on the owning thread, and
+//   otherwise posts `WM_CLOSE` to the owner's queue (`PostMessageW`, the
+//   documented cross-thread mechanism).
 //
 // The decision rules are pure and Linux-tested (`shared::hwnd_affinity`);
 // the remaining Win32 calls on `&self` (`ShowWindow`, `SetWindowPos`,
@@ -233,18 +251,9 @@ impl WindowsWindow {
                 title: options.title.clone(),
             }));
 
-            let window = Arc::new(Self {
-                hwnd,
-                state,
-                callbacks: Arc::clone(&callbacks),
-                windows_map,
-                // On the creating (owning) thread, as Win32 subclassing
-                // requires; `hwnd` was validated just above.
-                #[cfg(feature = "a11y")]
-                accessibility: Arc::new(super::accessibility::WindowsAccessibility::new(hwnd)),
-            });
-
-            // Create and store WindowContext for event dispatch
+            // Create and install the WindowContext for event dispatch
+            // BEFORE building the wrapper: the wrapper keeps the pointer as
+            // its teardown identity token (see the `context` field doc).
             use flui_types::geometry::{DevicePixels, Size};
 
             use super::platform::WindowContext;
@@ -256,7 +265,7 @@ impl WindowsWindow {
             let context = Box::new(WindowContext {
                 window_id,
                 handlers: handlers.clone(),
-                callbacks,
+                callbacks: Arc::clone(&callbacks),
                 scale_factor: std::cell::Cell::new(scale_factor),
                 mode: std::cell::Cell::new(WindowMode::Normal),
                 last_size: std::cell::Cell::new(initial_size),
@@ -266,9 +275,22 @@ impl WindowsWindow {
                 cursor: std::cell::Cell::new(CursorIcon::default()),
                 restore_style: std::cell::Cell::new(0),
                 pending_high_surrogate: std::cell::Cell::new(None),
+                ledger: std::cell::RefCell::new(crate::shared::hwnd_affinity::ContextLedger::new()),
             });
             let context_ptr = Box::into_raw(context);
             SetWindowLongPtrW(hwnd, GWLP_USERDATA, context_ptr as isize);
+
+            let window = Arc::new(Self {
+                hwnd,
+                state,
+                callbacks,
+                windows_map,
+                context: context_ptr,
+                // On the creating (owning) thread, as Win32 subclassing
+                // requires; `hwnd` was validated just above.
+                #[cfg(feature = "a11y")]
+                accessibility: Arc::new(super::accessibility::WindowsAccessibility::new(hwnd)),
+            });
 
             // Show window if requested
             if options.visible {
@@ -428,12 +450,18 @@ impl WindowsWindow {
             // `SetWindowPos`/`MonitorFromWindow`/`GetMonitorInfoW` below all
             // take `hwnd` or a `&raw mut` to a stack-local out-parameter
             // whose size matches what each call expects, and are otherwise
-            // ordinary Win32 calls with no invariant beyond `hwnd` naming a
-            // live window — which `with_window_context` just established,
-            // and which cannot lapse mid-closure on the owning thread (the
-            // only destroy path, `WM_DESTROY`, dispatches here; nothing in
-            // this closure reaches `DestroyWindow` or retrieves queued
-            // messages, per the gate's contract).
+            // ordinary Win32 calls whose failure mode against a dead `hwnd`
+            // is an error return, not UB. The window CAN die mid-closure:
+            // `SetWindowPos` synchronously re-enters `window_proc`
+            // (`WM_SIZE`/`WM_MOVE`), whose arms dispatch framework
+            // callbacks, and `ctx.dispatch_event` below does so directly —
+            // a callback may close this window, running a nested
+            // `WM_DESTROY` right here. What stays valid regardless is
+            // `ctx` itself: the gate's `ContextGuard` defers the context
+            // free past this closure (`WM_DESTROY` only retires it — see
+            // `ContextLedger`), so post-destruction the remaining `Cell`
+            // reads/writes and dead-`hwnd` Win32 calls are sound no-ops,
+            // never dangling.
             unsafe {
                 if let WindowMode::Fullscreen { restore_bounds } = current_mode {
                     // Exit fullscreen - restore previous style and bounds
@@ -943,7 +971,7 @@ impl PlatformWindow for WindowsWindow {
 
     fn close(&self) {
         use crate::shared::hwnd_affinity::TeardownRoute;
-        match super::platform::teardown_route(self.hwnd) {
+        match super::platform::teardown_route(self.hwnd, self.context) {
             TeardownRoute::DestroyDirect => {
                 // SAFETY: `DestroyWindow` takes `self.hwnd` by value; the
                 // route just established this is the owning thread, the only
@@ -979,6 +1007,13 @@ impl PlatformWindow for WindowsWindow {
             }
             TeardownRoute::AlreadyGone => {
                 tracing::debug!(hwnd = ?self.hwnd, "close: the native window is already gone");
+            }
+            TeardownRoute::StaleHandle => {
+                tracing::debug!(
+                    hwnd = ?self.hwnd,
+                    "close: the handle no longer names this wrapper's window \
+                     (recycled by the OS); leaving its new owner untouched"
+                );
             }
         }
     }
@@ -1139,6 +1174,8 @@ impl Clone for WindowsWindow {
             state: Arc::clone(&self.state),
             callbacks: Arc::clone(&self.callbacks),
             windows_map: Arc::clone(&self.windows_map),
+            // Same window, same identity token.
+            context: self.context,
             // The clone shares the same window, so it shares the same UIA
             // bridge — one subclass hook per HWND, never two.
             #[cfg(feature = "a11y")]
@@ -1841,7 +1878,7 @@ impl Drop for WindowsWindow {
             tracing::debug!("Destroying window HWND {:?}", self.hwnd);
 
             use crate::shared::hwnd_affinity::TeardownRoute;
-            match super::platform::teardown_route(self.hwnd) {
+            match super::platform::teardown_route(self.hwnd, self.context) {
                 TeardownRoute::DestroyDirect => {
                     // Unhook the UIA subclass BEFORE destroying the window —
                     // Win32 wants subclasses removed while the window still
@@ -1853,10 +1890,13 @@ impl Drop for WindowsWindow {
 
                     // SAFETY: `DestroyWindow` takes `self.hwnd` by value;
                     // the route just established this is the owning thread
-                    // (a handle that was never created routes `AlreadyGone`
-                    // instead), where `WM_DESTROY` (handled in
-                    // `platform.rs`) reclaims the `GWLP_USERDATA`
-                    // allocation synchronously within this call.
+                    // and that the handle still names THIS wrapper's window
+                    // (a never-created or already-destroyed handle routes
+                    // `AlreadyGone`, a recycled one `StaleHandle`), where
+                    // `WM_DESTROY` (handled in `platform.rs`) retires the
+                    // `GWLP_USERDATA` allocation synchronously within this
+                    // call, the ledger freeing it at the outermost borrow
+                    // release.
                     unsafe {
                         if let Err(error) = DestroyWindow(self.hwnd) {
                             tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed in Drop");
@@ -1884,6 +1924,13 @@ impl Drop for WindowsWindow {
                 }
                 TeardownRoute::AlreadyGone => {
                     tracing::debug!(hwnd = ?self.hwnd, "Drop: the native window is already gone");
+                }
+                TeardownRoute::StaleHandle => {
+                    tracing::debug!(
+                        hwnd = ?self.hwnd,
+                        "Drop: the handle no longer names this wrapper's window \
+                         (recycled by the OS); leaving its new owner untouched"
+                    );
                 }
             }
 

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -12,7 +12,7 @@ use raw_window_handle::{
 };
 use windows::{
     Win32::{
-        Foundation::{FALSE, HWND, POINT, RECT, TRUE},
+        Foundation::{FALSE, HWND, LPARAM, POINT, RECT, TRUE, WPARAM},
         Graphics::Gdi::{
             HRGN, InvalidateRect, MONITOR_DEFAULTTOPRIMARY, MonitorFromWindow, ScreenToClient,
             UpdateWindow,
@@ -25,12 +25,12 @@ use windows::{
                 GWLP_USERDATA, GetClientRect, GetCursorPos, GetForegroundWindow, GetWindowLongPtrW,
                 GetWindowPlacement, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_IBEAM,
                 IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
-                IsZoomed, LoadCursorW, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW,
-                SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
+                IsZoomed, LoadCursorW, PostMessageW, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE,
+                SW_SHOW, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
                 SetClassLongPtrW, SetCursor, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
-                SetWindowTextW, ShowWindow, WINDOWPLACEMENT, WS_EX_APPWINDOW, WS_MAXIMIZEBOX,
-                WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SYSMENU, WS_THICKFRAME,
-                WS_VISIBLE,
+                SetWindowTextW, ShowWindow, WINDOWPLACEMENT, WM_CLOSE, WS_EX_APPWINDOW,
+                WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SYSMENU,
+                WS_THICKFRAME, WS_VISIBLE,
             },
         },
     },
@@ -75,17 +75,32 @@ pub struct WindowsWindow {
 // address — sending or sharing the address itself aliases nothing, so `Send`
 // and `Sync` are sound for the struct.
 //
-// NOT claimed — an HWND is thread-AFFINE, not "thread-safe by design": its
-// message queue belongs to the thread that created it, and Win32 requires
-// several of the calls below (`DestroyWindow`, `SetWindowLongPtrW` on
-// `GWLP_USERDATA`, anything touching the `WindowContext` stashed there) to
-// run on that owning thread to stay race-free against `window_proc`'s
-// `WM_DESTROY` handler freeing the same context. These impls only make it
-// legal to move/share the `Arc<WindowsWindow>` across threads; they do not
-// themselves discharge that thread-affinity obligation — see the per-call
-// SAFETY comments below and the same gap already documented on
-// `WindowsPlatform`'s `Send`/`Sync` impls in `platform.rs`.
+// The HWND behind that address is thread-AFFINE, not "thread-safe by
+// design": its message queue belongs to the thread that created it, Win32
+// dispatches `window_proc` (including the `WM_DESTROY` arm that frees the
+// `WindowContext` stored in `GWLP_USERDATA`) on that thread, and
+// `DestroyWindow` refuses to run anywhere else. That obligation is
+// DISCHARGED — not merely documented — by routing every affine touch on
+// this type through two gates in `platform.rs`:
+//
+// - every dereference of the `GWLP_USERDATA` context goes through
+//   `with_window_context`, which refuses (safe fallback, traced) unless the
+//   calling thread is the window's owning thread and the window is live, of
+//   our class, with a non-null slot — on the owning thread the deref cannot
+//   race the free, because the only freeing path (`WM_DESTROY`) is
+//   dispatched on that same thread;
+// - every teardown (`close()`, the last wrapper `Drop`) goes through
+//   `teardown_route`, which calls `DestroyWindow` only on the owning thread
+//   and otherwise posts `WM_CLOSE` to the owner's queue (`PostMessageW`,
+//   the documented cross-thread mechanism).
+//
+// The decision rules are pure and Linux-tested (`shared::hwnd_affinity`);
+// the remaining Win32 calls on `&self` (`ShowWindow`, `SetWindowPos`,
+// `SetWindowTextW`, DWM attributes, ...) are documented by Win32 as legal
+// cross-thread and dereference nothing.
 unsafe impl Send for WindowsWindow {}
+// SAFETY: see `Send` above — shared access adds nothing beyond the same
+// gated paths.
 unsafe impl Sync for WindowsWindow {}
 
 /// Mutable window state
@@ -383,9 +398,11 @@ impl WindowsWindow {
     ///   events
     ///
     /// # Thread Safety
-    /// This method is unsafe because it accesses raw window context via
-    /// GWLP_USERDATA. It should only be called from the window's message
-    /// loop thread or with proper synchronization.
+    /// Callable from any thread, but only effective on the window's owning
+    /// thread (where `window_proc`'s hotkey arm calls it): the context gate
+    /// (`with_window_context`, see `platform.rs`) refuses the toggle with a
+    /// warning on any other thread instead of racing the owner's
+    /// `WM_DESTROY` free of the window context.
     ///
     /// # Example
     /// ```ignore
@@ -398,167 +415,153 @@ impl WindowsWindow {
                 GetMonitorInfoW, MONITOR_DEFAULTTOPRIMARY, MONITORINFO, MonitorFromWindow,
             },
             UI::WindowsAndMessaging::{
-                GWL_STYLE, GWLP_USERDATA, GetWindowLongPtrW, GetWindowRect, HWND_TOP,
-                SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SetWindowLongPtrW, SetWindowPos,
-                WS_POPUP, WS_VISIBLE,
+                GWL_STYLE, GetWindowLongPtrW, GetWindowRect, HWND_TOP, SWP_FRAMECHANGED,
+                SWP_NOACTIVATE, SWP_NOZORDER, SetWindowLongPtrW, SetWindowPos, WS_POPUP,
+                WS_VISIBLE,
             },
         };
 
-        // SAFETY: `ctx_ptr` is whatever `isize` is currently stored in
-        // `hwnd`'s `GWLP_USERDATA` slot. A non-null value was written by
-        // `WindowsWindow::new` (`Box::into_raw`) and is only cleared+freed by
-        // `WindowsPlatform::window_proc`'s `WM_DESTROY` arm, on this window's
-        // owning thread. The null check covers a window not yet initialized
-        // or already destroyed by the time this call reads the slot.
-        //
-        // Known gap (not fixed by this comment): this function is reachable
-        // both from `window_proc` (always on the owning thread, per the
-        // `# Thread Safety` doc above) and from `WindowsWindow::toggle_fullscreen`
-        // on `&self`, which carries no thread-affinity check — a caller on a
-        // different thread than the one servicing this HWND's message queue
-        // races the `WM_DESTROY` free with no synchronization discharging
-        // that race. `GetWindowRect`/`GetWindowLongPtrW`/`SetWindowLongPtrW`/
-        // `SetWindowPos`/`MonitorFromWindow`/`GetMonitorInfoW` below all take
-        // `hwnd` or a `&raw mut` to a stack-local out-parameter whose size
-        // matches what each call expects, and are otherwise ordinary Win32
-        // calls with no additional invariant beyond `hwnd` naming a live
-        // window, which the OS itself would report via a failed return
-        // rather than UB if it did not.
-        unsafe {
-            // Get WindowContext from GWLP_USERDATA
-            let ctx_ptr =
-                GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                tracing::warn!("Cannot toggle fullscreen: no WindowContext");
-                return;
-            }
-            let ctx = &*ctx_ptr;
-
+        let toggled = super::platform::with_window_context(hwnd, "toggle_fullscreen", |ctx| {
             let current_mode = ctx.mode.get();
 
-            if let WindowMode::Fullscreen { restore_bounds } = current_mode {
-                // Exit fullscreen - restore previous style and bounds
-                tracing::info!("Exiting fullscreen mode");
+            // SAFETY: `GetWindowRect`/`GetWindowLongPtrW`/`SetWindowLongPtrW`/
+            // `SetWindowPos`/`MonitorFromWindow`/`GetMonitorInfoW` below all
+            // take `hwnd` or a `&raw mut` to a stack-local out-parameter
+            // whose size matches what each call expects, and are otherwise
+            // ordinary Win32 calls with no invariant beyond `hwnd` naming a
+            // live window — which `with_window_context` just established,
+            // and which cannot lapse mid-closure on the owning thread (the
+            // only destroy path, `WM_DESTROY`, dispatches here; nothing in
+            // this closure reaches `DestroyWindow` or retrieves queued
+            // messages, per the gate's contract).
+            unsafe {
+                if let WindowMode::Fullscreen { restore_bounds } = current_mode {
+                    // Exit fullscreen - restore previous style and bounds
+                    tracing::info!("Exiting fullscreen mode");
 
-                // Validate transition
-                let candidate = WindowMode::Normal;
-                if !current_mode.can_transition_to(&candidate) {
-                    tracing::warn!("Cannot exit fullscreen: invalid state transition");
-                    return;
-                }
+                    // Validate transition
+                    let candidate = WindowMode::Normal;
+                    if !current_mode.can_transition_to(&candidate) {
+                        tracing::warn!("Cannot exit fullscreen: invalid state transition");
+                        return;
+                    }
 
-                // Restore window style from WindowContext
-                let restore_style = ctx.restore_style.get();
-                SetWindowLongPtrW(hwnd, GWL_STYLE, restore_style as isize);
+                    // Restore window style from WindowContext
+                    let restore_style = ctx.restore_style.get();
+                    SetWindowLongPtrW(hwnd, GWL_STYLE, restore_style as isize);
 
-                // Restore window position and size
-                if let Err(error) = SetWindowPos(
-                    hwnd,
-                    None,
-                    restore_bounds.origin.x.0,
-                    restore_bounds.origin.y.0,
-                    restore_bounds.size.width.0,
-                    restore_bounds.size.height.0,
-                    SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE,
-                ) {
-                    tracing::warn!(
-                        ?hwnd,
-                        ?error,
-                        "SetWindowPos (exit fullscreen restore) failed"
+                    // Restore window position and size
+                    if let Err(error) = SetWindowPos(
+                        hwnd,
+                        None,
+                        restore_bounds.origin.x.0,
+                        restore_bounds.origin.y.0,
+                        restore_bounds.size.width.0,
+                        restore_bounds.size.height.0,
+                        SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE,
+                    ) {
+                        tracing::warn!(
+                            ?hwnd,
+                            ?error,
+                            "SetWindowPos (exit fullscreen restore) failed"
+                        );
+                    }
+
+                    // Update state
+                    ctx.mode.set(WindowMode::Normal);
+
+                    // Dispatch ExitFullscreen event
+                    ctx.dispatch_event(crate::traits::WindowEvent::ExitFullscreen {
+                        window_id: ctx.window_id,
+                        size: restore_bounds.size,
+                    });
+                } else {
+                    // Enter fullscreen - save current state and go borderless on monitor
+                    tracing::info!("Entering fullscreen mode");
+
+                    // Get current window rect
+                    let mut rect = RECT::default();
+                    if let Err(error) = GetWindowRect(hwnd, &raw mut rect) {
+                        tracing::warn!(
+                            ?hwnd,
+                            ?error,
+                            "GetWindowRect failed entering fullscreen; restore bounds will be zeroed"
+                        );
+                    }
+
+                    // Save current style to WindowContext
+                    let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
+                    ctx.restore_style.set(current_style);
+
+                    // Save current bounds
+                    let restore_bounds = Bounds {
+                        origin: Point::new(DevicePixels(rect.left), DevicePixels(rect.top)),
+                        size: Size::new(
+                            DevicePixels(rect.right - rect.left),
+                            DevicePixels(rect.bottom - rect.top),
+                        ),
+                    };
+
+                    // Validate transition
+                    let candidate = WindowMode::Fullscreen { restore_bounds };
+                    if !current_mode.can_transition_to(&candidate) {
+                        tracing::warn!(
+                            "Cannot enter fullscreen: invalid state transition from {:?}",
+                            current_mode
+                        );
+                        return;
+                    }
+
+                    // Get monitor containing this window
+                    let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
+                    let mut monitor_info = MONITORINFO {
+                        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                        ..Default::default()
+                    };
+                    if let Err(error) = GetMonitorInfoW(monitor, &raw mut monitor_info).ok() {
+                        tracing::warn!(
+                            ?hwnd,
+                            ?error,
+                            "GetMonitorInfoW failed entering fullscreen; monitor rect will be zeroed"
+                        );
+                    }
+
+                    let monitor_rect = monitor_info.rcMonitor;
+
+                    // Set borderless style
+                    let fullscreen_style = WS_POPUP | WS_VISIBLE;
+                    SetWindowLongPtrW(hwnd, GWL_STYLE, fullscreen_style.0 as isize);
+
+                    // Position window to cover entire monitor
+                    if let Err(error) = SetWindowPos(
+                        hwnd,
+                        Some(HWND_TOP),
+                        monitor_rect.left,
+                        monitor_rect.top,
+                        monitor_rect.right - monitor_rect.left,
+                        monitor_rect.bottom - monitor_rect.top,
+                        SWP_FRAMECHANGED | SWP_NOACTIVATE,
+                    ) {
+                        tracing::warn!(?hwnd, ?error, "SetWindowPos (enter fullscreen) failed");
+                    }
+
+                    // Update state
+                    ctx.mode.set(candidate);
+
+                    // Dispatch Fullscreen event
+                    let size = Size::new(
+                        flui_types::geometry::DevicePixels(monitor_rect.right - monitor_rect.left),
+                        flui_types::geometry::DevicePixels(monitor_rect.bottom - monitor_rect.top),
                     );
+                    ctx.dispatch_event(crate::traits::WindowEvent::Fullscreen {
+                        window_id: ctx.window_id,
+                        size,
+                    });
                 }
-
-                // Update state
-                ctx.mode.set(WindowMode::Normal);
-
-                // Dispatch ExitFullscreen event
-                ctx.dispatch_event(crate::traits::WindowEvent::ExitFullscreen {
-                    window_id: ctx.window_id,
-                    size: restore_bounds.size,
-                });
-            } else {
-                // Enter fullscreen - save current state and go borderless on monitor
-                tracing::info!("Entering fullscreen mode");
-
-                // Get current window rect
-                let mut rect = RECT::default();
-                if let Err(error) = GetWindowRect(hwnd, &raw mut rect) {
-                    tracing::warn!(
-                        ?hwnd,
-                        ?error,
-                        "GetWindowRect failed entering fullscreen; restore bounds will be zeroed"
-                    );
-                }
-
-                // Save current style to WindowContext
-                let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
-                ctx.restore_style.set(current_style);
-
-                // Save current bounds
-                let restore_bounds = Bounds {
-                    origin: Point::new(DevicePixels(rect.left), DevicePixels(rect.top)),
-                    size: Size::new(
-                        DevicePixels(rect.right - rect.left),
-                        DevicePixels(rect.bottom - rect.top),
-                    ),
-                };
-
-                // Validate transition
-                let candidate = WindowMode::Fullscreen { restore_bounds };
-                if !current_mode.can_transition_to(&candidate) {
-                    tracing::warn!(
-                        "Cannot enter fullscreen: invalid state transition from {:?}",
-                        current_mode
-                    );
-                    return;
-                }
-
-                // Get monitor containing this window
-                let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
-                let mut monitor_info = MONITORINFO {
-                    cbSize: std::mem::size_of::<MONITORINFO>() as u32,
-                    ..Default::default()
-                };
-                if let Err(error) = GetMonitorInfoW(monitor, &raw mut monitor_info).ok() {
-                    tracing::warn!(
-                        ?hwnd,
-                        ?error,
-                        "GetMonitorInfoW failed entering fullscreen; monitor rect will be zeroed"
-                    );
-                }
-
-                let monitor_rect = monitor_info.rcMonitor;
-
-                // Set borderless style
-                let fullscreen_style = WS_POPUP | WS_VISIBLE;
-                SetWindowLongPtrW(hwnd, GWL_STYLE, fullscreen_style.0 as isize);
-
-                // Position window to cover entire monitor
-                if let Err(error) = SetWindowPos(
-                    hwnd,
-                    Some(HWND_TOP),
-                    monitor_rect.left,
-                    monitor_rect.top,
-                    monitor_rect.right - monitor_rect.left,
-                    monitor_rect.bottom - monitor_rect.top,
-                    SWP_FRAMECHANGED | SWP_NOACTIVATE,
-                ) {
-                    tracing::warn!(?hwnd, ?error, "SetWindowPos (enter fullscreen) failed");
-                }
-
-                // Update state
-                ctx.mode.set(candidate);
-
-                // Dispatch Fullscreen event
-                let size = Size::new(
-                    flui_types::geometry::DevicePixels(monitor_rect.right - monitor_rect.left),
-                    flui_types::geometry::DevicePixels(monitor_rect.bottom - monitor_rect.top),
-                );
-                ctx.dispatch_event(crate::traits::WindowEvent::Fullscreen {
-                    window_id: ctx.window_id,
-                    size,
-                });
             }
+        });
+        if toggled.is_none() {
+            tracing::warn!(?hwnd, "cannot toggle fullscreen: no usable window context");
         }
     }
 
@@ -568,21 +571,14 @@ impl WindowsWindow {
     }
 
     /// Check if the window is currently in fullscreen mode
+    ///
+    /// `false` off the owning thread or once the window is gone — the
+    /// context gate refuses the read instead of racing `WM_DESTROY`'s free.
     pub fn is_fullscreen(&self) -> bool {
-        // SAFETY: same `GWLP_USERDATA` contract as
-        // `toggle_fullscreen_for_hwnd` above — non-null implies `new`
-        // populated it and `WM_DESTROY` (owning thread only) hasn't cleared
-        // it yet; the same cross-thread race is a known, undischarged gap
-        // when this is called off that thread.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return false;
-            }
-            let ctx = &*ctx_ptr;
+        super::platform::with_window_context(self.hwnd, "is_fullscreen", |ctx| {
             ctx.mode.get().is_fullscreen()
-        }
+        })
+        .unwrap_or(false)
     }
 
     /// Set fullscreen mode
@@ -603,20 +599,13 @@ impl WindowsWindow {
     /// Returns true if the window is minimized, as rendering minimized windows
     /// wastes CPU/GPU resources without any visible output.
     pub fn should_skip_render(hwnd: HWND) -> bool {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above. Every current call site (`platform.rs`'s `WM_PAINT` arm)
-        // runs on the owning thread, so the race noted there does not apply
-        // here today — but the function itself does not enforce that, since
-        // it takes a bare `HWND` from any caller.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return false;
-            }
-            let ctx = &*ctx_ptr;
+        // Every current call site (`platform.rs`'s `WM_PAINT` arm) runs on
+        // the owning thread; the context gate enforces that for any other
+        // caller of this bare-`HWND` function instead of trusting it.
+        super::platform::with_window_context(hwnd, "should_skip_render", |ctx| {
             ctx.mode.get().is_minimized()
-        }
+        })
+        .unwrap_or(false)
     }
 
     pub(super) fn apply_native_cursor(cursor: CursorIcon) -> Result<(), CursorError> {
@@ -712,23 +701,19 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn set_cursor(&self, cursor: CursorIcon) -> Result<(), CursorError> {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above; `.as_ref()` turns the possibly-null raw pointer into
-        // `Option<&WindowContext>` without dereferencing a null pointer, and
-        // the cross-thread `WM_DESTROY` race documented there applies
-        // equally here.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            let context = ctx_ptr
-                .as_ref()
-                .ok_or_else(|| CursorError::Backend("the native window is closed".to_string()))?;
-            context.cursor.set(cursor);
-            if context.is_hovered.get() {
+        super::platform::with_window_context(self.hwnd, "set_cursor", |ctx| {
+            ctx.cursor.set(cursor);
+            if ctx.is_hovered.get() {
                 Self::apply_native_cursor(cursor)?;
             }
-        }
-        Ok(())
+            Ok(())
+        })
+        .ok_or_else(|| {
+            CursorError::Backend(
+                "the native window is closed, or set_cursor was called off its owning thread"
+                    .to_string(),
+            )
+        })?
     }
 
     // ==================== Query Methods (US2) ====================
@@ -758,17 +743,12 @@ impl PlatformWindow for WindowsWindow {
 
     fn window_bounds(&self) -> WindowBounds {
         let bounds = self.bounds();
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above, including the same undischarged cross-thread race.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if !ctx_ptr.is_null() {
-                let ctx = &*ctx_ptr;
-                if ctx.mode.get().is_fullscreen() {
-                    return WindowBounds::Fullscreen(bounds);
-                }
-            }
+        let fullscreen = super::platform::with_window_context(self.hwnd, "window_bounds", |ctx| {
+            ctx.mode.get().is_fullscreen()
+        })
+        .unwrap_or(false);
+        if fullscreen {
+            return WindowBounds::Fullscreen(bounds);
         }
         if PlatformWindow::is_maximized(self) {
             WindowBounds::Maximized(bounds)
@@ -796,16 +776,8 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn is_hovered(&self) -> bool {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above, including the same undischarged cross-thread race.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return false;
-            }
-            (*ctx_ptr).is_hovered.get()
-        }
+        super::platform::with_window_context(self.hwnd, "is_hovered", |ctx| ctx.is_hovered.get())
+            .unwrap_or(false)
     }
 
     fn mouse_position(&self) -> Point<Pixels> {
@@ -831,30 +803,20 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn modifiers(&self) -> keyboard_types::Modifiers {
-        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
-        // above, including the same undischarged cross-thread race.
-        unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return keyboard_types::Modifiers::empty();
-            }
-            (*ctx_ptr).modifiers.get()
-        }
+        super::platform::with_window_context(self.hwnd, "modifiers", |ctx| ctx.modifiers.get())
+            .unwrap_or_else(keyboard_types::Modifiers::empty)
     }
 
     fn appearance(&self) -> WindowAppearance {
-        // SAFETY: the `GWLP_USERDATA` read shares the contract documented on
-        // `toggle_fullscreen_for_hwnd` above. `DwmGetWindowAttribute` below
-        // writes through `&raw mut dark_mode` cast to `c_void`, sized via
-        // `size_of::<i32>()` to match the stack-local `i32` it points at;
-        // `dark_mode` is only read after checking `result.is_ok()`.
+        // No window-context read: this query touches no framework state, and
+        // DWM answers (or fails safely to the `Light` default, which is also
+        // what a dead handle produces) from any thread.
+        //
+        // SAFETY: `DwmGetWindowAttribute` writes through `&raw mut
+        // dark_mode` cast to `c_void`, sized via `size_of::<i32>()` to match
+        // the stack-local `i32` it points at; `dark_mode` is only read after
+        // checking `result.is_ok()`.
         unsafe {
-            let ctx_ptr =
-                GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
-            if ctx_ptr.is_null() {
-                return WindowAppearance::default();
-            }
             // Check DWM dark mode attribute
             use windows::Win32::Graphics::Dwm::{DWMWINDOWATTRIBUTE, DwmGetWindowAttribute};
             let mut dark_mode: i32 = 0;
@@ -980,14 +942,43 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn close(&self) {
-        // SAFETY: `DestroyWindow` takes `self.hwnd` by value; `WM_DESTROY`
-        // (handled in `platform.rs`) reclaims the `GWLP_USERDATA` allocation
-        // synchronously within this same call before it returns, on this
-        // thread — Win32 dispatches `WM_DESTROY` to the window procedure
-        // before `DestroyWindow` returns.
-        unsafe {
-            if let Err(error) = DestroyWindow(self.hwnd) {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow (PlatformWindow::close) failed");
+        use crate::shared::hwnd_affinity::TeardownRoute;
+        match super::platform::teardown_route(self.hwnd) {
+            TeardownRoute::DestroyDirect => {
+                // SAFETY: `DestroyWindow` takes `self.hwnd` by value; the
+                // route just established this is the owning thread, the only
+                // one Win32 permits the call from, and where `WM_DESTROY`
+                // (handled in `platform.rs`, reclaiming the `GWLP_USERDATA`
+                // allocation) is dispatched synchronously before the call
+                // returns.
+                unsafe {
+                    if let Err(error) = DestroyWindow(self.hwnd) {
+                        tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow (PlatformWindow::close) failed");
+                    }
+                }
+            }
+            TeardownRoute::PostClose => {
+                // Cross-thread close cannot call `DestroyWindow` (Win32
+                // forbids it off the creating thread), so it goes through
+                // the documented mechanism instead: post `WM_CLOSE` to the
+                // owner thread's queue. Note the behavioral nuance: the
+                // owner-side `WM_CLOSE` arm consults the window's
+                // should-close veto before destroying, so a vetoing window
+                // treats a cross-thread `close()` as a close *request*.
+                //
+                // SAFETY: `PostMessageW` takes the handle and plain
+                // integers by value — nothing dereferenced, delivery
+                // marshalled by the OS to the owning thread.
+                unsafe {
+                    if let Err(error) =
+                        PostMessageW(Some(self.hwnd), WM_CLOSE, WPARAM(0), LPARAM(0))
+                    {
+                        tracing::warn!(hwnd = ?self.hwnd, ?error, "PostMessageW(WM_CLOSE) (cross-thread PlatformWindow::close) failed");
+                    }
+                }
+            }
+            TeardownRoute::AlreadyGone => {
+                tracing::debug!(hwnd = ?self.hwnd, "close: the native window is already gone");
             }
         }
     }
@@ -1114,11 +1105,11 @@ impl HasWindowHandle for WindowsWindow {
         // regardless of which thread requested it) can destroy the native
         // window while an `Arc<WindowsWindow>`, and therefore a
         // `WindowHandle` borrowed from it, is still held and used elsewhere
-        // (e.g. by wgpu to (re)create a surface). This is the same
-        // undischarged-HWND-lifetime class as the documented cross-thread
-        // `GWLP_USERDATA` race on this type's `Send`/`Sync` impls above —
-        // a real gap this comment does not close, not a validity claim
-        // this code has actually established.
+        // (e.g. by wgpu to (re)create a surface). Unlike the cross-thread
+        // `GWLP_USERDATA` race (closed by the context gate documented on
+        // this type's `Send`/`Sync` impls above), this HWND-lifetime gap
+        // remains open — a real gap this comment does not close, not a
+        // validity claim this code has actually established.
         Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(RawWindowHandle::Win32(handle)) })
     }
 }
@@ -1849,23 +1840,50 @@ impl Drop for WindowsWindow {
         if Arc::strong_count(&self.state) == 1 {
             tracing::debug!("Destroying window HWND {:?}", self.hwnd);
 
-            // Unhook the UIA subclass BEFORE destroying the window — Win32
-            // wants subclasses removed while the window still exists, and
-            // this wrapper's drop is the owner-thread teardown path. Any
-            // capability `Arc` still held elsewhere degrades to a no-op.
-            #[cfg(feature = "a11y")]
-            self.accessibility.shutdown();
+            use crate::shared::hwnd_affinity::TeardownRoute;
+            match super::platform::teardown_route(self.hwnd) {
+                TeardownRoute::DestroyDirect => {
+                    // Unhook the UIA subclass BEFORE destroying the window —
+                    // Win32 wants subclasses removed while the window still
+                    // exists, and this is the owner-thread teardown path
+                    // subclassing requires. Any capability `Arc` still held
+                    // elsewhere degrades to a no-op.
+                    #[cfg(feature = "a11y")]
+                    self.accessibility.shutdown();
 
-            // SAFETY: `DestroyWindow` takes `self.hwnd` by value; the
-            // `is_invalid()` guard skips the call for a handle that was
-            // never successfully created, and `WM_DESTROY` (handled in
-            // `platform.rs`) reclaims the `GWLP_USERDATA` allocation
-            // synchronously within this call.
-            unsafe {
-                if !self.hwnd.is_invalid()
-                    && let Err(error) = DestroyWindow(self.hwnd)
-                {
-                    tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed in Drop");
+                    // SAFETY: `DestroyWindow` takes `self.hwnd` by value;
+                    // the route just established this is the owning thread
+                    // (a handle that was never created routes `AlreadyGone`
+                    // instead), where `WM_DESTROY` (handled in
+                    // `platform.rs`) reclaims the `GWLP_USERDATA`
+                    // allocation synchronously within this call.
+                    unsafe {
+                        if let Err(error) = DestroyWindow(self.hwnd) {
+                            tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed in Drop");
+                        }
+                    }
+                }
+                TeardownRoute::PostClose => {
+                    // Off the owning thread `DestroyWindow` is forbidden and
+                    // unhooking the UIA subclass would race the owner's
+                    // message dispatch, so neither runs here: the close is
+                    // posted to the owner's queue, and the subclass adapter
+                    // is left for `WindowsAccessibility`'s own drop guard
+                    // (which leaks it, with a warning, rather than unhook
+                    // cross-thread).
+                    //
+                    // SAFETY: `PostMessageW` takes the handle and plain
+                    // integers by value — nothing dereferenced.
+                    unsafe {
+                        if let Err(error) =
+                            PostMessageW(Some(self.hwnd), WM_CLOSE, WPARAM(0), LPARAM(0))
+                        {
+                            tracing::warn!(hwnd = ?self.hwnd, ?error, "PostMessageW(WM_CLOSE) (cross-thread Drop) failed");
+                        }
+                    }
+                }
+                TeardownRoute::AlreadyGone => {
+                    tracing::debug!(hwnd = ?self.hwnd, "Drop: the native window is already gone");
                 }
             }
 

--- a/crates/flui-platform/src/shared/hwnd_affinity.rs
+++ b/crates/flui-platform/src/shared/hwnd_affinity.rs
@@ -1,0 +1,219 @@
+//! The Win32 HWND thread-affinity contract, in pure functions.
+//!
+//! An HWND is thread-affine: Win32 dispatches a window's messages — including
+//! the `WM_DESTROY` that frees the context allocation stored in its
+//! `GWLP_USERDATA` slot — on the thread that created the window, and
+//! `DestroyWindow` refuses to destroy a window created by a different thread
+//! (both are documented contracts: see MSDN's `DestroyWindow` remarks and the
+//! "About Messages and Message Queues" thread-affinity section). The Windows
+//! backend shares `Arc<WindowsWindow>` freely across threads, so every
+//! dereference of the raw context pointer read back from `GWLP_USERDATA`
+//! must first decide whether the calling thread may touch it at all: a
+//! foreign thread's read races the owner thread's `WM_DESTROY` clear+free
+//! with no synchronization, and no ordering of the read alone can close that
+//! window (it is a time-of-check/time-of-use race).
+//!
+//! The decisions are pure rules over thread identities and slot state. They
+//! live here, cfg-free, because the Win32 shells that apply them are
+//! lint-only in CI (`cross-typecheck` compiles them and runs nothing) — the
+//! Linux-executed suite is the only coverage these rules actually get.
+//!
+//! Thread identities are Win32 thread ids (`GetCurrentThreadId`,
+//! `GetWindowThreadProcessId`): nonzero `u32`s, with `0` meaning "the HWND
+//! no longer names a live window" (`GetWindowThreadProcessId`'s documented
+//! failure value), which is why [`OWNER_GONE`] is a valid `owner_thread`
+//! input and never a valid `current_thread` one.
+
+/// The `owner_thread` value meaning the HWND no longer names a live window
+/// (`GetWindowThreadProcessId` returns 0 for an invalid handle).
+pub const OWNER_GONE: u32 = 0;
+
+/// Verdict for one attempted dereference of the `GWLP_USERDATA` context
+/// pointer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserDataVerdict {
+    /// Dereferencing is sound: the caller is on the window's owning thread,
+    /// the window is alive and of this backend's own class, and the slot
+    /// holds a pointer. On the owning thread the deref cannot race the free:
+    /// `WM_DESTROY` (the only path that frees the context) is dispatched on
+    /// that same thread, serialized with the caller.
+    Deref,
+    /// Dereferencing must be refused; the reason says why. Callers fall back
+    /// to a safe default (or report an error) instead of touching the slot.
+    Refuse(UserDataRefusal),
+}
+
+/// Why a `GWLP_USERDATA` dereference was refused.
+///
+/// Ordered by precedence: a gone window is reported before a foreign thread,
+/// which is reported before a foreign class, which is reported before an
+/// empty slot — each later check is only meaningful once the earlier ones
+/// pass (class and slot reads against a dead handle return defined but
+/// stale-looking values, and a foreign thread must not proceed to *any*
+/// use of the slot).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserDataRefusal {
+    /// The HWND no longer names a live window (`owner_thread == 0`). The
+    /// handle value may even have been recycled by the OS for an unrelated
+    /// window; nothing read through it describes this wrapper's window.
+    WindowGone,
+    /// The calling thread is not the window's creating thread. A foreign
+    /// thread's dereference races the owner thread's `WM_DESTROY` clear+free
+    /// of the same allocation, so it is refused outright — this is the
+    /// refusal that discharges the `Send`/`Sync` affinity obligation.
+    ForeignThread,
+    /// The live window behind the handle is not of this backend's window
+    /// class, so its `GWLP_USERDATA` slot belongs to someone else's protocol
+    /// entirely. Reachable only through OS handle recycling: this wrapper's
+    /// window died and its handle value now names a foreign window.
+    ForeignClass,
+    /// The slot is null: the context was never installed, or `WM_DESTROY`
+    /// already cleared it (it zeroes the slot before freeing the box).
+    EmptySlot,
+}
+
+/// Classifies one attempted dereference of the context pointer stored in a
+/// window's `GWLP_USERDATA` slot.
+///
+/// Inputs are the caller's OS queries, made in any order before calling:
+///
+/// - `owner_thread` — `GetWindowThreadProcessId(hwnd)`; `0` ([`OWNER_GONE`])
+///   when the handle is dead.
+/// - `current_thread` — `GetCurrentThreadId()`; never `0` (Win32 thread ids
+///   are nonzero).
+/// - `is_own_class` — whether the window's class name equals this backend's
+///   registered class (a dead handle reports `false`).
+/// - `slot` — the raw `GWLP_USERDATA` value (a dead handle reports `0`).
+#[must_use]
+pub fn classify_user_data_access(
+    owner_thread: u32,
+    current_thread: u32,
+    is_own_class: bool,
+    slot: isize,
+) -> UserDataVerdict {
+    if owner_thread == OWNER_GONE {
+        UserDataVerdict::Refuse(UserDataRefusal::WindowGone)
+    } else if owner_thread != current_thread {
+        UserDataVerdict::Refuse(UserDataRefusal::ForeignThread)
+    } else if !is_own_class {
+        UserDataVerdict::Refuse(UserDataRefusal::ForeignClass)
+    } else if slot == 0 {
+        UserDataVerdict::Refuse(UserDataRefusal::EmptySlot)
+    } else {
+        UserDataVerdict::Deref
+    }
+}
+
+/// How a teardown request (`close()`, or the wrapper's last `Drop`) must
+/// reach the native window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TeardownRoute {
+    /// The HWND no longer names a live window; there is nothing to destroy
+    /// and nothing to post to.
+    AlreadyGone,
+    /// The caller is on the owning thread: `DestroyWindow` may run directly
+    /// (Win32 dispatches the resulting `WM_DESTROY` synchronously on this
+    /// same thread before it returns).
+    DestroyDirect,
+    /// The caller is on a foreign thread: `DestroyWindow` would fail there
+    /// ("a thread cannot use `DestroyWindow` to destroy a window created by
+    /// a different thread" — MSDN), so the close must be posted to the owner
+    /// thread's message queue with `PostMessageW(WM_CLOSE)`, the documented
+    /// cross-thread mechanism.
+    PostClose,
+}
+
+/// Routes a teardown request by thread identity. Same input convention as
+/// [`classify_user_data_access`].
+#[must_use]
+pub fn route_teardown(owner_thread: u32, current_thread: u32) -> TeardownRoute {
+    if owner_thread == OWNER_GONE {
+        TeardownRoute::AlreadyGone
+    } else if owner_thread == current_thread {
+        TeardownRoute::DestroyDirect
+    } else {
+        TeardownRoute::PostClose
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OWNER: u32 = 7;
+    const FOREIGN: u32 = 8;
+
+    #[test]
+    fn owner_thread_with_live_own_class_window_and_filled_slot_may_deref() {
+        assert_eq!(
+            classify_user_data_access(OWNER, OWNER, true, 0x1000),
+            UserDataVerdict::Deref
+        );
+    }
+
+    #[test]
+    fn a_dead_handle_is_refused_before_any_other_check_can_mislead() {
+        // Everything else looking plausible must not matter: a dead handle's
+        // class/slot reads are stale or foreign by definition.
+        assert_eq!(
+            classify_user_data_access(OWNER_GONE, OWNER, true, 0x1000),
+            UserDataVerdict::Refuse(UserDataRefusal::WindowGone)
+        );
+    }
+
+    #[test]
+    fn a_foreign_thread_is_refused_even_with_a_live_window_and_filled_slot() {
+        assert_eq!(
+            classify_user_data_access(OWNER, FOREIGN, true, 0x1000),
+            UserDataVerdict::Refuse(UserDataRefusal::ForeignThread)
+        );
+    }
+
+    #[test]
+    fn a_recycled_handle_naming_a_foreign_class_window_is_refused() {
+        assert_eq!(
+            classify_user_data_access(OWNER, OWNER, false, 0x1000),
+            UserDataVerdict::Refuse(UserDataRefusal::ForeignClass)
+        );
+    }
+
+    #[test]
+    fn an_empty_slot_is_refused_on_the_owner_thread_too() {
+        assert_eq!(
+            classify_user_data_access(OWNER, OWNER, true, 0),
+            UserDataVerdict::Refuse(UserDataRefusal::EmptySlot)
+        );
+    }
+
+    #[test]
+    fn refusal_precedence_is_gone_then_foreign_thread_then_class_then_slot() {
+        // All four conditions failing at once report the highest-precedence
+        // refusal, walking down as each earlier condition is repaired.
+        assert_eq!(
+            classify_user_data_access(OWNER_GONE, FOREIGN, false, 0),
+            UserDataVerdict::Refuse(UserDataRefusal::WindowGone)
+        );
+        assert_eq!(
+            classify_user_data_access(OWNER, FOREIGN, false, 0),
+            UserDataVerdict::Refuse(UserDataRefusal::ForeignThread)
+        );
+        assert_eq!(
+            classify_user_data_access(OWNER, OWNER, false, 0),
+            UserDataVerdict::Refuse(UserDataRefusal::ForeignClass)
+        );
+        assert_eq!(
+            classify_user_data_access(OWNER, OWNER, true, 0),
+            UserDataVerdict::Refuse(UserDataRefusal::EmptySlot)
+        );
+    }
+
+    #[test]
+    fn teardown_routes_direct_on_owner_posted_on_foreign_skipped_when_gone() {
+        assert_eq!(route_teardown(OWNER, OWNER), TeardownRoute::DestroyDirect);
+        assert_eq!(route_teardown(OWNER, FOREIGN), TeardownRoute::PostClose);
+        assert_eq!(
+            route_teardown(OWNER_GONE, FOREIGN),
+            TeardownRoute::AlreadyGone
+        );
+    }
+}

--- a/crates/flui-platform/src/shared/hwnd_affinity.rs
+++ b/crates/flui-platform/src/shared/hwnd_affinity.rs
@@ -72,6 +72,28 @@ pub enum UserDataRefusal {
     EmptySlot,
 }
 
+/// Whether a class-name buffer as filled by `GetClassNameW` names the same
+/// class as `expected`.
+///
+/// Length conventions, pinned by the tests below because both sides are
+/// subtle: `copied` is `GetClassNameW`'s return value — the number of UTF-16
+/// units copied **excluding** the terminating NUL (`0` or negative means the
+/// call failed); `expected` must likewise carry **no** terminating NUL (a
+/// `w!(..)` literal read back through `PCWSTR::as_wide`, which measures with
+/// `wcslen`, satisfies this). An `expected` that still carries its NUL can
+/// never match anything `GetClassNameW` reports.
+#[must_use]
+pub fn class_name_matches(buffer: &[u16], copied: i32, expected: &[u16]) -> bool {
+    if copied <= 0 {
+        return false;
+    }
+    let copied = copied as usize;
+    if copied > buffer.len() {
+        return false;
+    }
+    buffer[..copied] == *expected
+}
+
 /// Classifies one attempted dereference of the context pointer stored in a
 /// window's `GWLP_USERDATA` slot.
 ///
@@ -111,6 +133,13 @@ pub enum TeardownRoute {
     /// The HWND no longer names a live window; there is nothing to destroy
     /// and nothing to post to.
     AlreadyGone,
+    /// The HWND names a live window that is not the one this wrapper
+    /// created — the OS recycled the handle value (foreign class, or a
+    /// user-data identity different from the context this wrapper
+    /// installed). Destroying or posting `WM_CLOSE` would target an
+    /// innocent window, so teardown must not touch the HWND at all;
+    /// wrapper-side cleanup still proceeds.
+    StaleHandle,
     /// The caller is on the owning thread: `DestroyWindow` may run directly
     /// (Win32 dispatches the resulting `WM_DESTROY` synchronously on this
     /// same thread before it returns).
@@ -123,16 +152,112 @@ pub enum TeardownRoute {
     PostClose,
 }
 
-/// Routes a teardown request by thread identity. Same input convention as
-/// [`classify_user_data_access`].
+/// Routes a teardown request by thread identity **and window identity**.
+///
+/// Thread inputs follow [`classify_user_data_access`]'s convention. The
+/// identity inputs guard against OS handle recycling — without them a
+/// wrapper that outlived its native window would destroy (owner thread) or
+/// politely close (foreign thread) whatever unrelated window the recycled
+/// handle now names:
+///
+/// - `is_own_class` — whether the live window's class is this backend's
+///   registered class.
+/// - `slot` — the raw `GWLP_USERDATA` value currently stored in the window
+///   (read without dereferencing, so it is safe to query from any thread).
+/// - `expected_slot` — the context pointer this wrapper's constructor
+///   installed (never `0`, since it came from `Box::into_raw`). A live
+///   window is "ours" only while `slot == expected_slot`; a cleared slot
+///   (`0`, mid-`WM_DESTROY`) or a recycled window's foreign value both
+///   route [`TeardownRoute::StaleHandle`].
+///
+/// Residual, stated rather than claimed closed: pointer-value ABA — the
+/// freed context allocation's address being reused for a *new* FLUI
+/// window's context while the OS also recycles the same numeric HWND —
+/// would pass this check. Both reuses must collide at once; the
+/// consequence is bounded to closing a window this same process owns.
 #[must_use]
-pub fn route_teardown(owner_thread: u32, current_thread: u32) -> TeardownRoute {
+pub fn route_teardown(
+    owner_thread: u32,
+    current_thread: u32,
+    is_own_class: bool,
+    slot: isize,
+    expected_slot: isize,
+) -> TeardownRoute {
     if owner_thread == OWNER_GONE {
         TeardownRoute::AlreadyGone
+    } else if !is_own_class || slot != expected_slot {
+        TeardownRoute::StaleHandle
     } else if owner_thread == current_thread {
         TeardownRoute::DestroyDirect
     } else {
         TeardownRoute::PostClose
+    }
+}
+
+/// A single-threaded borrow ledger deciding when a retired window context
+/// may be freed.
+///
+/// Win32 message dispatch re-enters: an outbound call made while a context
+/// borrow is live (`SetWindowPos` inside the fullscreen toggle, a callback
+/// dispatched from a `window_proc` arm) can synchronously run more
+/// `window_proc` frames — including `WM_DESTROY`, if a framework callback
+/// closes the window from inside the dispatch. Freeing the context in the
+/// `WM_DESTROY` arm would therefore free it *under* the borrowing frames
+/// further up the same stack. Instead, every borrow holds a guard counted
+/// here, `WM_DESTROY` only [`retire`]s the context after clearing the slot,
+/// and the free happens when the **outermost** guard releases — the same
+/// recursion-deferred user-data reclaim the winit backend's wndproc uses.
+///
+/// Single-threaded by contract: every acquire/release/retire happens on the
+/// window's owning thread (enforced by the affinity gates), which is what
+/// makes a plain counter — no atomics — correct.
+///
+/// [`retire`]: Self::retire
+#[derive(Debug)]
+pub struct ContextLedger {
+    guards: u32,
+    retired: bool,
+}
+
+impl ContextLedger {
+    /// A fresh ledger: no live borrows, not retired.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            guards: 0,
+            retired: false,
+        }
+    }
+
+    /// Records one live borrow of the context.
+    pub fn acquire(&mut self) {
+        self.guards += 1;
+    }
+
+    /// Releases one borrow. Returns `true` when the caller must now free
+    /// the context allocation: this was the outermost borrow and the
+    /// context has been retired.
+    #[must_use]
+    pub fn release(&mut self) -> bool {
+        self.guards = self
+            .guards
+            .checked_sub(1)
+            .expect("BUG: ContextLedger released more guards than were acquired");
+        self.retired && self.guards == 0
+    }
+
+    /// Marks the context retired: the `GWLP_USERDATA` slot has been cleared
+    /// and no new borrow can be minted. The caller is itself a live
+    /// borrower (the `WM_DESTROY` frame), so the free always happens in a
+    /// later [`release`](Self::release), never here.
+    pub fn retire(&mut self) {
+        self.retired = true;
+    }
+}
+
+impl Default for ContextLedger {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -207,13 +332,108 @@ mod tests {
         );
     }
 
+    const OUR_SLOT: isize = 0x1000;
+
     #[test]
     fn teardown_routes_direct_on_owner_posted_on_foreign_skipped_when_gone() {
-        assert_eq!(route_teardown(OWNER, OWNER), TeardownRoute::DestroyDirect);
-        assert_eq!(route_teardown(OWNER, FOREIGN), TeardownRoute::PostClose);
         assert_eq!(
-            route_teardown(OWNER_GONE, FOREIGN),
+            route_teardown(OWNER, OWNER, true, OUR_SLOT, OUR_SLOT),
+            TeardownRoute::DestroyDirect
+        );
+        assert_eq!(
+            route_teardown(OWNER, FOREIGN, true, OUR_SLOT, OUR_SLOT),
+            TeardownRoute::PostClose
+        );
+        assert_eq!(
+            route_teardown(OWNER_GONE, FOREIGN, true, OUR_SLOT, OUR_SLOT),
             TeardownRoute::AlreadyGone
         );
+    }
+
+    #[test]
+    fn teardown_refuses_a_recycled_handle_on_every_identity_mismatch() {
+        // A live window of a foreign class is never ours, no matter whose
+        // thread asks.
+        assert_eq!(
+            route_teardown(OWNER, OWNER, false, OUR_SLOT, OUR_SLOT),
+            TeardownRoute::StaleHandle
+        );
+        // Our class, but a different context identity: the handle was
+        // recycled for another FLUI window.
+        assert_eq!(
+            route_teardown(OWNER, OWNER, true, 0x2000, OUR_SLOT),
+            TeardownRoute::StaleHandle
+        );
+        // A cleared slot (mid-WM_DESTROY, or never installed) is not ours
+        // to destroy either — and identity must also protect the posted
+        // cross-thread route, not just the direct one.
+        assert_eq!(
+            route_teardown(OWNER, FOREIGN, true, 0, OUR_SLOT),
+            TeardownRoute::StaleHandle
+        );
+    }
+
+    #[test]
+    fn class_name_match_pins_the_nul_exclusion_convention_on_both_sides() {
+        // "Flui" as GetClassNameW leaves it: buffer holds the name, then
+        // trailing NULs; the returned count EXCLUDES the terminator.
+        let mut buffer = [0_u16; 8];
+        buffer[..4].copy_from_slice(&[0x46, 0x6C, 0x75, 0x69]);
+        let expected: &[u16] = &[0x46, 0x6C, 0x75, 0x69];
+
+        assert!(class_name_matches(&buffer, 4, expected));
+
+        // An `expected` that still carries its terminating NUL can never
+        // match — this is the exact bug a `w!(..)` literal read back WITH
+        // its terminator would cause, refusing every valid window.
+        let expected_with_nul: &[u16] = &[0x46, 0x6C, 0x75, 0x69, 0x0000];
+        assert!(!class_name_matches(&buffer, 4, expected_with_nul));
+
+        // Failed call (0 or negative), prefixes, and overlong counts all
+        // refuse rather than match or panic.
+        assert!(!class_name_matches(&buffer, 0, expected));
+        assert!(!class_name_matches(&buffer, -1, expected));
+        assert!(!class_name_matches(&buffer, 3, expected));
+        assert!(!class_name_matches(&buffer, 5, expected));
+        assert!(!class_name_matches(&buffer, 9, expected));
+    }
+
+    #[test]
+    fn ledger_frees_exactly_once_at_the_outermost_release_after_retire() {
+        // Reentrant dispatch: an outer borrow (a window_proc frame or a
+        // with_window_context closure) is live when a nested WM_DESTROY
+        // frame retires the context. The free must wait for the OUTERMOST
+        // release.
+        let mut ledger = ContextLedger::new();
+        ledger.acquire(); // outer frame
+        ledger.acquire(); // nested WM_DESTROY frame
+        ledger.retire();
+        assert!(
+            !ledger.release(),
+            "the retiring frame's own release must not free under the outer borrow"
+        );
+        assert!(
+            ledger.release(),
+            "the outermost release after retirement must free"
+        );
+    }
+
+    #[test]
+    fn ledger_frees_at_the_single_frame_release_in_the_plain_destroy_case() {
+        // The common, non-reentrant teardown: one WM_DESTROY frame, no
+        // borrower above it.
+        let mut ledger = ContextLedger::new();
+        ledger.acquire();
+        ledger.retire();
+        assert!(ledger.release());
+    }
+
+    #[test]
+    fn ledger_never_frees_while_the_context_is_not_retired() {
+        let mut ledger = ContextLedger::new();
+        ledger.acquire();
+        ledger.acquire();
+        assert!(!ledger.release());
+        assert!(!ledger.release());
     }
 }

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -13,8 +13,10 @@
 pub(crate) mod accessibility_bridge;
 pub mod gestures;
 mod handlers;
+pub mod hwnd_affinity;
 pub mod keys;
 pub mod keys_macos;
+pub mod panic_boundary;
 pub mod scroll;
 
 pub use handlers::{PlatformHandlers, WindowCallbacks};

--- a/crates/flui-platform/src/shared/mod.rs
+++ b/crates/flui-platform/src/shared/mod.rs
@@ -13,6 +13,12 @@
 pub(crate) mod accessibility_bridge;
 pub mod gestures;
 mod handlers;
+// `pub`, not `pub(crate)`, for the same reason `keys`/`keys_macos` are:
+// these cfg-free rule modules are consumed only by one target's backend
+// (here Win32), so on every other target a crate-private visibility flags
+// them dead — `pub` is what keeps a Linux-tested, Windows-consumed rule
+// module warning-free everywhere. (`accessibility_bridge` can afford
+// `pub(crate)` only because Linux production code consumes it too.)
 pub mod hwnd_affinity;
 pub mod keys;
 pub mod keys_macos;

--- a/crates/flui-platform/src/shared/panic_boundary.rs
+++ b/crates/flui-platform/src/shared/panic_boundary.rs
@@ -1,0 +1,73 @@
+//! Panic-boundary support for `extern`-ABI OS callbacks.
+//!
+//! Native backends hand callback pointers straight to the OS — Win32 calls
+//! `WNDPROC` (`extern "system"`) for every window message. Rust forbids a
+//! panic from unwinding across such a non-unwind ABI boundary: when one
+//! reaches it, the process is aborted (Rust Reference, *Panic* chapter,
+//! "unwinding across FFI boundaries"; before Rust 1.81 this was undefined
+//! behavior rather than a guaranteed abort). That language-level abort is
+//! silent about *where* it happened as far as the framework's own
+//! diagnostics are concerned, so a backend wraps the callback body in
+//! `std::panic::catch_unwind`, logs the caught payload through `tracing`,
+//! and then terminates deliberately with `std::process::abort()` — the same
+//! outcome the language would impose, made observable first. Swallowing the
+//! panic and continuing is *not* an option for these boundaries: a panic
+//! mid-`WM_DESTROY` or mid-dispatch leaves framework state torn, and
+//! resuming the message loop over torn state converts one crash into
+//! arbitrary later misbehavior (see `docs/PANIC-POLICY.md` — a panic is a
+//! bug report, never control flow).
+//!
+//! The payload-to-message rule is the pure, decidable part; it lives here,
+//! cfg-free, so the Linux-executed suite pins it (the Win32 shell that
+//! applies it is lint-only in CI).
+
+use std::any::Any;
+
+/// Fallback text for a panic payload that is neither a `&'static str` nor a
+/// `String` (someone used `std::panic::panic_any` with an arbitrary type).
+pub const OPAQUE_PANIC_PAYLOAD: &str = "non-string panic payload";
+
+/// Extracts the human-readable message from a caught panic payload.
+///
+/// `panic!("literal")` produces a `&'static str` payload; `panic!("{x}")`
+/// and every formatted variant produce a `String`; anything else (via
+/// `panic_any`) is opaque and reported as [`OPAQUE_PANIC_PAYLOAD`].
+#[must_use]
+pub fn panic_payload_message(payload: &(dyn Any + Send)) -> &str {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        message
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message
+    } else {
+        OPAQUE_PANIC_PAYLOAD
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+
+    #[test]
+    fn a_literal_panic_payload_is_a_static_str_and_comes_through_verbatim() {
+        let payload =
+            catch_unwind(|| panic!("literal wndproc failure")).expect_err("the closure must panic");
+        assert_eq!(panic_payload_message(&*payload), "literal wndproc failure");
+    }
+
+    #[test]
+    fn a_formatted_panic_payload_is_a_string_and_comes_through_verbatim() {
+        let detail = 42;
+        let payload = catch_unwind(AssertUnwindSafe(|| panic!("failure {detail}")))
+            .expect_err("the closure must panic");
+        assert_eq!(panic_payload_message(&*payload), "failure 42");
+    }
+
+    #[test]
+    fn a_non_string_payload_is_reported_as_opaque_not_dropped_or_panicking() {
+        let payload =
+            catch_unwind(|| std::panic::panic_any(1234_i32)).expect_err("the closure must panic");
+        assert_eq!(panic_payload_message(&*payload), OPAQUE_PANIC_PAYLOAD);
+    }
+}


### PR DESCRIPTION
Closes #597, Closes #598 — two related Win32 correctness issues, one branch, as scoped in the issues.

## #598 — `window_proc` panic boundary

`window_proc` (`extern "system"`) dispatches framework-supplied callbacks that can panic, and it had no panic boundary. Under Rust's rules, a panic that reaches a non-unwind ABI boundary such as `extern "system"` **aborts the process** (Rust Reference, *Panic* chapter, "unwinding across FFI boundaries"); before Rust 1.81 it was **undefined behavior**. That language-imposed abort reports nothing through the framework's own diagnostics.

The fix restructures the wndproc into a thin `catch_unwind` boundary around `window_proc_body` (the untouched message handling):

- **payload**: extracted by the pure rule `shared::panic_boundary::panic_payload_message` (`&'static str` / `String` verbatim, opaque fallback otherwise) and logged via `tracing::error!` together with the message id and HWND;
- **then `std::process::abort()`** — the same outcome the language imposes, made deterministic and observable first. Swallow-and-continue (`DefWindowProcW` fallback) is rejected deliberately, per the issue and `docs/PANIC-POLICY.md`: a panic mid-`WM_DESTROY` or mid-dispatch leaves framework state torn, and pumping further messages over torn state converts one crash into arbitrary later misbehavior. `AssertUnwindSafe` is discharged by the immediate abort: no code can observe torn state.

(The winit backend needs no equivalent production boundary — its callbacks unwind through safe Rust into `run_app` with `Drop`-guard cleanup + `resume_unwind`; its `catch_unwind` sites are test-side. The wndproc cannot `resume_unwind` — that is exactly the forbidden ABI crossing — hence log-then-abort.)

## #597 — `GWLP_USERDATA` cross-thread race / HWND thread-affinity discharge

`unsafe impl Send/Sync for WindowsWindow` did not discharge HWND thread affinity: any thread holding `Arc<WindowsWindow>` could `GetWindowLongPtrW(GWLP_USERDATA)` + deref while the owner thread's `WM_DESTROY` frees the same box — a TOCTOU no zero-before-free ordering can close. Now discharged structurally, following the a11y bridge precedent (owner-thread check + safe fallback off-thread) and Win32's actual rules:

- **`with_window_context` gate** (platform.rs): every context deref first checks — via `GetWindowThreadProcessId(hwnd)` vs `GetCurrentThreadId()` — that the caller *is* the owning thread (MSDN: the window procedure, including `WM_DESTROY`, runs on the creating thread; so on that thread the deref is serialized with the only freeing path), that the live window is of our registered class (`GetClassNameW` — closes the recycled-handle-deref hole), and that the slot is non-null. Any refusal is traced and answered with a safe fallback (`false`, empty modifiers, `CursorError`), never a deref.
- **`teardown_route`**: `DestroyWindow` only on the owning thread ("a thread cannot use DestroyWindow to destroy a window created by a different thread" — MSDN `DestroyWindow` remarks); from a foreign thread, `close()`/last-`Drop` post `WM_CLOSE` via `PostMessageW`, the documented cross-thread mechanism (marshalled to the owner's queue; note: this path consults the should-close veto — documented at the call site). A foreign-thread `Drop` also skips the UIA subclass unhook (it would race owner-side dispatch); the adapter falls to `WindowsAccessibility`'s existing leak-on-wrong-thread guard.
- Converted derefs: `toggle_fullscreen(_for_hwnd)`, `is_fullscreen`, `should_skip_render`, `set_cursor`, `window_bounds`, `is_hovered`, `modifiers`, `close`, `Drop`. `appearance()` dropped its context read entirely (it read no framework state; DWM answers thread-safely, failing to the same `Light` default).
- **Honestly stated residuals** (documented in-code, not claimed closed): same-thread reentrancy (a callback that closes its own window mid-dispatch — pre-existing, unchanged) and the `window_handle()` HWND-lifetime gap (a borrowed `WindowHandle` outliving the native window), which is a different contract from this race.

## Executable vs lint coverage — the honest split

No Windows CI executes this backend; `cross-typecheck` (clippy, no link, no tests) is its only gate. Per the repo's established pattern, every decidable rule is extracted into cfg-free helpers with tests that **execute on Linux**:

- `shared/hwnd_affinity.rs` — access-verdict classification (gone / foreign-thread / foreign-class / empty-slot, with pinned precedence) and teardown routing; 7 tests.
- `shared/panic_boundary.rs` — payload-to-message extraction, pinned against *real* `catch_unwind` payloads; 3 tests.

What remains **lint-only** (typed-checked, never executed anywhere): the Win32 shells — the `catch_unwind`/abort wiring in `window_proc`, the OS queries feeding the gates (`GetWindowThreadProcessId`, `GetClassNameW`, `GetWindowLongPtrW`), `PostMessageW` teardown delivery, and every converted call site. Those have not run on a real Windows machine.

## Gates

- `cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings` — clean (also with `--features a11y`, mirroring CI's cross-typecheck line)
- `FLUI_HEADLESS=1 xvfb-run -a cargo nextest run -p flui-platform --locked --all-features` — 249 passed, 8 skipped
- `just ci` — exit 0 (foreground, full chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM