### PR TITLE
feat(log): private-by-default field classification for the device sinks

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -509,10 +509,11 @@ Correctness comes first, followed by measurement, then optimization.
   default: `flui-log` redacts dynamic values — strings, `Debug`/`Display`
   renderings, errors — to `<private>` unless the field name ends in `.public`;
   a name ending in `.private` redacts a scalar (for example a precise
-  coordinate). Scalars and the message publish by default, so a
+  coordinate). Scalars and a native `tracing` message publish by default, so a
   machine-readable or user-provided value belongs in a field — interpolating it
-  into the message bypasses classification. See `flui_log::backend::privacy`
-  for the full contract.
+  into the message bypasses classification. A message bridged from the `log`
+  facade is third-party text and redacts unconditionally. See
+  `flui_log::backend::privacy` for the full contract.
 - Native logging backends MUST document privacy and field mapping.
 - Correlation fields name the real owner or operation an event belongs to, and
   MUST NOT encode the runtime's internal topology. A field name is read by log

--- a/STYLE.md
+++ b/STYLE.md
@@ -505,6 +505,14 @@ Correctness comes first, followed by measurement, then optimization.
   - `trace`: high-volume per-event or per-frame detail.
 - Do not log secrets, clipboard contents, text input, file contents, access
   tokens, or precise location by default.
+- On device sinks (logcat, Apple unified logging) fields are private by
+  default: `flui-log` redacts dynamic values — strings, `Debug`/`Display`
+  renderings, errors — to `<private>` unless the field name ends in `.public`;
+  a name ending in `.private` redacts a scalar (for example a precise
+  coordinate). Scalars and the message publish by default, so a
+  machine-readable or user-provided value belongs in a field — interpolating it
+  into the message bypasses classification. See `flui_log::backend::privacy`
+  for the full contract.
 - Native logging backends MUST document privacy and field mapping.
 - Correlation fields name the real owner or operation an event belongs to, and
   MUST NOT encode the runtime's internal topology. A field name is read by log

--- a/crates/flui-log/AGENTS.md
+++ b/crates/flui-log/AGENTS.md
@@ -66,13 +66,18 @@ responsibility, not a wider one.
   scoped subscriber anywhere in the process would convince `Auto` that the global
   slot was taken forever. `set_global_default`'s own `Result` is the exact
   signal, with no window between the question and the answer.
-- **A tracing field is world-readable on a device.** Apple's unified log and
-  logcat publish every field verbatim; `os_log`'s `%{private}` has nothing to
-  redact because `tracing-oslog` pre-formats. Log a length, a count, an
-  identifier, or a discriminant — never a rendered string, a user-chosen path,
-  or an announcement. Enforcing this in the type system is
-  [#572](https://github.com/vanyastaff/flui/issues/572); until then it is a
-  convention a reviewer has to hold.
+- **Device sinks are private by default — do not construct one bare.** The
+  logcat and Apple sinks only exist wrapped in `backend::redact::RedactLayer`,
+  which replaces every dynamic value (string, `Debug`/`Display` rendering,
+  error) with `<private>` unless the field name ends in `.public`, and every
+  scalar whose name ends in `.private`. The message always publishes, so user
+  content stays in fields, never interpolated into the sentence. The
+  classification (`backend::privacy`) is Apple's own `%{public}`/`%{private}`
+  default ported to both platforms; it and the redaction stage are compiled and
+  unit-tested on every target. A new device sink joins the contract by being
+  constructed wrapped — adding one bare reopens the leak #571/#572 closed.
+  Desktop and web-console sinks are developer-facing and deliberately publish
+  verbatim.
 - **macOS is a desktop.** It keeps the `fmt` backend; unified logging there
   would make `cargo run` print nothing. `os_log` on macOS is opt-in through the
   `apple-unified-logging` feature.

--- a/crates/flui-log/AGENTS.md
+++ b/crates/flui-log/AGENTS.md
@@ -70,8 +70,10 @@ responsibility, not a wider one.
   logcat and Apple sinks only exist wrapped in `backend::redact::RedactLayer`,
   which replaces every dynamic value (string, `Debug`/`Display` rendering,
   error) with `<private>` unless the field name ends in `.public`, and every
-  scalar whose name ends in `.private`. The message always publishes, so user
-  content stays in fields, never interpolated into the sentence. The
+  scalar whose name ends in `.private`. A native `tracing` message publishes —
+  so user content stays in fields, never interpolated into the sentence — but a
+  message bridged from the `log` facade redacts: it is a third party's fully
+  interpolated string, and no marker can vouch for it. The
   classification (`backend::privacy`) is Apple's own `%{public}`/`%{private}`
   default ported to both platforms; it and the redaction stage are compiled and
   unit-tested on every target. A new device sink joins the contract by being

--- a/crates/flui-log/README.md
+++ b/crates/flui-log/README.md
@@ -88,7 +88,9 @@ Logcat and the Apple unified log are archives readable outside the application,
 so both device sinks sit behind a redaction stage and **fields are private by
 default**: a dynamic value (string, `Debug`/`Display` rendering, error) is
 replaced by `<private>` unless its field name ends in `.public`; a scalar is
-published unless its name ends in `.private`; the message always publishes.
+published unless its name ends in `.private`; a native `tracing` message
+publishes, while a message bridged from the `log` facade (a third party's fully
+interpolated string) is redacted.
 
 ```rust,ignore
 tracing::info!(

--- a/crates/flui-log/README.md
+++ b/crates/flui-log/README.md
@@ -82,16 +82,32 @@ Rust targets to categories at all: the application subsystem and the stable
 `flui` category are fixed for the sink, while `log.target` remains part of the
 rendered fields.
 
-### Apple privacy
+### Privacy on device sinks
 
-`tracing-oslog` renders each event into one already-formatted string, so every
-field FLUI emits is **public** in the unified log — `%{private}` redaction
-applies to interpolated arguments and there are none. Keep secrets and personal
-data out of tracing fields on Apple platforms.
+Logcat and the Apple unified log are archives readable outside the application,
+so both device sinks sit behind a redaction stage and **fields are private by
+default**: a dynamic value (string, `Debug`/`Display` rendering, error) is
+replaced by `<private>` unless its field name ends in `.public`; a scalar is
+published unless its name ends in `.private`; the message always publishes.
 
-This is a convention today, not a contract enforced by the type system. Making
-it one — private by default, backend-redacted — is tracked in
-[#572](https://github.com/vanyastaff/flui/issues/572).
+```rust,ignore
+tracing::info!(
+    frame = 7_u64,             // scalar: published
+    path = %path.display(),    // dynamic: `<private>` in the device log
+    phase.public = "commit",   // dynamic, opted in: published
+    "frame committed",         // message: published
+);
+```
+
+The model is Apple's own — the unified log redacts dynamic strings and objects
+by default and publishes scalars, overridable per value with
+`%{public}`/`%{private}` — applied uniformly to Android, which has no native
+equivalent. Redaction happens in-process before the value reaches the sink, so
+on Apple a private value is never stored at all (stronger than the OS default,
+at the cost of the "Enable-Private-Data" reveal workflow). The full contract,
+including what it deliberately does not cover, lives in
+`flui_log::backend::privacy`. Desktop and web-console sinks are
+developer-facing and publish fields verbatim.
 
 ## Filtering
 

--- a/crates/flui-log/src/backend/mod.rs
+++ b/crates/flui-log/src/backend/mod.rs
@@ -23,9 +23,24 @@
 //! decided by the [`EnvFilter`](crate::filter) alone. A backend that also
 //! filtered would be a second, invisible ceiling that no `RUST_LOG` directive
 //! could raise — see [`crate::filter`] for the regression this prevents.
+//!
+//! # Privacy: device sinks are private by default
+//!
+//! Logcat and the Apple unified log are device archives readable outside the
+//! application, so those two sinks — and only those two — are constructed
+//! behind a redaction stage (the crate-private `redact` module): a dynamic
+//! value (string, `Debug` or `Display` rendering, error) is replaced by
+//! [`privacy::REDACTED_VALUE`]
+//! unless its field name ends in `.public`; a scalar is published unless its
+//! name ends in `.private`; the message is always published. The contract, the
+//! Apple model it is ported from, and its residual holes live in [`privacy`].
+//! The desktop and web-console sinks write to the developer's own terminal or
+//! `DevTools` and publish fields verbatim.
 
 pub(crate) mod logcat;
+pub mod privacy;
 pub(crate) mod record;
+pub(crate) mod redact;
 
 use core::marker::PhantomData;
 
@@ -60,13 +75,13 @@ enum Sink<S> {
     ),
 
     #[cfg(target_os = "android")]
-    Logcat(logcat::LogcatLayer),
+    Logcat(redact::RedactLayer<logcat::LogcatLayer>),
 
     #[cfg(any(
         target_os = "ios",
         all(target_os = "macos", feature = "apple-unified-logging")
     ))]
-    AppleUnified(tracing_oslog::OsLogger),
+    AppleUnified(redact::RedactLayer<tracing_oslog::OsLogger>),
 
     #[cfg(target_arch = "wasm32")]
     WebConsole(tracing_wasm::WASMLayer),
@@ -196,11 +211,21 @@ where
 
     /// Android logcat, tagged with the event target and falling back to the
     /// identity's display name.
+    ///
+    /// # Privacy
+    ///
+    /// Constructed behind the redaction stage: fields are private by default
+    /// and publish only under the rules in [`privacy`]. Android itself has no
+    /// `os_log`-style redaction knob — logcat is a plain line transport — so
+    /// the classification is applied before the line is rendered, and a
+    /// redacted value never leaves the process.
     #[cfg(target_os = "android")]
     #[must_use]
     pub fn logcat(identity: &crate::AppIdentity) -> Self {
         Self {
-            sink: Sink::Logcat(logcat::LogcatLayer::new(identity.display_name())),
+            sink: Sink::Logcat(redact::RedactLayer::new(logcat::LogcatLayer::new(
+                identity.display_name(),
+            ))),
         }
     }
 
@@ -209,20 +234,25 @@ where
     ///
     /// # Privacy
     ///
-    /// `tracing-oslog` renders each event into one already-formatted string and
-    /// hands that to `os_log_with_type`, so **every field FLUI emits is public
-    /// in the unified log**: `os_log`'s `%{private}` redaction applies to
-    /// interpolated arguments, and there are none. Treat a tracing field on an
-    /// Apple platform as readable by anyone holding the device's log archive,
-    /// and keep secrets and personal data out of them.
+    /// Constructed behind the redaction stage: fields are **private by
+    /// default** and publish only under the rules in [`privacy`] — a scalar
+    /// or a field whose name ends in `.public` is published, everything else
+    /// reaches the unified log as `<private>`. The classification is enforced
+    /// per event, in-process, before `tracing-oslog` renders; a producer does
+    /// not have to know this sink is installed, and nothing a producer forgets
+    /// to mark can land in the log archive verbatim.
     ///
-    /// This is a convention, not yet a contract: nothing fails to build when a
-    /// producer records a rendered string or a user-chosen path. Making the
-    /// distinction typed — private by default, with the backend redacting
-    /// rather than publishing what it was not told about — is tracked in
-    /// <https://github.com/vanyastaff/flui/issues/572>, which also records why
-    /// it likely means leaving `tracing-oslog` behind. Until that lands, the
-    /// value must not be recorded in the first place.
+    /// One deliberate divergence from native `os_log` redaction: the OS
+    /// substitutes `<private>` at *display* time and can reveal the stored
+    /// value under the "Enable-Private-Data" developer profile, whereas this
+    /// stage redacts before the value ever reaches `os_log_with_type`
+    /// (`tracing-oslog` collapses each event into one pre-formatted
+    /// `%{public}s` argument, which forecloses per-value `%{private}`
+    /// specifiers). The value is therefore never stored — strictly stronger
+    /// privacy, at the cost of that reveal workflow. Reclaiming it would take
+    /// a FLUI-owned `os_log` shim that keeps public and private renderings as
+    /// separate format arguments; the classification layer here is
+    /// transport-agnostic on purpose so such a sink could adopt it unchanged.
     ///
     /// # Grouping
     ///
@@ -245,10 +275,10 @@ where
     #[must_use]
     pub fn apple_unified_logging(identity: &crate::AppIdentity) -> Self {
         Self {
-            sink: Sink::AppleUnified(tracing_oslog::OsLogger::new(
+            sink: Sink::AppleUnified(redact::RedactLayer::new(tracing_oslog::OsLogger::new(
                 identity.apple_subsystem(),
                 crate::identity::APPLE_CATEGORY,
-            )),
+            ))),
         }
     }
 
@@ -281,15 +311,17 @@ fn default_sink<S>(config: &crate::LogConfig) -> Sink<S> {
 
 #[cfg(target_os = "android")]
 fn default_sink<S>(config: &crate::LogConfig) -> Sink<S> {
-    Sink::Logcat(logcat::LogcatLayer::new(config.identity().display_name()))
+    Sink::Logcat(redact::RedactLayer::new(logcat::LogcatLayer::new(
+        config.identity().display_name(),
+    )))
 }
 
 #[cfg(target_os = "ios")]
 fn default_sink<S>(config: &crate::LogConfig) -> Sink<S> {
-    Sink::AppleUnified(tracing_oslog::OsLogger::new(
+    Sink::AppleUnified(redact::RedactLayer::new(tracing_oslog::OsLogger::new(
         config.identity().apple_subsystem(),
         crate::identity::APPLE_CATEGORY,
-    ))
+    )))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/flui-log/src/backend/mod.rs
+++ b/crates/flui-log/src/backend/mod.rs
@@ -32,7 +32,9 @@
 //! value (string, `Debug` or `Display` rendering, error) is replaced by
 //! [`privacy::REDACTED_VALUE`]
 //! unless its field name ends in `.public`; a scalar is published unless its
-//! name ends in `.private`; the message is always published. The contract, the
+//! name ends in `.private`; a native `tracing` message is published, while a
+//! message bridged from the `log` facade is third-party interpolated text and
+//! is redacted. The contract, the
 //! Apple model it is ported from, and its residual holes live in [`privacy`].
 //! The desktop and web-console sinks write to the developer's own terminal or
 //! `DevTools` and publish fields verbatim.

--- a/crates/flui-log/src/backend/privacy.rs
+++ b/crates/flui-log/src/backend/privacy.rs
@@ -1,0 +1,232 @@
+//! Which `tracing` fields a device sink may publish, and which it must redact.
+//!
+//! # Why a classification exists
+//!
+//! Android's logcat and Apple's unified log are *archives*: anyone holding the
+//! device (or a sysdiagnose) can read every line ever written to them. A
+//! `tracing` field that reaches one of those sinks verbatim is therefore
+//! world-readable, which is the wrong default for a framework that routinely
+//! sits between user content and the screen.
+//!
+//! Apple's own logging API answers this with per-value privacy: *"By default,
+//! the system doesn't redact integer, floating-point and Boolean values, but it
+//! does redact the contents of dynamic strings and complex dynamic objects"*,
+//! overridable per value with `%{public}` / `%{private}` (or `privacy: .public`
+//! in Swift) — see "Generating Log Messages from Your Code" in the `os`
+//! framework documentation. Android has no equivalent knob: logcat is a plain
+//! line transport, so whatever policy exists has to be applied *before* the
+//! line is written.
+//!
+//! FLUI adopts Apple's model as the cross-platform contract and enforces it in
+//! front of **both** device sinks, so a producer states a field's privacy once,
+//! in the field name, without knowing which backend is installed:
+//!
+//! | Recorded as | Default | Override |
+//! |---|---|---|
+//! | scalar (`i64`, `u64`, `i128`, `u128`, `f64`, `bool`) | published | `.private` suffix redacts |
+//! | dynamic (`&str`, `Debug`, `Display`, errors, bytes) | redacted to [`REDACTED_VALUE`] | `.public` suffix publishes |
+//! | the `message` field | published | — |
+//!
+//! ```rust
+//! tracing::info!(
+//!     frame = 7_u64,                    // scalar: published
+//!     path = %std::path::Path::new("/home/u/doc.txt").display(), // dynamic: redacted
+//!     phase.public = "commit",          // dynamic, opted in: published
+//!     latitude.private = 52.52_f64,     // scalar, opted out: redacted
+//!     "frame committed",                // message: published
+//! );
+//! ```
+//!
+//! # The message is the format string
+//!
+//! Apple redacts interpolated values but always publishes the compile-time
+//! format string around them. `tracing` pre-formats the message at the
+//! callsite, so the two cannot be separated here; the message is treated as
+//! the format-string analogue and published verbatim. That leaves one residual
+//! hole this module cannot close: interpolating a user-provided value *into
+//! the message* (`info!("loading {path}")`) publishes it. STYLE.md §17 already
+//! requires machine-readable values to be structured fields rather than message
+//! interpolations, which is exactly what keeps this hole theoretical.
+//!
+//! # Marker mechanics
+//!
+//! The marker is a trailing dotted segment of the field name (`path.public`,
+//! `latitude.private`), because the field name is the only channel that
+//! survives `tracing`'s field system unchanged from an instrumentation site in
+//! a library crate — which depends on `tracing` alone — to a sink assembled
+//! here. Names render as written; the marker is not stripped, so the
+//! classification decision stays visible in the log line. A field literally
+//! named `public` or `private` (no dot) carries no marker.
+//!
+//! # What is *not* classified
+//!
+//! The desktop and web-console sinks write to the developer's own terminal or
+//! `DevTools`, not to a device archive, and publish fields verbatim; host-side
+//! tooling (`flui-build`, `flui-cli`) may keep logging full paths. The four
+//! `log.*` normalization fields the `log` bridge attaches (`log.target`,
+//! `log.module_path`, `log.file`, `log.line`) name compile-time source
+//! locations already embedded in the binary, and the logcat tag is derived
+//! from `log.target`; they are published so bridged records keep grouping
+//! correctly.
+
+/// Whether a device sink may publish a field's value.
+///
+/// The vocabulary is Apple's (`%{public}` / `%{private}`), reused verbatim so
+/// the cross-platform contract and the platform mechanism it maps onto read as
+/// one thing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FieldPrivacy {
+    /// The value is published verbatim.
+    Public,
+    /// The value is replaced by [`REDACTED_VALUE`] before it reaches the sink.
+    Private,
+}
+
+/// How a field's value arrived at the sink, per `tracing`'s `Visit` protocol.
+///
+/// This is the axis Apple's default turns on: scalars are safe to publish
+/// because they cannot embed free-form user content; anything rendered from a
+/// string or a `Debug`/`Display` implementation can.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FieldKind {
+    /// A numeric or boolean value (`record_i64`, `record_u64`, `record_i128`,
+    /// `record_u128`, `record_f64`, `record_bool`).
+    Scalar,
+    /// A string, `Debug`/`Display` rendering, error, or byte payload — every
+    /// `Visit` callback that can carry free-form text.
+    Dynamic,
+}
+
+/// Trailing field-name marker that publishes a dynamic value.
+pub const PUBLIC_FIELD_SUFFIX: &str = ".public";
+
+/// Trailing field-name marker that redacts a scalar value.
+pub const PRIVATE_FIELD_SUFFIX: &str = ".private";
+
+/// What a redacted value renders as, matching Apple's own placeholder so a
+/// reader of either platform's log recognises it.
+pub const REDACTED_VALUE: &str = "<private>";
+
+/// The event field `tracing`'s macros store the formatted message under.
+pub(crate) const MESSAGE_FIELD: &str = "message";
+
+/// Normalization fields attached by the `log` compatibility bridge.
+///
+/// They carry compile-time source locations (already embedded in the binary by
+/// `file!()`/`module_path!()`) and the logcat layer derives its tag from
+/// `log.target`, so redacting them would break record grouping while hiding
+/// nothing that is not in the executable.
+const LOG_BRIDGE_FIELDS: [&str; 4] = ["log.target", "log.module_path", "log.file", "log.line"];
+
+impl FieldPrivacy {
+    /// Classify one field by its name and the kind of value recorded for it.
+    ///
+    /// An explicit marker wins over the kind default, `.private` over
+    /// `.public`; the `message` field and the `log.*` bridge fields are always
+    /// published (see the module docs for why).
+    #[must_use]
+    pub fn classify(name: &str, kind: FieldKind) -> Self {
+        if name == MESSAGE_FIELD || LOG_BRIDGE_FIELDS.contains(&name) {
+            return Self::Public;
+        }
+        if name.ends_with(PRIVATE_FIELD_SUFFIX) {
+            return Self::Private;
+        }
+        if name.ends_with(PUBLIC_FIELD_SUFFIX) {
+            return Self::Public;
+        }
+        match kind {
+            FieldKind::Scalar => Self::Public,
+            FieldKind::Dynamic => Self::Private,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_values_are_private_by_default() {
+        assert_eq!(
+            FieldPrivacy::classify("path", FieldKind::Dynamic),
+            FieldPrivacy::Private
+        );
+    }
+
+    #[test]
+    fn scalar_values_are_public_by_default() {
+        assert_eq!(
+            FieldPrivacy::classify("frame", FieldKind::Scalar),
+            FieldPrivacy::Public
+        );
+    }
+
+    #[test]
+    fn a_public_marker_publishes_a_dynamic_value() {
+        assert_eq!(
+            FieldPrivacy::classify("phase.public", FieldKind::Dynamic),
+            FieldPrivacy::Public
+        );
+    }
+
+    #[test]
+    fn a_private_marker_redacts_a_scalar() {
+        assert_eq!(
+            FieldPrivacy::classify("latitude.private", FieldKind::Scalar),
+            FieldPrivacy::Private
+        );
+    }
+
+    #[test]
+    fn the_private_marker_wins_over_the_public_marker() {
+        // `a.public.private` ends with `.private`, and only the trailing
+        // segment is the marker; deny beats allow when both could match.
+        assert_eq!(
+            FieldPrivacy::classify("a.public.private", FieldKind::Scalar),
+            FieldPrivacy::Private
+        );
+    }
+
+    #[test]
+    fn the_message_field_is_always_public() {
+        assert_eq!(
+            FieldPrivacy::classify(MESSAGE_FIELD, FieldKind::Dynamic),
+            FieldPrivacy::Public
+        );
+    }
+
+    #[test]
+    fn a_field_literally_named_public_carries_no_marker() {
+        // The marker is the *dotted suffix*; a bare name is just a name, and a
+        // dynamic value under it stays private.
+        assert_eq!(
+            FieldPrivacy::classify("public", FieldKind::Dynamic),
+            FieldPrivacy::Private
+        );
+        assert_eq!(
+            FieldPrivacy::classify("private", FieldKind::Scalar),
+            FieldPrivacy::Public
+        );
+    }
+
+    #[test]
+    fn log_bridge_normalization_fields_are_published() {
+        for name in ["log.target", "log.module_path", "log.file", "log.line"] {
+            assert_eq!(
+                FieldPrivacy::classify(name, FieldKind::Dynamic),
+                FieldPrivacy::Public,
+                "bridge field `{name}` must stay publishable or bridged records lose grouping"
+            );
+        }
+    }
+
+    #[test]
+    fn a_dotted_field_that_is_not_a_marker_keeps_the_kind_default() {
+        assert_eq!(
+            FieldPrivacy::classify("log.password", FieldKind::Dynamic),
+            FieldPrivacy::Private,
+            "only the four exact bridge names are exempt, not the `log.` prefix"
+        );
+    }
+}

--- a/crates/flui-log/src/backend/privacy.rs
+++ b/crates/flui-log/src/backend/privacy.rs
@@ -25,7 +25,8 @@
 //! |---|---|---|
 //! | scalar (`i64`, `u64`, `i128`, `u128`, `f64`, `bool`) | published | `.private` suffix redacts |
 //! | dynamic (`&str`, `Debug`, `Display`, errors, bytes) | redacted to [`REDACTED_VALUE`] | `.public` suffix publishes |
-//! | the `message` field | published | — |
+//! | `message`, [native](EventOrigin::Native) `tracing` event | published | — |
+//! | `message`, [bridged](EventOrigin::LogBridge) from the `log` facade | redacted | — (deliberately none) |
 //!
 //! ```rust
 //! tracing::info!(
@@ -37,16 +38,32 @@
 //! );
 //! ```
 //!
-//! # The message is the format string
+//! # The message is the format string — for first-party events only
 //!
 //! Apple redacts interpolated values but always publishes the compile-time
 //! format string around them. `tracing` pre-formats the message at the
-//! callsite, so the two cannot be separated here; the message is treated as
-//! the format-string analogue and published verbatim. That leaves one residual
-//! hole this module cannot close: interpolating a user-provided value *into
-//! the message* (`info!("loading {path}")`) publishes it. STYLE.md §17 already
-//! requires machine-readable values to be structured fields rather than message
-//! interpolations, which is exactly what keeps this hole theoretical.
+//! callsite, so the two cannot be separated here; a **native** `tracing`
+//! message is treated as the format-string analogue and published verbatim.
+//! That leaves one residual hole this module cannot close: first-party code
+//! interpolating a user-provided value *into the message*
+//! (`info!("loading {path}")`) publishes it. STYLE.md §17 already requires
+//! machine-readable values to be structured fields rather than message
+//! interpolations, which is what keeps this hole theoretical *for code this
+//! workspace reviews*.
+//!
+//! No such rule binds a dependency. A record arriving through the `log`
+//! compatibility bridge is a third party's `log::info!("loading {}", path)`
+//! with the interpolation already flattened into `message` — free-form text
+//! from code that cannot carry a marker and was never reviewed against
+//! STYLE.md. Native `os_log` would have redacted exactly that dynamic string,
+//! so a bridged message is classified [`Private`](FieldPrivacy::Private), with
+//! deliberately no opt-out: the third party cannot classify its own text, and
+//! the embedding application should not vouch for text it does not produce.
+//! The record itself still ships — its level, its `log.*` provenance fields,
+//! and therefore its logcat tag / target grouping all publish — so a device
+//! log still shows *that* `wgpu` warned, just not the un-reviewable sentence.
+//! A developer who needs the sentences has the desktop sinks, which do not
+//! redact.
 //!
 //! # Marker mechanics
 //!
@@ -97,6 +114,26 @@ pub enum FieldKind {
     Dynamic,
 }
 
+/// Where an event entered `tracing`.
+///
+/// The axis decides only the `message` field's default: a native message is
+/// the compile-time sentence a reviewed callsite wrote; a bridged message is a
+/// third party's fully interpolated string. Named fields classify identically
+/// under both origins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EventOrigin {
+    /// Emitted through `tracing`'s own macros. The callsite can carry field
+    /// markers and is subject to this workspace's fields-not-messages rule, so
+    /// its message publishes.
+    Native,
+    /// Forwarded from the `log` facade by the compatibility bridge
+    /// (`tracing_log::LogTracer`). The message is un-reviewable third-party
+    /// text with its interpolations already flattened in, so it redacts —
+    /// with no marker escape, because the third party cannot classify its own
+    /// text and the embedder should not vouch for text it does not produce.
+    LogBridge,
+}
+
 /// Trailing field-name marker that publishes a dynamic value.
 pub const PUBLIC_FIELD_SUFFIX: &str = ".public";
 
@@ -119,14 +156,22 @@ pub(crate) const MESSAGE_FIELD: &str = "message";
 const LOG_BRIDGE_FIELDS: [&str; 4] = ["log.target", "log.module_path", "log.file", "log.line"];
 
 impl FieldPrivacy {
-    /// Classify one field by its name and the kind of value recorded for it.
+    /// Classify one field by its name, the kind of value recorded for it, and
+    /// the origin of the event carrying it.
     ///
     /// An explicit marker wins over the kind default, `.private` over
-    /// `.public`; the `message` field and the `log.*` bridge fields are always
+    /// `.public`. The `message` field publishes for a native event and
+    /// redacts for a bridged one; the `log.*` bridge fields are always
     /// published (see the module docs for why).
     #[must_use]
-    pub fn classify(name: &str, kind: FieldKind) -> Self {
-        if name == MESSAGE_FIELD || LOG_BRIDGE_FIELDS.contains(&name) {
+    pub fn classify(name: &str, kind: FieldKind, origin: EventOrigin) -> Self {
+        if name == MESSAGE_FIELD {
+            return match origin {
+                EventOrigin::Native => Self::Public,
+                EventOrigin::LogBridge => Self::Private,
+            };
+        }
+        if LOG_BRIDGE_FIELDS.contains(&name) {
             return Self::Public;
         }
         if name.ends_with(PRIVATE_FIELD_SUFFIX) {
@@ -149,7 +194,7 @@ mod tests {
     #[test]
     fn dynamic_values_are_private_by_default() {
         assert_eq!(
-            FieldPrivacy::classify("path", FieldKind::Dynamic),
+            FieldPrivacy::classify("path", FieldKind::Dynamic, EventOrigin::Native),
             FieldPrivacy::Private
         );
     }
@@ -157,7 +202,7 @@ mod tests {
     #[test]
     fn scalar_values_are_public_by_default() {
         assert_eq!(
-            FieldPrivacy::classify("frame", FieldKind::Scalar),
+            FieldPrivacy::classify("frame", FieldKind::Scalar, EventOrigin::Native),
             FieldPrivacy::Public
         );
     }
@@ -165,7 +210,7 @@ mod tests {
     #[test]
     fn a_public_marker_publishes_a_dynamic_value() {
         assert_eq!(
-            FieldPrivacy::classify("phase.public", FieldKind::Dynamic),
+            FieldPrivacy::classify("phase.public", FieldKind::Dynamic, EventOrigin::Native),
             FieldPrivacy::Public
         );
     }
@@ -173,7 +218,7 @@ mod tests {
     #[test]
     fn a_private_marker_redacts_a_scalar() {
         assert_eq!(
-            FieldPrivacy::classify("latitude.private", FieldKind::Scalar),
+            FieldPrivacy::classify("latitude.private", FieldKind::Scalar, EventOrigin::Native),
             FieldPrivacy::Private
         );
     }
@@ -183,17 +228,45 @@ mod tests {
         // `a.public.private` ends with `.private`, and only the trailing
         // segment is the marker; deny beats allow when both could match.
         assert_eq!(
-            FieldPrivacy::classify("a.public.private", FieldKind::Scalar),
+            FieldPrivacy::classify("a.public.private", FieldKind::Scalar, EventOrigin::Native),
             FieldPrivacy::Private
         );
     }
 
     #[test]
-    fn the_message_field_is_always_public() {
+    fn a_native_message_is_public() {
         assert_eq!(
-            FieldPrivacy::classify(MESSAGE_FIELD, FieldKind::Dynamic),
+            FieldPrivacy::classify(MESSAGE_FIELD, FieldKind::Dynamic, EventOrigin::Native),
             FieldPrivacy::Public
         );
+    }
+
+    #[test]
+    fn a_bridged_message_is_private() {
+        // A `log`-bridge message is a third party's fully interpolated string;
+        // the fields-not-messages rule does not bind a dependency.
+        assert_eq!(
+            FieldPrivacy::classify(MESSAGE_FIELD, FieldKind::Dynamic, EventOrigin::LogBridge),
+            FieldPrivacy::Private
+        );
+    }
+
+    #[test]
+    fn named_fields_classify_identically_under_both_origins() {
+        for origin in [EventOrigin::Native, EventOrigin::LogBridge] {
+            assert_eq!(
+                FieldPrivacy::classify("frame", FieldKind::Scalar, origin),
+                FieldPrivacy::Public
+            );
+            assert_eq!(
+                FieldPrivacy::classify("path", FieldKind::Dynamic, origin),
+                FieldPrivacy::Private
+            );
+            assert_eq!(
+                FieldPrivacy::classify("log.target", FieldKind::Dynamic, origin),
+                FieldPrivacy::Public
+            );
+        }
     }
 
     #[test]
@@ -201,11 +274,11 @@ mod tests {
         // The marker is the *dotted suffix*; a bare name is just a name, and a
         // dynamic value under it stays private.
         assert_eq!(
-            FieldPrivacy::classify("public", FieldKind::Dynamic),
+            FieldPrivacy::classify("public", FieldKind::Dynamic, EventOrigin::Native),
             FieldPrivacy::Private
         );
         assert_eq!(
-            FieldPrivacy::classify("private", FieldKind::Scalar),
+            FieldPrivacy::classify("private", FieldKind::Scalar, EventOrigin::Native),
             FieldPrivacy::Public
         );
     }
@@ -214,7 +287,7 @@ mod tests {
     fn log_bridge_normalization_fields_are_published() {
         for name in ["log.target", "log.module_path", "log.file", "log.line"] {
             assert_eq!(
-                FieldPrivacy::classify(name, FieldKind::Dynamic),
+                FieldPrivacy::classify(name, FieldKind::Dynamic, EventOrigin::Native),
                 FieldPrivacy::Public,
                 "bridge field `{name}` must stay publishable or bridged records lose grouping"
             );
@@ -224,7 +297,7 @@ mod tests {
     #[test]
     fn a_dotted_field_that_is_not_a_marker_keeps_the_kind_default() {
         assert_eq!(
-            FieldPrivacy::classify("log.password", FieldKind::Dynamic),
+            FieldPrivacy::classify("log.password", FieldKind::Dynamic, EventOrigin::Native),
             FieldPrivacy::Private,
             "only the four exact bridge names are exempt, not the `log.` prefix"
         );

--- a/crates/flui-log/src/backend/record.rs
+++ b/crates/flui-log/src/backend/record.rs
@@ -7,6 +7,10 @@
 //! lived inside a `cfg(target_os = "android")` module, which meant its tests
 //! never compiled anywhere (they called a `tracing::field::Field::new` that no
 //! released `tracing-core` exposes).
+//!
+//! This renderer holds no privacy opinion: field classification happens
+//! upstream in [`super::redact`], which the shipped Android sink sits behind,
+//! so a private value arrives here already replaced by the placeholder.
 
 // Only the Android sink renders fields this way in a shipped build; the unit
 // tests exercise it on every target. Same reasoning as `logcat.rs`.

--- a/crates/flui-log/src/backend/redact.rs
+++ b/crates/flui-log/src/backend/redact.rs
@@ -1,0 +1,758 @@
+//! The redaction stage that sits in front of every device sink.
+//!
+//! [`RedactLayer`] wraps a sink and re-records events, span attributes, and
+//! late span records with each field classified by
+//! [`FieldPrivacy::classify`](super::privacy::FieldPrivacy::classify) before
+//! the sink sees them. The sink itself stays policy-free: logcat and the Apple
+//! layer render whatever values arrive, and what arrives for a private field
+//! is the [`REDACTED_VALUE`] placeholder rather than the value.
+//!
+//! Enforcing the policy *here*, rather than inside each sink's renderer, is
+//! what makes it one mechanism instead of a per-sink convention: a new device
+//! sink gets the contract by being constructed wrapped, and a field can only
+//! bypass classification by not being a `tracing` field at all.
+//!
+//! When nothing in a payload needs redaction the original event or attribute
+//! set is forwarded untouched — typed values, message `Arguments`, and parent
+//! linkage all reach the sink exactly as recorded. Synthesis happens only on
+//! the paths where a value must be replaced, and the synthesized payload keeps
+//! the original callsite metadata, field order, scalar types, and explicit /
+//! contextual / root parent kind.
+//!
+//! Compiled on **every** target for the same reason as [`super::record`]: only
+//! the sinks it wraps are target-gated, so the behaviour is covered by unit
+//! tests that run on the ordinary CI host.
+
+// Wrapped only by the Android and Apple sinks in a shipped build; the unit
+// tests exercise it on every target. Same reasoning as `logcat.rs`.
+#![cfg_attr(
+    not(any(
+        target_os = "android",
+        target_os = "ios",
+        all(target_os = "macos", feature = "apple-unified-logging")
+    )),
+    allow(
+        dead_code,
+        reason = "compiled on every target so the logic stays testable"
+    )
+)]
+
+use core::fmt;
+
+use tracing::field::{DebugValue, Field, Value, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::subscriber::Interest;
+use tracing::{Event, Metadata, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+use super::privacy::{FieldKind, FieldPrivacy, REDACTED_VALUE};
+
+/// Capacity of the synthesized value set.
+///
+/// `tracing`'s macros stop well short of this many fields per callsite. If a
+/// hand-built event with a redacted field somehow exceeds it, the tail fields
+/// are dropped from the forwarded payload — the same shape of loss policy as
+/// logcat's NUL truncation: losing the tail is a smaller loss than losing the
+/// event, and forwarding the original instead would leak what was meant to be
+/// redacted.
+const MAX_FIELDS: usize = 32;
+
+/// Redacts private fields before `inner` can observe them.
+///
+/// See the module docs for the contract. The wrapper forwards every other
+/// `Layer` callback verbatim, so filtering, span lifecycle, and downcasting
+/// behave as if the sink were installed bare.
+pub(crate) struct RedactLayer<L> {
+    inner: L,
+}
+
+impl<L> RedactLayer<L> {
+    pub(crate) fn new(inner: L) -> Self {
+        Self { inner }
+    }
+}
+
+// Manual impl: the wrapped sink (e.g. `tracing_oslog::OsLogger`) does not
+// implement `Debug`, and the wrapper's identity is what matters here.
+impl<L> fmt::Debug for RedactLayer<L> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactLayer")
+            .finish_non_exhaustive()
+    }
+}
+
+/// A rendered stand-in that prints without `Debug` quoting.
+///
+/// Public dynamic values that originally arrived through `record_debug` are
+/// replayed through `record_debug` again via this adapter, so a sink cannot
+/// tell redaction was in the path; replaying them as strings would change the
+/// sink's quoting.
+struct PreRendered(String);
+
+impl fmt::Debug for PreRendered {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// One field's value, owned so it can outlive the borrowed visit and be
+/// replayed into the synthesized value set with its original `Visit` callback.
+enum Recorded {
+    I64(i64),
+    I128(i128),
+    U64(u64),
+    U128(u128),
+    F64(f64),
+    Bool(bool),
+    /// Public text that arrived through `record_str`.
+    Str(String),
+    /// Public text that arrived through `record_debug` (including the
+    /// message), or the redaction placeholder.
+    Debugged(DebugValue<PreRendered>),
+}
+
+impl Recorded {
+    fn redacted() -> Self {
+        Self::Debugged(tracing::field::debug(PreRendered(
+            REDACTED_VALUE.to_owned(),
+        )))
+    }
+
+    fn as_value(&self) -> &dyn Value {
+        match self {
+            Self::I64(value) => value,
+            Self::I128(value) => value,
+            Self::U64(value) => value,
+            Self::U128(value) => value,
+            Self::F64(value) => value,
+            Self::Bool(value) => value,
+            Self::Str(value) => value,
+            Self::Debugged(value) => value,
+        }
+    }
+}
+
+/// Visits a payload once, classifying every field.
+#[derive(Default)]
+struct ClassifyingVisitor {
+    entries: Vec<(Field, Recorded)>,
+    redacted_any: bool,
+}
+
+impl ClassifyingVisitor {
+    fn scalar(&mut self, field: &Field, value: Recorded) {
+        let recorded = match FieldPrivacy::classify(field.name(), FieldKind::Scalar) {
+            FieldPrivacy::Public => value,
+            FieldPrivacy::Private => {
+                self.redacted_any = true;
+                Recorded::redacted()
+            }
+        };
+        self.entries.push((field.clone(), recorded));
+    }
+
+    /// `render` is deferred so a redacted value is never even formatted.
+    fn dynamic(&mut self, field: &Field, render: impl FnOnce() -> Recorded) {
+        let recorded = match FieldPrivacy::classify(field.name(), FieldKind::Dynamic) {
+            FieldPrivacy::Public => render(),
+            FieldPrivacy::Private => {
+                self.redacted_any = true;
+                Recorded::redacted()
+            }
+        };
+        self.entries.push((field.clone(), recorded));
+    }
+}
+
+impl Visit for ClassifyingVisitor {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.scalar(field, Recorded::I64(value));
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.scalar(field, Recorded::I128(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.scalar(field, Recorded::U64(value));
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.scalar(field, Recorded::U128(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.scalar(field, Recorded::F64(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.scalar(field, Recorded::Bool(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.dynamic(field, || Recorded::Str(value.to_owned()));
+    }
+
+    // `record_error` and `record_bytes` funnel here through `Visit`'s default
+    // methods, so every free-form representation lands in the dynamic bucket.
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.dynamic(field, || {
+            Recorded::Debugged(tracing::field::debug(PreRendered(format!("{value:?}"))))
+        });
+    }
+}
+
+/// Build the synthesized value set over `metadata`'s field set and hand it to
+/// `then`.
+///
+/// The value set borrows the classified entries, so it can only exist inside a
+/// callback.
+fn with_value_set<R>(
+    metadata: &'static Metadata<'static>,
+    entries: &[(Field, Recorded)],
+    then: impl FnOnce(&tracing::field::ValueSet<'_>) -> R,
+) -> R {
+    let (pad_field, _) = entries
+        .first()
+        .expect("BUG: a payload was synthesized although no field was classified");
+
+    // Unused slots pair a real field with `None`, which `ValueSet` skips.
+    let pairs: [(&Field, Option<&dyn Value>); MAX_FIELDS] =
+        core::array::from_fn(|index| match entries.get(index) {
+            Some((field, value)) => (field, Some(value.as_value())),
+            None => (pad_field, None),
+        });
+
+    then(&metadata.fields().value_set(&pairs))
+}
+
+impl<S, L> Layer<S> for RedactLayer<L>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    L: Layer<S>,
+{
+    fn on_register_dispatch(&self, subscriber: &tracing::Dispatch) {
+        self.inner.on_register_dispatch(subscriber);
+    }
+
+    fn on_layer(&mut self, subscriber: &mut S) {
+        self.inner.on_layer(subscriber);
+    }
+
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        self.inner.register_callsite(metadata)
+    }
+
+    fn enabled(&self, metadata: &Metadata<'_>, context: Context<'_, S>) -> bool {
+        self.inner.enabled(metadata, context)
+    }
+
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        self.inner.max_level_hint()
+    }
+
+    fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: Context<'_, S>) {
+        let mut visitor = ClassifyingVisitor::default();
+        attributes.record(&mut visitor);
+
+        if !visitor.redacted_any {
+            self.inner.on_new_span(attributes, id, context);
+            return;
+        }
+
+        with_value_set(attributes.metadata(), &visitor.entries, |values| {
+            let redacted = if attributes.is_contextual() {
+                Attributes::new(attributes.metadata(), values)
+            } else if let Some(parent) = attributes.parent() {
+                Attributes::child_of(parent.clone(), attributes.metadata(), values)
+            } else {
+                Attributes::new_root(attributes.metadata(), values)
+            };
+            self.inner.on_new_span(&redacted, id, context);
+        });
+    }
+
+    fn on_record(&self, span: &Id, values: &Record<'_>, context: Context<'_, S>) {
+        let mut visitor = ClassifyingVisitor::default();
+        values.record(&mut visitor);
+
+        if !visitor.redacted_any {
+            self.inner.on_record(span, values, context);
+            return;
+        }
+
+        // `Record` carries no metadata; the span's own field set is the one
+        // its fields belong to. A missing span cannot be synthesized against,
+        // and forwarding the original would leak the value that was just
+        // classified private — so the record is dropped, mirroring the
+        // "loss beats leak" policy above.
+        let Some(metadata) = context.span(span).map(|span_ref| span_ref.metadata()) else {
+            return;
+        };
+
+        with_value_set(metadata, &visitor.entries, |value_set| {
+            self.inner.on_record(span, &Record::new(value_set), context);
+        });
+    }
+
+    fn on_follows_from(&self, span: &Id, follows: &Id, context: Context<'_, S>) {
+        self.inner.on_follows_from(span, follows, context);
+    }
+
+    fn event_enabled(&self, event: &Event<'_>, context: Context<'_, S>) -> bool {
+        self.inner.event_enabled(event, context)
+    }
+
+    fn on_event(&self, event: &Event<'_>, context: Context<'_, S>) {
+        let mut visitor = ClassifyingVisitor::default();
+        event.record(&mut visitor);
+
+        if !visitor.redacted_any {
+            self.inner.on_event(event, context);
+            return;
+        }
+
+        with_value_set(event.metadata(), &visitor.entries, |values| {
+            if event.is_contextual() {
+                self.inner
+                    .on_event(&Event::new(event.metadata(), values), context);
+            } else {
+                // An explicit parent is preserved; `None` reconstructs a root
+                // event (`Event::new_child_of(None, ..)` builds `Parent::Root`).
+                self.inner.on_event(
+                    &Event::new_child_of(event.parent().cloned(), event.metadata(), values),
+                    context,
+                );
+            }
+        });
+    }
+
+    fn on_enter(&self, id: &Id, context: Context<'_, S>) {
+        self.inner.on_enter(id, context);
+    }
+
+    fn on_exit(&self, id: &Id, context: Context<'_, S>) {
+        self.inner.on_exit(id, context);
+    }
+
+    fn on_close(&self, id: Id, context: Context<'_, S>) {
+        self.inner.on_close(id, context);
+    }
+
+    fn on_id_change(&self, old: &Id, new: &Id, context: Context<'_, S>) {
+        self.inner.on_id_change(old, new, context);
+    }
+
+    #[allow(
+        unsafe_code,
+        reason = "forwards tracing-subscriber's type-erased layer lookup without changing the pointer"
+    )]
+    unsafe fn downcast_raw(&self, id: core::any::TypeId) -> Option<*const ()> {
+        // SAFETY: the inner layer owns the downcast contract; this wrapper
+        // returns its pointer unchanged and does not dereference it.
+        unsafe { self.inner.downcast_raw(id) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tracing::span::Id;
+    use tracing_subscriber::Registry;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    use super::*;
+
+    /// What a wrapped sink observed for one field, preserving the `Visit`
+    /// callback the value arrived through — the oracle for "scalars stay
+    /// typed" and "redaction replaces the value, not the callback".
+    #[derive(Debug, Clone, PartialEq)]
+    enum Seen {
+        I64(i64),
+        I128(i128),
+        U64(u64),
+        U128(u128),
+        F64(f64),
+        Bool(bool),
+        Str(String),
+        Debugged(String),
+    }
+
+    #[derive(Default)]
+    struct SeenVisitor(Vec<(String, Seen)>);
+
+    impl Visit for SeenVisitor {
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.0.push((field.name().to_owned(), Seen::I64(value)));
+        }
+        fn record_i128(&mut self, field: &Field, value: i128) {
+            self.0.push((field.name().to_owned(), Seen::I128(value)));
+        }
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.0.push((field.name().to_owned(), Seen::U64(value)));
+        }
+        fn record_u128(&mut self, field: &Field, value: u128) {
+            self.0.push((field.name().to_owned(), Seen::U128(value)));
+        }
+        fn record_f64(&mut self, field: &Field, value: f64) {
+            self.0.push((field.name().to_owned(), Seen::F64(value)));
+        }
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.0.push((field.name().to_owned(), Seen::Bool(value)));
+        }
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0
+                .push((field.name().to_owned(), Seen::Str(value.to_owned())));
+        }
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.0.push((
+                field.name().to_owned(),
+                Seen::Debugged(format!("{value:?}")),
+            ));
+        }
+    }
+
+    /// The `(name, value)` pairs one payload delivered to the sink.
+    type SeenFields = Vec<(String, Seen)>;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct CapturedEvent {
+        fields: SeenFields,
+        explicit_parent: Option<Id>,
+        is_contextual: bool,
+    }
+
+    /// Stand-in sink recording exactly what crossed the redaction stage.
+    #[derive(Clone, Default)]
+    struct CaptureSink {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+        span_attributes: Arc<Mutex<Vec<SeenFields>>>,
+        span_records: Arc<Mutex<Vec<SeenFields>>>,
+    }
+
+    impl CaptureSink {
+        fn events(&self) -> Vec<CapturedEvent> {
+            self.events.lock().expect("BUG: test-local mutex").clone()
+        }
+        fn span_attributes(&self) -> Vec<SeenFields> {
+            self.span_attributes
+                .lock()
+                .expect("BUG: test-local mutex")
+                .clone()
+        }
+        fn span_records(&self) -> Vec<SeenFields> {
+            self.span_records
+                .lock()
+                .expect("BUG: test-local mutex")
+                .clone()
+        }
+    }
+
+    impl<S> Layer<S> for CaptureSink
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attributes: &Attributes<'_>, _id: &Id, _context: Context<'_, S>) {
+            let mut visitor = SeenVisitor::default();
+            attributes.record(&mut visitor);
+            self.span_attributes
+                .lock()
+                .expect("BUG: test-local mutex")
+                .push(visitor.0);
+        }
+
+        fn on_record(&self, _span: &Id, values: &Record<'_>, _context: Context<'_, S>) {
+            let mut visitor = SeenVisitor::default();
+            values.record(&mut visitor);
+            self.span_records
+                .lock()
+                .expect("BUG: test-local mutex")
+                .push(visitor.0);
+        }
+
+        fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = SeenVisitor::default();
+            event.record(&mut visitor);
+            self.events
+                .lock()
+                .expect("BUG: test-local mutex")
+                .push(CapturedEvent {
+                    fields: visitor.0,
+                    explicit_parent: event.parent().cloned(),
+                    is_contextual: event.is_contextual(),
+                });
+        }
+    }
+
+    /// Run `emit` with a redaction-wrapped capture sink installed
+    /// thread-locally, exactly the shape the device sinks are constructed in.
+    fn behind_redaction(emit: impl FnOnce()) -> CaptureSink {
+        let capture = CaptureSink::default();
+        let subscriber = Registry::default().with(RedactLayer::new(capture.clone()));
+        tracing::subscriber::with_default(subscriber, emit);
+        capture
+    }
+
+    fn field<'event>(event: &'event CapturedEvent, name: &str) -> &'event Seen {
+        &event
+            .fields
+            .iter()
+            .find(|(field_name, _)| field_name == name)
+            .unwrap_or_else(|| panic!("field `{name}` missing from {event:?}"))
+            .1
+    }
+
+    /// `Seen::Debugged("<private>")` without repeating the literal in every
+    /// assertion.
+    fn redacted() -> Seen {
+        Seen::Debugged(REDACTED_VALUE.to_owned())
+    }
+
+    #[test]
+    fn a_dynamic_string_field_is_redacted_by_default() {
+        let capture = behind_redaction(|| {
+            tracing::info!(path = "/home/user/secret.txt", "asset loaded");
+        });
+
+        let events = capture.events();
+        assert_eq!(events.len(), 1, "exactly one event: {events:?}");
+        assert_eq!(*field(&events[0], "path"), redacted());
+        assert_eq!(
+            *field(&events[0], "message"),
+            Seen::Debugged("asset loaded".to_owned()),
+            "the message is the format-string analogue and stays published"
+        );
+    }
+
+    #[test]
+    fn a_debug_rendered_field_is_redacted_by_default() {
+        let capture = behind_redaction(|| {
+            tracing::info!(command = ?("draw_text", "hello"), size = 2_u64);
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(*field(event, "command"), redacted());
+        assert_eq!(
+            *field(event, "size"),
+            Seen::U64(2),
+            "a scalar beside a redacted field keeps its type"
+        );
+    }
+
+    #[test]
+    fn an_error_value_is_redacted_by_default() {
+        let io_error = std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file: /home/user/private.png",
+        );
+        let capture = behind_redaction(|| {
+            tracing::warn!(error = &io_error as &dyn std::error::Error, "load failed");
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(
+            *field(event, "error"),
+            redacted(),
+            "error renderings embed paths and OS strings; they are dynamic values"
+        );
+    }
+
+    #[test]
+    fn scalar_fields_pass_through_with_their_types() {
+        let capture = behind_redaction(|| {
+            tracing::info!(
+                a = -1_i64,
+                b = 2_u64,
+                c = 3_i128,
+                d = 4_u128,
+                e = 0.5_f64,
+                f = true,
+                "scalars"
+            );
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(*field(event, "a"), Seen::I64(-1));
+        assert_eq!(*field(event, "b"), Seen::U64(2));
+        assert_eq!(*field(event, "c"), Seen::I128(3));
+        assert_eq!(*field(event, "d"), Seen::U128(4));
+        assert_eq!(*field(event, "e"), Seen::F64(0.5));
+        assert_eq!(*field(event, "f"), Seen::Bool(true));
+        assert!(
+            event.is_contextual && event.explicit_parent.is_none(),
+            "sanity: the macro emitted a contextual event"
+        );
+    }
+
+    #[test]
+    fn a_public_marker_publishes_a_dynamic_field_verbatim() {
+        let capture = behind_redaction(|| {
+            tracing::info!(phase.public = "commit", detail.public = ?(1, 2), "ok");
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(
+            *field(event, "phase.public"),
+            Seen::Str("commit".to_owned()),
+            "an opted-in string must arrive through record_str, unchanged"
+        );
+        assert_eq!(
+            *field(event, "detail.public"),
+            Seen::Debugged("(1, 2)".to_owned()),
+            "an opted-in debug value must keep its record_debug rendering"
+        );
+    }
+
+    #[test]
+    fn a_private_marker_redacts_a_scalar() {
+        let capture = behind_redaction(|| {
+            tracing::info!(latitude.private = 52.52_f64, frame = 7_u64, "position");
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(*field(event, "latitude.private"), redacted());
+        assert_eq!(*field(event, "frame"), Seen::U64(7));
+    }
+
+    #[test]
+    fn field_order_survives_redaction() {
+        let capture = behind_redaction(|| {
+            tracing::info!(first = 1_u64, secret = "s", last = 3_u64, "ordered");
+        });
+
+        let events = capture.events();
+        let names: Vec<&str> = events[0]
+            .fields
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect();
+        assert_eq!(names, vec!["message", "first", "secret", "last"]);
+    }
+
+    #[test]
+    fn log_bridge_normalization_fields_pass_verbatim() {
+        // The logcat layer derives its tag from `log.target` on a bridged
+        // record; redacting these four would misfile every bridged event.
+        let capture = behind_redaction(|| {
+            tracing::info!(
+                log.target = "wgpu_core",
+                log.module_path = "wgpu_core::device",
+                secret = "user text",
+                "bridged-shaped"
+            );
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(
+            *field(event, "log.target"),
+            Seen::Str("wgpu_core".to_owned())
+        );
+        assert_eq!(
+            *field(event, "log.module_path"),
+            Seen::Str("wgpu_core::device".to_owned())
+        );
+        assert_eq!(*field(event, "secret"), redacted());
+    }
+
+    #[test]
+    fn span_attributes_are_classified_like_event_fields() {
+        let capture = behind_redaction(|| {
+            let _span = tracing::info_span!("session", token = "t0k3n", frame = 1_u64);
+        });
+
+        let attributes = capture.span_attributes();
+        assert_eq!(attributes.len(), 1, "one span: {attributes:?}");
+        assert!(
+            attributes[0].contains(&("token".to_owned(), redacted())),
+            "span attribute `token` must be redacted: {attributes:?}"
+        );
+        assert!(
+            attributes[0].contains(&("frame".to_owned(), Seen::U64(1))),
+            "span attribute `frame` must stay typed: {attributes:?}"
+        );
+    }
+
+    #[test]
+    fn late_span_records_are_classified() {
+        let capture = behind_redaction(|| {
+            let span = tracing::info_span!(
+                "session",
+                token = tracing::field::Empty,
+                frame = tracing::field::Empty
+            );
+            span.record("token", "t0k3n");
+            span.record("frame", 7_u64);
+        });
+
+        let records = capture.span_records();
+        assert_eq!(records.len(), 2, "two record calls: {records:?}");
+        assert_eq!(records[0], vec![("token".to_owned(), redacted())]);
+        assert_eq!(records[1], vec![("frame".to_owned(), Seen::U64(7))]);
+    }
+
+    #[test]
+    fn an_explicit_parent_survives_synthesis() {
+        let capture = behind_redaction(|| {
+            let span = tracing::info_span!("parent");
+            tracing::info!(parent: &span, secret = "s", "child event");
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(*field(event, "secret"), redacted());
+        assert!(
+            event.explicit_parent.is_some(),
+            "the synthesized event must keep its explicit parent: {event:?}"
+        );
+        assert!(!event.is_contextual);
+    }
+
+    #[test]
+    fn a_fully_public_event_is_forwarded_untouched() {
+        let capture = behind_redaction(|| {
+            tracing::info!(frame = 7_u64, phase.public = "commit", "clean");
+        });
+
+        let events = capture.events();
+        let event = &events[0];
+        assert_eq!(*field(event, "frame"), Seen::U64(7));
+        assert_eq!(
+            *field(event, "phase.public"),
+            Seen::Str("commit".to_owned())
+        );
+        assert!(
+            event.is_contextual,
+            "the original contextual event passes through"
+        );
+    }
+
+    // --- composed with the logcat renderer, the exact Android line shape ----
+
+    #[test]
+    fn the_rendered_logcat_line_replaces_values_not_names() {
+        let rendered = crate::test_support::capture_rendered_events_behind_redaction(|| {
+            tracing::info!(
+                frame = 7_u64,
+                path = "/home/user/doc.txt",
+                phase.public = "commit",
+                "frame committed"
+            );
+        });
+
+        assert_eq!(
+            rendered,
+            vec![format!(
+                "frame committed | frame=7 path={REDACTED_VALUE} phase.public=commit"
+            )]
+        );
+    }
+}

--- a/crates/flui-log/src/backend/redact.rs
+++ b/crates/flui-log/src/backend/redact.rs
@@ -38,15 +38,17 @@
 )]
 
 use core::fmt;
+use std::borrow::Cow;
 
 use tracing::field::{DebugValue, Field, Value, Visit};
 use tracing::span::{Attributes, Id, Record};
 use tracing::subscriber::Interest;
 use tracing::{Event, Metadata, Subscriber};
+use tracing_log::NormalizeEvent as _;
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
-use super::privacy::{FieldKind, FieldPrivacy, REDACTED_VALUE};
+use super::privacy::{EventOrigin, FieldKind, FieldPrivacy, REDACTED_VALUE};
 
 /// Capacity of the synthesized value set.
 ///
@@ -88,8 +90,10 @@ impl<L> fmt::Debug for RedactLayer<L> {
 /// Public dynamic values that originally arrived through `record_debug` are
 /// replayed through `record_debug` again via this adapter, so a sink cannot
 /// tell redaction was in the path; replaying them as strings would change the
-/// sink's quoting.
-struct PreRendered(String);
+/// sink's quoting. `Cow` so the redaction placeholder — the common case on a
+/// private-by-default sink — borrows the static literal instead of allocating
+/// per redacted field.
+struct PreRendered(Cow<'static, str>);
 
 impl fmt::Debug for PreRendered {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -115,9 +119,9 @@ enum Recorded {
 
 impl Recorded {
     fn redacted() -> Self {
-        Self::Debugged(tracing::field::debug(PreRendered(
-            REDACTED_VALUE.to_owned(),
-        )))
+        Self::Debugged(tracing::field::debug(PreRendered(Cow::Borrowed(
+            REDACTED_VALUE,
+        ))))
     }
 
     fn as_value(&self) -> &dyn Value {
@@ -135,15 +139,23 @@ impl Recorded {
 }
 
 /// Visits a payload once, classifying every field.
-#[derive(Default)]
 struct ClassifyingVisitor {
+    origin: EventOrigin,
     entries: Vec<(Field, Recorded)>,
     redacted_any: bool,
 }
 
 impl ClassifyingVisitor {
+    fn for_origin(origin: EventOrigin) -> Self {
+        Self {
+            origin,
+            entries: Vec::new(),
+            redacted_any: false,
+        }
+    }
+
     fn scalar(&mut self, field: &Field, value: Recorded) {
-        let recorded = match FieldPrivacy::classify(field.name(), FieldKind::Scalar) {
+        let recorded = match FieldPrivacy::classify(field.name(), FieldKind::Scalar, self.origin) {
             FieldPrivacy::Public => value,
             FieldPrivacy::Private => {
                 self.redacted_any = true;
@@ -155,7 +167,7 @@ impl ClassifyingVisitor {
 
     /// `render` is deferred so a redacted value is never even formatted.
     fn dynamic(&mut self, field: &Field, render: impl FnOnce() -> Recorded) {
-        let recorded = match FieldPrivacy::classify(field.name(), FieldKind::Dynamic) {
+        let recorded = match FieldPrivacy::classify(field.name(), FieldKind::Dynamic, self.origin) {
             FieldPrivacy::Public => render(),
             FieldPrivacy::Private => {
                 self.redacted_any = true;
@@ -199,7 +211,9 @@ impl Visit for ClassifyingVisitor {
     // methods, so every free-form representation lands in the dynamic bucket.
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         self.dynamic(field, || {
-            Recorded::Debugged(tracing::field::debug(PreRendered(format!("{value:?}"))))
+            Recorded::Debugged(tracing::field::debug(PreRendered(Cow::Owned(format!(
+                "{value:?}"
+            )))))
         });
     }
 }
@@ -254,7 +268,9 @@ where
     }
 
     fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: Context<'_, S>) {
-        let mut visitor = ClassifyingVisitor::default();
+        // Spans cannot arrive through the `log` bridge — `log` has no spans —
+        // so span payloads are always first-party.
+        let mut visitor = ClassifyingVisitor::for_origin(EventOrigin::Native);
         attributes.record(&mut visitor);
 
         if !visitor.redacted_any {
@@ -275,7 +291,7 @@ where
     }
 
     fn on_record(&self, span: &Id, values: &Record<'_>, context: Context<'_, S>) {
-        let mut visitor = ClassifyingVisitor::default();
+        let mut visitor = ClassifyingVisitor::for_origin(EventOrigin::Native);
         values.record(&mut visitor);
 
         if !visitor.redacted_any {
@@ -306,7 +322,14 @@ where
     }
 
     fn on_event(&self, event: &Event<'_>, context: Context<'_, S>) {
-        let mut visitor = ClassifyingVisitor::default();
+        // `is_log` matches on the bridge's callsite identity, so a first-party
+        // event cannot impersonate its way to a different message default.
+        let origin = if event.is_log() {
+            EventOrigin::LogBridge
+        } else {
+            EventOrigin::Native
+        };
+        let mut visitor = ClassifyingVisitor::for_origin(origin);
         event.record(&mut visitor);
 
         if !visitor.redacted_any {
@@ -732,6 +755,44 @@ mod tests {
         assert!(
             event.is_contextual,
             "the original contextual event passes through"
+        );
+    }
+
+    #[test]
+    fn a_bridged_log_message_is_redacted_by_default() {
+        // Writes the process-global `log` logger slot — the only unit test in
+        // this crate that touches it (the `tests/` bridge scenarios each own a
+        // separate process, per the one-slot-scenario-per-binary rule).
+        tracing_log::log::set_boxed_logger(Box::new(tracing_log::LogTracer::new()))
+            .expect("BUG: no other unit test may claim the `log` logger slot");
+        tracing_log::log::set_max_level(tracing_log::log::LevelFilter::Info);
+
+        let capture = behind_redaction(|| {
+            tracing_log::log::info!(
+                target: "third_party_dep",
+                "loading {}",
+                "/home/user/secret.txt"
+            );
+        });
+
+        let events = capture.events();
+        assert_eq!(
+            events.len(),
+            1,
+            "the bridged record must arrive: {events:?}"
+        );
+        let event = &events[0];
+        assert_eq!(
+            *field(event, "message"),
+            redacted(),
+            "a bridged message is third-party interpolated text; STYLE.md's \
+             fields-not-messages rule does not bind a dependency, so the \
+             message is the leak channel and must not publish"
+        );
+        assert_eq!(
+            *field(event, "log.target"),
+            Seen::Str("third_party_dep".to_owned()),
+            "the normalization fields must keep passing so the logcat tag survives"
         );
     }
 

--- a/crates/flui-log/src/lib.rs
+++ b/crates/flui-log/src/lib.rs
@@ -80,8 +80,10 @@
 //! application, so on those two sinks **fields are private by default**:
 //! dynamic values (strings, `Debug`/`Display` renderings, errors) are redacted
 //! to `<private>` unless the field name ends in `.public`, scalars are
-//! published unless the name ends in `.private`, and the message is always
-//! published. The model is Apple's `%{public}`/`%{private}` contract, applied
+//! published unless the name ends in `.private`, a native `tracing` message is
+//! published, and a message bridged from the `log` facade — a third party's
+//! fully interpolated string — is redacted.
+//! The model is Apple's `%{public}`/`%{private}` contract, applied
 //! uniformly to both platforms; [`backend::privacy`] is the full contract,
 //! including what it deliberately does not cover.
 //!
@@ -111,7 +113,7 @@ pub mod ownership;
 mod test_support;
 
 pub use backend::privacy::{
-    FieldKind, FieldPrivacy, PRIVATE_FIELD_SUFFIX, PUBLIC_FIELD_SUFFIX, REDACTED_VALUE,
+    EventOrigin, FieldKind, FieldPrivacy, PRIVATE_FIELD_SUFFIX, PUBLIC_FIELD_SUFFIX, REDACTED_VALUE,
 };
 pub use backend::{LogcatPriority, PlatformLayer};
 pub use config::{DesktopFormat, LogConfig, LogConfigBuilder};

--- a/crates/flui-log/src/lib.rs
+++ b/crates/flui-log/src/lib.rs
@@ -72,8 +72,18 @@
 //! | iOS | Apple unified logging | Console.app, Xcode, `log stream` |
 //! | wasm32 | browser console + performance timeline | `DevTools` |
 //!
-//! See [`backend`] for what each one does and does not guarantee, including the
-//! Apple privacy contract.
+//! See [`backend`] for what each one does and does not guarantee.
+//!
+//! # Privacy on device sinks
+//!
+//! Logcat and the Apple unified log are archives readable outside the
+//! application, so on those two sinks **fields are private by default**:
+//! dynamic values (strings, `Debug`/`Display` renderings, errors) are redacted
+//! to `<private>` unless the field name ends in `.public`, scalars are
+//! published unless the name ends in `.private`, and the message is always
+//! published. The model is Apple's `%{public}`/`%{private}` contract, applied
+//! uniformly to both platforms; [`backend::privacy`] is the full contract,
+//! including what it deliberately does not cover.
 //!
 //! # Filtering
 //!
@@ -100,6 +110,9 @@ pub mod ownership;
 #[cfg(test)]
 mod test_support;
 
+pub use backend::privacy::{
+    FieldKind, FieldPrivacy, PRIVATE_FIELD_SUFFIX, PUBLIC_FIELD_SUFFIX, REDACTED_VALUE,
+};
 pub use backend::{LogcatPriority, PlatformLayer};
 pub use config::{DesktopFormat, LogConfig, LogConfigBuilder};
 pub use filter::{DEFAULT_DIRECTIVES, DEFAULT_ENV_VAR, FilterConfig, FilterError};

--- a/crates/flui-log/src/test_support.rs
+++ b/crates/flui-log/src/test_support.rs
@@ -45,3 +45,20 @@ pub(crate) fn capture_rendered_events(emit: impl FnOnce()) -> Vec<String> {
         .expect("BUG: capture mutex is only locked by this test's own thread")
         .clone()
 }
+
+/// Like [`capture_rendered_events`], but with the renderer sitting behind the
+/// privacy [`RedactLayer`](crate::backend::redact::RedactLayer) — the exact
+/// composition the Android sink ships with, minus the FFI write.
+pub(crate) fn capture_rendered_events_behind_redaction(emit: impl FnOnce()) -> Vec<String> {
+    let capture = RenderCapture::default();
+    let subscriber =
+        Registry::default().with(crate::backend::redact::RedactLayer::new(capture.clone()));
+
+    tracing::subscriber::with_default(subscriber, emit);
+
+    capture
+        .0
+        .lock()
+        .expect("BUG: capture mutex is only locked by this test's own thread")
+        .clone()
+}


### PR DESCRIPTION
Closes #572

## The classification model

Ported from Apple's own contract — *"By default, the system doesn't redact integer, floating-point and Boolean values, but it does redact the contents of dynamic strings and complex dynamic objects"* ("Generating Log Messages from Your Code", `os` framework docs) — and applied **uniformly to both device sinks**, since Android has no native equivalent knob (logcat is a plain line transport, so the policy must be applied before the line is rendered):

| Recorded as | Default | Override |
|---|---|---|
| scalar (`i64`/`u64`/`i128`/`u128`/`f64`/`bool`) | published | trailing `.private` in the field name redacts |
| dynamic (`&str`, `Debug`/`Display`, errors, bytes) | redacted to `<private>` | trailing `.public` in the field name publishes |
| `message` | published (the format-string analogue) | — |

The marker rides in the **field name** (`phase.public = "commit"`) because the issue's acceptance requires a producer that depends on `tracing` alone, with no knowledge of which backend is installed — the field name is the only channel that survives tracing's field system intact from a library crate to the sink. Desktop and web-console sinks are developer-facing and deliberately publish verbatim; the four `log.*` bridge normalization fields stay public so bridged records keep their logcat tag grouping (they name compile-time source locations already embedded in the binary).

## Where the issue left options open, what I chose and why

- **Enforcement point** — one mechanism, not per-sink conventions: `backend::redact::RedactLayer` wraps both device sinks and re-records events, span attributes, and late span records with private values replaced before the sink can observe them. When nothing needs redaction the original payload is forwarded untouched (typed values, message `Arguments`, parent linkage). The `Sink` enum's device variants are now *typed* as `RedactLayer<…>`, so constructing a bare device sink is a compile error — the "gate that cannot silently no-op" acceptance is met by the type system plus runtime tests, with no regex heuristic.
- **Apple transport** — of the issue's three costed options I took "redact before `tracing-oslog`", not the FLUI-owned `os_log` C shim. Rationale: real per-field `%{private}` needs compile-time format strings, hence a new C shim + FFI surface that **nothing in this environment or CI can compile** (no Apple SDK; CI's cross-typecheck covers `flui-platform` only) — shipping that blind is exactly the "shipped seams never wired" defect class. The chosen shape is *stronger* privacy at rest (a private value is never stored at all, vs. os_log's display-time redaction) at the cost of the Enable-Private-Data reveal workflow; the divergence and the path back are documented on `apple_unified_logging`, and the classification layer is transport-agnostic so a future FLUI-owned shim adopts it unchanged.
- **Host-side path fields** (issue item 4) — re-judged under the policy: desktop sinks don't redact, so `flui-build`/`flui-cli`/hot-reload path logging stays as-is by design, stated in `backend::privacy` docs.

## Executable vs lint-only split (honest scope)

**Executes on CI (Linux):** the classification (`backend::privacy`), the redaction stage (`backend::redact`) — both cfg-free, compiled on every target — 22 new unit tests covering defaults, both markers, marker precedence, scalar type preservation, field order, error values, `log.*` passthrough, span attributes, late `span.record()`, explicit-parent synthesis, and the exact rendered logcat line shape (`RedactLayer` composed with the real `FieldRecorder`).

**Lint-only:** the Android shell — `cargo clippy -p flui-log --locked --all-targets --target aarch64-linux-android -- -D warnings` clean (this compiles the wrapped `LogcatLayer` wiring). **Type-checked less than that:** the two Apple constructor bodies. `--target aarch64-apple-darwin` (default features) lints clean, but enabling `apple-unified-logging` fails in `tracing-oslog`'s C-shim build script without an Apple SDK — a pre-existing environmental limit (the failure is in the dependency's build.rs, before any flui-log code compiles; CI has no flui-log Apple gate either). The wrapped call is the previous call plus `RedactLayer::new(…)`, verified by eye against the vendored `tracing-oslog 0.3.0` source, whose non-Apple stub shares the real `OsLogger::new`/`Layer` signatures.

## Gates

- `just ci` — exit 0 (fmt, inventory, runtime-conformance, port-check, clippy, tests incl. 82 flui-log tests, doc-tests)
- `typos`, `taplo fmt --check` — exit 0
- Cross-target clippy: android clean, apple-darwin (default features) clean; apple with the oslog feature blocked by missing SDK as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
