### PR TITLE
feat(app): unified execution services under AppRuntime with host injection (part of #557)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,8 @@ dependencies = [
  "raw-window-handle",
  "static_assertions",
  "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen-futures",
@@ -2059,7 +2061,6 @@ dependencies = [
  "flui-types",
  "keyboard-types",
  "libc",
- "num_cpus",
  "objc",
  "parking_lot",
  "raw-window-handle",
@@ -3701,16 +3702,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,10 @@ tokio = { version = "1.43" }
 # Structured cancellation for the runtime-owned execution services
 # (`CancellationToken`; adoption sanctioned by
 # docs/research/2026-08-01-runtime-dependency-adoption-guide.md with the
-# unified-executor work, issue #557). Default features only — no `rt`
+# unified-executor work, issue #557). `default-features = false` and no
+# optional features requested: `CancellationToken` lives in the
+# always-compiled `sync` module, and the explicit opt-out keeps a future
+# tokio-util default from arriving silently. In particular no `rt`
 # (`TaskTracker`) until the task/service lifecycle work (#558) needs it.
 tokio-util = { version = "0.7", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,12 @@ repository = "https://github.com/vanyastaff/flui"
 [workspace.dependencies]
 # ASYNC RUNTIME — tokio 1.43 = LTS floor (lock resolves latest 1.x)
 tokio = { version = "1.43" }
+# Structured cancellation for the runtime-owned execution services
+# (`CancellationToken`; adoption sanctioned by
+# docs/research/2026-08-01-runtime-dependency-adoption-guide.md with the
+# unified-executor work, issue #557). Default features only — no `rt`
+# (`TaskTracker`) until the task/service lifecycle work (#558) needs it.
+tokio-util = { version = "0.7", default-features = false }
 
 # SYNCHRONIZATION - Used by multiple crates
 parking_lot = "0.12"

--- a/crates/flui-app/Cargo.toml
+++ b/crates/flui-app/Cargo.toml
@@ -95,6 +95,15 @@ raw-window-handle.workspace = true
 pollster = "0.4"
 web-time = { workspace = true }
 
+# Default execution services (issue #557): the loop-scoped `AppRuntime` owns
+# the process's background worker pools (an IO runtime and a bounded compute
+# pool), replacing the per-platform full-core `BackgroundExecutor`s. Native
+# only — the wasm32 build of `app::execution` is the sequential variant and
+# needs neither crate.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
+tokio-util = { workspace = true }
+
 # Web/WASM platform (runner spawns the frame loop via spawn_local)
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"

--- a/crates/flui-app/src/app/config.rs
+++ b/crates/flui-app/src/app/config.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use flui_log::AppIdentity;
 use flui_types::{Size, geometry::px};
 
+use super::execution::HostExecutors;
 #[cfg(not(target_os = "ios"))]
 use super::runtime::ExitPolicy;
 
@@ -147,6 +148,16 @@ pub struct AppConfig {
     /// entirely — see that function's own doc).
     #[cfg(not(target_os = "ios"))]
     pub exit_policy: ExitPolicy,
+
+    /// Host-injected background executors (issue #557).
+    ///
+    /// `None` (the default): the runtime constructs its own worker pools,
+    /// lazily, on first background spawn. `Some`: all background work routes
+    /// to the host's pools and the default pools are **never** constructed —
+    /// the seam by which FLUI embedded next to an engine that already owns a
+    /// thread pool avoids oversubscribing the machine. See
+    /// [`HostExecutors`]'s own doc for the contract layered on top.
+    pub executors: Option<HostExecutors>,
 }
 
 impl Default for AppConfig {
@@ -168,6 +179,7 @@ impl Default for AppConfig {
             worker_plugin_path: None,
             #[cfg(not(target_os = "ios"))]
             exit_policy: ExitPolicy::default(),
+            executors: None,
         }
     }
 }
@@ -256,6 +268,13 @@ impl AppConfig {
     #[cfg(feature = "hot-reload")]
     pub fn with_worker_plugin_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.worker_plugin_path = Some(path.into());
+        self
+    }
+
+    /// Inject the host's own background executors. See
+    /// [`Self::executors`]'s doc for what this changes.
+    pub fn with_executors(mut self, executors: HostExecutors) -> Self {
+        self.executors = Some(executors);
         self
     }
 }

--- a/crates/flui-app/src/app/execution.rs
+++ b/crates/flui-app/src/app/execution.rs
@@ -1,0 +1,1241 @@
+//! Unified background execution services (issue #557, first slice).
+//!
+//! # Work-class model
+//!
+//! FLUI classifies work by **deadline and behavior**, not by a user-supplied
+//! priority (see the runtime architecture execution plan and ADR-0047):
+//!
+//! - **Frame-required compute** never leaves the owner thread. It is the
+//!   frame pipeline itself plus `flui_scheduler::AsyncDriver`'s mid-frame
+//!   poll — no thread pool is involved, so no amount of background work can
+//!   starve it of its executor. This module deliberately provides **no**
+//!   spawn API for that class.
+//! - **Asynchronous compute** ([`ExecutionServices::spawn_compute`]) is a
+//!   pure, possibly multi-frame CPU job (decode, tessellation, shaping). It
+//!   runs on a bounded worker pool sized to leave headroom for the owner
+//!   thread and the IO lane ([`default_compute_worker_count`]).
+//! - **IO** ([`ExecutionServices::spawn_io`]) is an await-heavy future (file
+//!   or network traffic). It runs on a small fixed-size async runtime
+//!   ([`IO_WORKER_THREADS`] workers).
+//! - **Durable services** are issue #558's lifecycle work and are not part
+//!   of this module yet.
+//!
+//! # Ownership
+//!
+//! `AppRuntime` (the loop-scoped composition root) owns exactly one
+//! [`ExecutionServices`] value. Nothing here is ambient: there is no global
+//! accessor, and library crates cannot reach these pools. An embedded host
+//! that already runs its own executors injects them through
+//! [`HostExecutors`] (`AppConfig::with_executors`); the default pools are
+//! then **never constructed**, so FLUI and the host cannot oversubscribe the
+//! machine with two full-core pools.
+//!
+//! # Admission, cancellation, shutdown
+//!
+//! Both lanes have bounded admission ([`AdmissionLimits`]): a full lane
+//! refuses new work with [`SpawnError::Saturated`] instead of queueing
+//! without bound. Shutdown stops admission first (later spawns get
+//! [`SpawnError::ShuttingDown`]), then cancels outstanding work (IO futures
+//! are dropped at their next await point via a `CancellationToken`; queued
+//! compute jobs that have not started are skipped), then joins running work
+//! bounded by a deadline. On wasm32 the same API is sequential: compute jobs
+//! run inline at the spawn site and IO futures go to the browser's
+//! microtask queue via `wasm_bindgen_futures::spawn_local`.
+//!
+//! # Determinism for tests
+//!
+//! [`DeterministicExecutors`] is a single-threaded, FIFO implementation of
+//! the same host-injection seam. Tests drive it with
+//! [`DeterministicExecutors::run_until_idle`]; the admission/shutdown
+//! conformance tests in this module run against both the default pools and
+//! the deterministic implementation, so an injected executor observes the
+//! same contract.
+
+// The spawn/admission machinery has no shipped consumer yet by design: the
+// background lanes' production callers are issue #558's task/worker/service
+// lifecycles (and #559's raster lane), the next items on the same critical
+// path. Until those land, this module's own tests are the executable
+// coverage. `expect`, not `allow`: the moment #558 wires a production
+// caller, the unfulfilled expectation errors and this attribute must go.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "background-lane spawn consumers arrive with the task/worker/service \
+                  lifecycle work (issue #558); until then this machinery is exercised \
+                  by this module's own tests"
+    )
+)]
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+/// A pure background compute job: a boxed closure, run once on a worker
+/// thread (or inline on wasm32).
+pub type ComputeJob = Box<dyn FnOnce() + Send + 'static>;
+
+/// A background IO future. Result delivery is the caller's business (send it
+/// through a channel the caller owns); the executor only drives the future.
+pub type IoFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// Why a spawn was refused.
+///
+/// The job or future passed to the failing spawn call is dropped (its
+/// destructors run); a caller that wants to retry must rebuild it.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum SpawnError {
+    /// The lane's bounded admission window is full. Backpressure, not a bug:
+    /// the caller may retry later or shed the work.
+    #[error("the executor lane's bounded admission window is full")]
+    Saturated,
+    /// Execution services are shutting down (or already shut down); no new
+    /// work is admitted.
+    #[error("execution services are shutting down; new work is refused")]
+    ShuttingDown,
+}
+
+/// Host-provided worker pool for the **asynchronous compute** work class.
+///
+/// Implementations run each job exactly once, on any thread. FLUI wraps
+/// every job it hands over with its own admission accounting and
+/// shutdown-cancellation check, so an implementation only needs to execute.
+///
+/// Return [`SpawnError::Saturated`] to refuse a job when the host's own
+/// queue is full — FLUI surfaces that to its caller unchanged.
+pub trait HostComputePool: Send + Sync {
+    /// Queue `job` for execution.
+    fn spawn_job(&self, job: ComputeJob) -> Result<(), SpawnError>;
+}
+
+/// Host-provided executor for the **IO** work class.
+///
+/// Implementations drive each future to completion, on any thread. FLUI
+/// wraps every future it hands over with its own admission accounting and
+/// cancellation (on shutdown the wrapped future resolves early), so an
+/// implementation only needs to poll.
+pub trait HostIoPool: Send + Sync {
+    /// Queue `future` for execution.
+    fn spawn_future(&self, future: IoFuture) -> Result<(), SpawnError>;
+}
+
+/// The host-injection seam: an embedded host's own executors, passed via
+/// `AppConfig::with_executors`.
+///
+/// When present, FLUI routes all background work through these pools and
+/// **never constructs its default pools** — the mechanism by which FLUI
+/// embedded in a game engine or editor avoids a second full-core thread
+/// pool. FLUI's bounded-admission and shutdown contracts still apply on top
+/// of whatever the host provides.
+#[derive(Clone)]
+pub struct HostExecutors {
+    compute: Arc<dyn HostComputePool>,
+    io: Arc<dyn HostIoPool>,
+}
+
+impl HostExecutors {
+    /// Bundle a compute pool and an IO pool provided by the host.
+    pub fn new(compute: Arc<dyn HostComputePool>, io: Arc<dyn HostIoPool>) -> Self {
+        Self { compute, io }
+    }
+}
+
+impl fmt::Debug for HostExecutors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HostExecutors").finish_non_exhaustive()
+    }
+}
+
+/// Worker threads in the default IO runtime.
+///
+/// IO futures are await-heavy, not CPU-heavy; two workers drive a large
+/// number of concurrent file/network futures. Kept const so
+/// [`default_compute_worker_count`] can reserve headroom for them.
+pub(crate) const IO_WORKER_THREADS: usize = 2;
+
+/// Default compute-pool size for a machine with `available_parallelism`
+/// hardware threads: everything except one hardware thread for the owner
+/// (frame) thread and [`IO_WORKER_THREADS`] for the IO lane, never below 1.
+///
+/// This is the "background work cannot starve frame-required compute"
+/// sizing half: even with every compute worker busy, the owner thread keeps
+/// a hardware thread (the other half is structural — the frame lane never
+/// runs on these pools at all, see the module doc).
+pub(crate) fn default_compute_worker_count(available_parallelism: usize) -> usize {
+    available_parallelism
+        .saturating_sub(IO_WORKER_THREADS + 1)
+        .max(1)
+}
+
+/// Bounded admission windows, counted as work admitted but not yet finished
+/// (queued + running).
+///
+/// Defaults are deliberately generous — they are overload backstops, not
+/// throttles. Tests inject small values to exercise refusal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AdmissionLimits {
+    /// Maximum in-flight compute jobs.
+    pub(crate) compute: usize,
+    /// Maximum in-flight IO futures.
+    pub(crate) io: usize,
+}
+
+impl Default for AdmissionLimits {
+    fn default() -> Self {
+        Self {
+            compute: 256,
+            io: 1024,
+        }
+    }
+}
+
+/// One lane's admission window: an in-flight counter with a cap.
+struct Admission {
+    in_flight: Arc<AtomicUsize>,
+    limit: usize,
+}
+
+impl Admission {
+    fn new(limit: usize) -> Self {
+        Self {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            limit,
+        }
+    }
+
+    /// Try to admit one unit of work; the returned guard releases the slot
+    /// when dropped (job finished, future completed/cancelled, or the
+    /// wrapper itself was dropped unrun at pool shutdown).
+    fn try_admit(&self) -> Result<AdmissionGuard, SpawnError> {
+        let mut current = self.in_flight.load(Ordering::Relaxed);
+        loop {
+            if current >= self.limit {
+                return Err(SpawnError::Saturated);
+            }
+            match self.in_flight.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Ok(AdmissionGuard {
+                        in_flight: Arc::clone(&self.in_flight),
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Acquire)
+    }
+}
+
+/// RAII release of one admission slot.
+struct AdmissionGuard {
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl Drop for AdmissionGuard {
+    fn drop(&mut self) {
+        self.in_flight.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// The `AppRuntime`-owned execution services: both background lanes, their
+/// admission windows, and the shutdown protocol. See the module doc for the
+/// work-class model.
+///
+/// Construction is cheap; on the default backend the pools start lazily on
+/// first spawn, so a run that never spawns background work never starts a
+/// worker thread.
+pub(crate) struct ExecutionServices {
+    accepting: AtomicBool,
+    compute_admission: Admission,
+    io_admission: Admission,
+    backend: Backend,
+    #[cfg(not(target_arch = "wasm32"))]
+    cancel: tokio_util::sync::CancellationToken,
+}
+
+enum Backend {
+    /// Host-injected pools; the default pools are never constructed.
+    Host(HostExecutors),
+    /// FLUI's own default pools, lazily started.
+    #[cfg(not(target_arch = "wasm32"))]
+    Default(DefaultPools),
+    /// wasm32 sequential execution: compute inline, IO via
+    /// `wasm_bindgen_futures::spawn_local`.
+    #[cfg(target_arch = "wasm32")]
+    Sequential,
+}
+
+/// A default pool's lifecycle: not yet started, running, or shut down.
+#[cfg(not(target_arch = "wasm32"))]
+enum PoolSlot {
+    NotStarted,
+    Running(tokio::runtime::Runtime),
+    Closed,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl PoolSlot {
+    fn take_runtime(&mut self) -> Option<tokio::runtime::Runtime> {
+        match std::mem::replace(self, PoolSlot::Closed) {
+            PoolSlot::Running(runtime) => Some(runtime),
+            PoolSlot::NotStarted | PoolSlot::Closed => None,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct DefaultPools {
+    io: parking_lot::Mutex<PoolSlot>,
+    compute: parking_lot::Mutex<PoolSlot>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl DefaultPools {
+    fn new() -> Self {
+        Self {
+            io: parking_lot::Mutex::new(PoolSlot::NotStarted),
+            compute: parking_lot::Mutex::new(PoolSlot::NotStarted),
+        }
+    }
+
+    /// Handle to the IO runtime, starting it on first use. `None` once the
+    /// slot is closed by shutdown.
+    fn io_handle(&self) -> Option<tokio::runtime::Handle> {
+        Self::handle_of(&self.io, || {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(IO_WORKER_THREADS)
+                .thread_name("flui-io")
+                .enable_all()
+                .build()
+        })
+    }
+
+    /// Handle to the compute runtime, starting it on first use. `None` once
+    /// the slot is closed by shutdown.
+    fn compute_handle(&self) -> Option<tokio::runtime::Handle> {
+        Self::handle_of(&self.compute, || {
+            let workers = default_compute_worker_count(
+                std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
+            );
+            // No `enable_all`: compute jobs are synchronous closures and
+            // need neither the IO nor the time driver.
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(workers)
+                .thread_name("flui-compute")
+                .build()
+        })
+    }
+
+    fn handle_of(
+        slot: &parking_lot::Mutex<PoolSlot>,
+        build: impl FnOnce() -> std::io::Result<tokio::runtime::Runtime>,
+    ) -> Option<tokio::runtime::Handle> {
+        let mut slot = slot.lock();
+        match &*slot {
+            PoolSlot::Running(runtime) => Some(runtime.handle().clone()),
+            PoolSlot::Closed => None,
+            PoolSlot::NotStarted => {
+                let runtime = build().expect(
+                    "BUG: building a tokio runtime must succeed on any platform \
+                     this crate targets short of OS thread exhaustion",
+                );
+                let handle = runtime.handle().clone();
+                *slot = PoolSlot::Running(runtime);
+                Some(handle)
+            }
+        }
+    }
+
+    /// Whether either default pool has actually started worker threads.
+    #[cfg(test)]
+    fn any_started(&self) -> bool {
+        matches!(&*self.io.lock(), PoolSlot::Running(_))
+            || matches!(&*self.compute.lock(), PoolSlot::Running(_))
+    }
+}
+
+impl ExecutionServices {
+    /// Services backed by FLUI's own default pools (lazily started).
+    pub(crate) fn with_defaults() -> Self {
+        Self::build(None, AdmissionLimits::default())
+    }
+
+    /// Services backed by host-injected pools; the default pools are never
+    /// constructed.
+    pub(crate) fn with_host(host: HostExecutors) -> Self {
+        Self::build(Some(host), AdmissionLimits::default())
+    }
+
+    /// Test seam: custom admission windows (both backends).
+    #[cfg(test)]
+    pub(crate) fn with_limits(host: Option<HostExecutors>, limits: AdmissionLimits) -> Self {
+        Self::build(host, limits)
+    }
+
+    fn build(host: Option<HostExecutors>, limits: AdmissionLimits) -> Self {
+        let backend = match host {
+            Some(host) => Backend::Host(host),
+            #[cfg(not(target_arch = "wasm32"))]
+            None => Backend::Default(DefaultPools::new()),
+            #[cfg(target_arch = "wasm32")]
+            None => Backend::Sequential,
+        };
+        Self {
+            accepting: AtomicBool::new(true),
+            compute_admission: Admission::new(limits.compute),
+            io_admission: Admission::new(limits.io),
+            backend,
+            #[cfg(not(target_arch = "wasm32"))]
+            cancel: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+
+    /// Whether this instance routes to host-injected pools (`false`) or owns
+    /// the default pools (`true`).
+    pub(crate) fn owns_default_pools(&self) -> bool {
+        !matches!(self.backend, Backend::Host(_))
+    }
+
+    /// Spawn an **asynchronous compute** job (see the module doc's
+    /// work-class model). Fire-and-forget: result delivery is the caller's
+    /// business.
+    pub(crate) fn spawn_compute(&self, job: ComputeJob) -> Result<(), SpawnError> {
+        if !self.accepting.load(Ordering::Acquire) {
+            return Err(SpawnError::ShuttingDown);
+        }
+        let guard = self.compute_admission.try_admit()?;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let cancel = self.cancel.clone();
+            let wrapped: ComputeJob = Box::new(move || {
+                let _slot = guard;
+                // A job still queued when shutdown began is skipped; a job
+                // already running is joined by the shutdown deadline instead.
+                if cancel.is_cancelled() {
+                    return;
+                }
+                job();
+            });
+            match &self.backend {
+                Backend::Host(host) => host.compute.spawn_job(wrapped),
+                Backend::Default(pools) => {
+                    let Some(handle) = pools.compute_handle() else {
+                        return Err(SpawnError::ShuttingDown);
+                    };
+                    handle.spawn(async move { wrapped() });
+                    Ok(())
+                }
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let wrapped: ComputeJob = Box::new(move || {
+                let _slot = guard;
+                job();
+            });
+            match &self.backend {
+                Backend::Host(host) => host.compute.spawn_job(wrapped),
+                // Sequential execution: no threads exist on this target, so
+                // the job runs inline at the spawn site.
+                Backend::Sequential => {
+                    wrapped();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// Spawn an **IO** future (see the module doc's work-class model).
+    /// Fire-and-forget: result delivery is the caller's business. On
+    /// shutdown the future is cancelled (dropped) at its next await point.
+    pub(crate) fn spawn_io(&self, future: IoFuture) -> Result<(), SpawnError> {
+        if !self.accepting.load(Ordering::Acquire) {
+            return Err(SpawnError::ShuttingDown);
+        }
+        let guard = self.io_admission.try_admit()?;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let cancel = self.cancel.clone();
+            let wrapped: IoFuture = Box::pin(async move {
+                let _slot = guard;
+                // Cancellation point: shutdown resolves this early, dropping
+                // `future` (and running its destructors) at whatever await
+                // point it had reached. Load-bearing especially for HOST
+                // pools, whose tasks FLUI cannot drop any other way — see
+                // `shutdown_cancels_work_handed_to_host_pools`.
+                let _ = cancel.run_until_cancelled(future).await;
+            });
+            match &self.backend {
+                Backend::Host(host) => host.io.spawn_future(wrapped),
+                Backend::Default(pools) => {
+                    let Some(handle) = pools.io_handle() else {
+                        return Err(SpawnError::ShuttingDown);
+                    };
+                    handle.spawn(wrapped);
+                    Ok(())
+                }
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let wrapped: IoFuture = Box::pin(async move {
+                let _slot = guard;
+                future.await;
+            });
+            match &self.backend {
+                Backend::Host(host) => host.io.spawn_future(wrapped),
+                // Browser microtask queue; single-threaded, uncancellable
+                // once queued — shutdown on wasm stops admission only.
+                Backend::Sequential => {
+                    wasm_bindgen_futures::spawn_local(wrapped);
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// Work admitted but not yet finished, per lane, `(compute, io)`.
+    /// Diagnostics only — a snapshot, immediately stale.
+    #[cfg(test)]
+    pub(crate) fn in_flight(&self) -> (usize, usize) {
+        (
+            self.compute_admission.in_flight(),
+            self.io_admission.in_flight(),
+        )
+    }
+
+    /// Whether either default pool has started worker threads. Always
+    /// `false` with host-injected pools — the probe behind the
+    /// "host injection avoids duplicate pools" evidence.
+    #[cfg(test)]
+    pub(crate) fn default_pools_started(&self) -> bool {
+        match &self.backend {
+            Backend::Host(_) => false,
+            #[cfg(not(target_arch = "wasm32"))]
+            Backend::Default(pools) => pools.any_started(),
+            #[cfg(target_arch = "wasm32")]
+            Backend::Sequential => false,
+        }
+    }
+
+    /// Shut down: stop admission, cancel outstanding work, then join running
+    /// work, waiting at most `grace` per pool.
+    ///
+    /// After this returns every spawn refuses with
+    /// [`SpawnError::ShuttingDown`]. Idempotent. With host-injected pools
+    /// only the first two stages apply — FLUI cancels the work it wrapped,
+    /// but joining the host's threads is the host's own lifecycle.
+    ///
+    /// `grace` bounds the wait for **running** work (an IO future between
+    /// await points, a compute closure mid-run); work that has not started
+    /// is dropped unrun, which is the cancellation stage doing its job.
+    pub(crate) fn shutdown(&self, grace: std::time::Duration) {
+        self.accepting.store(false, Ordering::Release);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.cancel.cancel();
+            if let Backend::Default(pools) = &self.backend {
+                let io = pools.io.lock().take_runtime();
+                let compute = pools.compute.lock().take_runtime();
+                if let Some(runtime) = io {
+                    runtime.shutdown_timeout(grace);
+                }
+                if let Some(runtime) = compute {
+                    runtime.shutdown_timeout(grace);
+                }
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            // Sequential target: nothing to cancel or join — compute ran
+            // inline and queued microtasks cannot be revoked. `grace` is
+            // deliberately unused.
+            let _ = grace;
+        }
+    }
+}
+
+impl fmt::Debug for ExecutionServices {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecutionServices")
+            .field("accepting", &self.accepting.load(Ordering::Relaxed))
+            .field("owns_default_pools", &self.owns_default_pools())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for ExecutionServices {
+    fn drop(&mut self) {
+        // Last-resort teardown for the path that never ran the explicit
+        // `shutdown` (a panic mid-teardown, a test dropping `AppRuntime`).
+        // `shutdown_background` never blocks, so — unlike `Runtime`'s own
+        // blocking `Drop` — this is safe even if the drop happens from
+        // inside a task running on some other runtime.
+        self.accepting.store(false, Ordering::Release);
+        self.cancel.cancel();
+        if let Backend::Default(pools) = &self.backend {
+            let io = pools.io.lock().take_runtime();
+            let compute = pools.compute.lock().take_runtime();
+            if let Some(runtime) = io {
+                runtime.shutdown_background();
+            }
+            if let Some(runtime) = compute {
+                runtime.shutdown_background();
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Deterministic executors (the injected reference implementation)
+// ============================================================================
+
+/// A deterministic, single-threaded implementation of the host-injection
+/// seam, for tests and for hosts that need reproducible execution.
+///
+/// Work is queued at spawn and executed only inside
+/// [`run_until_idle`](Self::run_until_idle), on the calling thread, in FIFO
+/// spawn order (all queued compute jobs run before IO futures are polled in
+/// each pass). Doubles as the reference implementation proving the
+/// [`HostComputePool`]/[`HostIoPool`] contract is implementable outside
+/// FLUI.
+#[derive(Clone, Default)]
+pub struct DeterministicExecutors {
+    inner: Arc<DeterministicShared>,
+}
+
+#[derive(Default)]
+struct DeterministicShared {
+    jobs: parking_lot::Mutex<std::collections::VecDeque<ComputeJob>>,
+    tasks: parking_lot::Mutex<Vec<DeterministicTask>>,
+}
+
+struct DeterministicTask {
+    /// Absent while being polled (moved out so the lock is not held across
+    /// user code — a polled future may spawn).
+    future: Option<IoFuture>,
+    /// Set by the waker; a task is polled only while this is `true`.
+    ready: Arc<AtomicBool>,
+}
+
+/// Waker payload: flips the task's `ready` flag; `run_until_idle` picks the
+/// task up on its next pass.
+struct DeterministicWaker {
+    ready: Arc<AtomicBool>,
+}
+
+impl std::task::Wake for DeterministicWaker {
+    fn wake(self: Arc<Self>) {
+        self.ready.store(true, Ordering::Release);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.ready.store(true, Ordering::Release);
+    }
+}
+
+impl DeterministicExecutors {
+    /// An empty deterministic executor pair.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The [`HostExecutors`] bundle routing both work classes to this
+    /// executor — pass it to `AppConfig::with_executors`.
+    #[must_use]
+    pub fn host_executors(&self) -> HostExecutors {
+        HostExecutors::new(Arc::new(self.clone()), Arc::new(self.clone()))
+    }
+
+    /// Run queued work on the calling thread until nothing is runnable:
+    /// executes every queued compute job, then polls every woken IO future,
+    /// repeating until a full pass makes no progress. Futures that returned
+    /// `Pending` without an intervening wake stay parked (they are not spun
+    /// on). Returns the number of jobs run plus polls made.
+    pub fn run_until_idle(&self) -> usize {
+        let mut steps = 0;
+        loop {
+            let mut progressed = false;
+
+            // Compute jobs first, FIFO.
+            while let Some(job) = self.inner.jobs.lock().pop_front() {
+                job();
+                steps += 1;
+                progressed = true;
+            }
+
+            // Then one poll pass over every woken future, in spawn order.
+            let woken: Vec<usize> = {
+                let tasks = self.inner.tasks.lock();
+                tasks
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, task)| task.ready.load(Ordering::Acquire))
+                    .map(|(index, _)| index)
+                    .collect()
+            };
+            for index in woken {
+                let Some((mut future, ready)) = ({
+                    let mut tasks = self.inner.tasks.lock();
+                    tasks.get_mut(index).and_then(|task| {
+                        // Clear before polling so a wake during the poll
+                        // re-arms rather than being swallowed.
+                        task.ready.store(false, Ordering::Release);
+                        task.future
+                            .take()
+                            .map(|future| (future, Arc::clone(&task.ready)))
+                    })
+                }) else {
+                    continue;
+                };
+
+                let waker = std::task::Waker::from(Arc::new(DeterministicWaker {
+                    ready: Arc::clone(&ready),
+                }));
+                let mut context = std::task::Context::from_waker(&waker);
+                let poll = future.as_mut().poll(&mut context);
+                steps += 1;
+                progressed = true;
+
+                let mut tasks = self.inner.tasks.lock();
+                match poll {
+                    std::task::Poll::Ready(()) => {
+                        if let Some(task) = tasks.get_mut(index) {
+                            // Leave a completed slot in place (indices stay
+                            // stable within the pass); it is compacted below.
+                            task.future = None;
+                            task.ready.store(false, Ordering::Release);
+                        }
+                    }
+                    std::task::Poll::Pending => {
+                        if let Some(task) = tasks.get_mut(index) {
+                            task.future = Some(future);
+                        }
+                    }
+                }
+            }
+
+            // Compact completed slots between passes (a slot with no future
+            // and no pending re-queue is done).
+            self.inner.tasks.lock().retain(|task| task.future.is_some());
+
+            if !progressed {
+                return steps;
+            }
+        }
+    }
+
+    /// Queued-but-unfinished work, `(jobs, futures)`.
+    #[must_use]
+    pub fn pending(&self) -> (usize, usize) {
+        (self.inner.jobs.lock().len(), self.inner.tasks.lock().len())
+    }
+}
+
+impl fmt::Debug for DeterministicExecutors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (jobs, futures) = self.pending();
+        f.debug_struct("DeterministicExecutors")
+            .field("pending_jobs", &jobs)
+            .field("pending_futures", &futures)
+            .finish()
+    }
+}
+
+impl HostComputePool for DeterministicExecutors {
+    fn spawn_job(&self, job: ComputeJob) -> Result<(), SpawnError> {
+        self.inner.jobs.lock().push_back(job);
+        Ok(())
+    }
+}
+
+impl HostIoPool for DeterministicExecutors {
+    fn spawn_future(&self, future: IoFuture) -> Result<(), SpawnError> {
+        self.inner.tasks.lock().push(DeterministicTask {
+            future: Some(future),
+            // Starts ready: a fresh future needs its first poll.
+            ready: Arc::new(AtomicBool::new(true)),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::time::Duration;
+
+    /// Pool-sizing policy: at least one worker, and on any machine with
+    /// enough hardware threads for the split (>= 4), the background lanes
+    /// together leave the owner thread a hardware thread of its own.
+    #[test]
+    fn compute_pool_sizing_leaves_owner_thread_headroom() {
+        assert_eq!(default_compute_worker_count(1), 1);
+        assert_eq!(default_compute_worker_count(2), 1);
+        assert_eq!(default_compute_worker_count(3), 1);
+        assert_eq!(default_compute_worker_count(4), 1);
+        assert_eq!(default_compute_worker_count(8), 5);
+        assert_eq!(default_compute_worker_count(32), 29);
+        for available in 4..=128 {
+            let compute = default_compute_worker_count(available);
+            assert!(
+                compute + IO_WORKER_THREADS < available,
+                "with {available} hardware threads, compute={compute} + io={IO_WORKER_THREADS} \
+                 must leave the owner thread headroom"
+            );
+        }
+    }
+
+    // ── conformance suite: the same contract for default and injected ──────
+    //
+    // Each check runs against BOTH backends: FLUI's default pools and the
+    // injected `DeterministicExecutors` — the "an injected deterministic
+    // executor passes the same tests" acceptance evidence. `drive` makes
+    // queued deterministic work actually run; it is a no-op for the default
+    // pools (their worker threads run the work themselves).
+
+    fn both_backends(check: impl Fn(&ExecutionServices, &dyn Fn())) {
+        let default_services =
+            ExecutionServices::with_limits(None, AdmissionLimits { compute: 4, io: 4 });
+        check(&default_services, &|| {});
+        default_services.shutdown(Duration::from_secs(5));
+
+        let deterministic = DeterministicExecutors::new();
+        let injected = ExecutionServices::with_limits(
+            Some(deterministic.host_executors()),
+            AdmissionLimits { compute: 4, io: 4 },
+        );
+        let driver = deterministic.clone();
+        check(&injected, &move || {
+            driver.run_until_idle();
+        });
+    }
+
+    #[test]
+    fn conformance_spawned_compute_job_runs() {
+        both_backends(|services, drive| {
+            let ran = Arc::new(AtomicBool::new(false));
+            let ran_for_job = Arc::clone(&ran);
+            services
+                .spawn_compute(Box::new(move || {
+                    ran_for_job.store(true, Ordering::Release);
+                }))
+                .expect("spawn must be admitted");
+            drive();
+            // Default pools run on worker threads; wait bounded.
+            wait_until(|| ran.load(Ordering::Acquire));
+            assert!(ran.load(Ordering::Acquire));
+        });
+    }
+
+    #[test]
+    fn conformance_spawned_io_future_completes() {
+        both_backends(|services, drive| {
+            let done = Arc::new(AtomicBool::new(false));
+            let done_for_future = Arc::clone(&done);
+            services
+                .spawn_io(Box::pin(async move {
+                    done_for_future.store(true, Ordering::Release);
+                }))
+                .expect("spawn must be admitted");
+            drive();
+            wait_until(|| done.load(Ordering::Acquire));
+            assert!(done.load(Ordering::Acquire));
+        });
+    }
+
+    #[test]
+    fn conformance_no_admission_after_shutdown() {
+        both_backends(|services, _drive| {
+            services.shutdown(Duration::from_secs(5));
+            let result = services.spawn_compute(Box::new(|| {}));
+            assert_eq!(result, Err(SpawnError::ShuttingDown));
+            let result = services.spawn_io(Box::pin(async {}));
+            assert_eq!(result, Err(SpawnError::ShuttingDown));
+        });
+    }
+
+    #[test]
+    fn conformance_admission_is_bounded_and_released() {
+        // Deterministic backend: queued work does not run until driven, so
+        // the admission window fills deterministically.
+        let deterministic = DeterministicExecutors::new();
+        let services = ExecutionServices::with_limits(
+            Some(deterministic.host_executors()),
+            AdmissionLimits { compute: 2, io: 2 },
+        );
+
+        for _ in 0..2 {
+            services
+                .spawn_compute(Box::new(|| {}))
+                .expect("within the admission window");
+        }
+        assert_eq!(
+            services.spawn_compute(Box::new(|| {})),
+            Err(SpawnError::Saturated),
+            "the third job must be refused, not queued without bound"
+        );
+
+        for _ in 0..2 {
+            services
+                .spawn_io(Box::pin(async {}))
+                .expect("within the admission window");
+        }
+        assert_eq!(
+            services.spawn_io(Box::pin(async {})),
+            Err(SpawnError::Saturated)
+        );
+
+        // Running the queued work releases the slots: admission recovers.
+        deterministic.run_until_idle();
+        assert_eq!(services.in_flight(), (0, 0));
+        services
+            .spawn_compute(Box::new(|| {}))
+            .expect("slots must be released after completion");
+        services
+            .spawn_io(Box::pin(async {}))
+            .expect("slots must be released after completion");
+    }
+
+    /// Bounded admission on the DEFAULT pools too: park the compute workers
+    /// on a gate, fill the window, and assert refusal while full.
+    #[test]
+    fn default_pool_admission_saturates_while_workers_are_parked() {
+        let services = ExecutionServices::with_limits(None, AdmissionLimits { compute: 2, io: 2 });
+        let gate = Arc::new(AtomicBool::new(false));
+        for _ in 0..2 {
+            let gate = Arc::clone(&gate);
+            services
+                .spawn_compute(Box::new(move || {
+                    while !gate.load(Ordering::Acquire) {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                }))
+                .expect("within the admission window");
+        }
+        assert_eq!(
+            services.spawn_compute(Box::new(|| {})),
+            Err(SpawnError::Saturated)
+        );
+        gate.store(true, Ordering::Release);
+        wait_until(|| services.in_flight().0 == 0);
+        services
+            .spawn_compute(Box::new(|| {}))
+            .expect("slots must be released after the gated jobs finish");
+        services.shutdown(Duration::from_secs(5));
+    }
+
+    /// Shutdown joins a RUNNING compute job: the job observably finishes
+    /// before `shutdown` returns.
+    #[test]
+    fn shutdown_joins_running_compute_work() {
+        let services = ExecutionServices::with_defaults();
+        let started = Arc::new(AtomicBool::new(false));
+        let finished = Arc::new(AtomicBool::new(false));
+        let started_for_job = Arc::clone(&started);
+        let finished_for_job = Arc::clone(&finished);
+        services
+            .spawn_compute(Box::new(move || {
+                started_for_job.store(true, Ordering::Release);
+                std::thread::sleep(Duration::from_millis(100));
+                finished_for_job.store(true, Ordering::Release);
+            }))
+            .expect("spawn must be admitted");
+        wait_until(|| started.load(Ordering::Acquire));
+
+        services.shutdown(Duration::from_secs(10));
+        assert!(
+            finished.load(Ordering::Acquire),
+            "shutdown must join running work, not abandon it"
+        );
+    }
+
+    /// Shutdown CANCELS a parked IO future promptly: a future that would
+    /// otherwise never resolve is dropped at its await point (destructors
+    /// run) and shutdown does not burn the whole grace deadline on it.
+    #[test]
+    fn shutdown_cancels_parked_io_future_without_burning_the_deadline() {
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let services = ExecutionServices::with_defaults();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let polled = Arc::new(AtomicBool::new(false));
+        let flag = DropFlag(Arc::clone(&dropped));
+        let polled_for_future = Arc::clone(&polled);
+        services
+            .spawn_io(Box::pin(async move {
+                let _flag = flag;
+                polled_for_future.store(true, Ordering::Release);
+                std::future::pending::<()>().await;
+            }))
+            .expect("spawn must be admitted");
+        wait_until(|| polled.load(Ordering::Acquire));
+
+        let grace = Duration::from_secs(30);
+        let before = std::time::Instant::now();
+        services.shutdown(grace);
+        let elapsed = before.elapsed();
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "cancellation must drop the parked future (destructors run)"
+        );
+        assert!(
+            elapsed < Duration::from_secs(15),
+            "a cancelled future must not burn the grace deadline; took {elapsed:?}"
+        );
+    }
+
+    /// Cancellation must work on pools FLUI does not own: with host-injected
+    /// executors, shutdown cannot drop the host's tasks — the wrapper's
+    /// cancellation point is the only mechanism. After `shutdown`, the next
+    /// drive of the host executor must resolve a parked future (its
+    /// destructors run) instead of leaving it parked forever.
+    #[test]
+    fn shutdown_cancels_work_handed_to_host_pools() {
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let deterministic = DeterministicExecutors::new();
+        let services = ExecutionServices::with_host(deterministic.host_executors());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let flag = DropFlag(Arc::clone(&dropped));
+        services
+            .spawn_io(Box::pin(async move {
+                let _flag = flag;
+                std::future::pending::<()>().await;
+            }))
+            .expect("spawn must be admitted");
+
+        deterministic.run_until_idle();
+        assert_eq!(
+            deterministic.pending(),
+            (0, 1),
+            "the future is parked in the host pool"
+        );
+        assert!(!dropped.load(Ordering::Acquire));
+
+        services.shutdown(Duration::from_secs(5));
+        deterministic.run_until_idle();
+        assert_eq!(
+            deterministic.pending(),
+            (0, 0),
+            "cancellation must resolve the parked future in the host pool"
+        );
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "cancellation must drop the parked future (destructors run)"
+        );
+        assert_eq!(
+            services.in_flight(),
+            (0, 0),
+            "the admission slot is released"
+        );
+    }
+
+    /// Host injection: work routes to the host pools and the default pools
+    /// are never constructed — no second set of worker threads.
+    #[test]
+    fn host_injection_routes_work_and_never_starts_default_pools() {
+        let deterministic = DeterministicExecutors::new();
+        let services = ExecutionServices::with_host(deterministic.host_executors());
+        assert!(!services.owns_default_pools());
+
+        let compute_ran = Arc::new(AtomicBool::new(false));
+        let io_ran = Arc::new(AtomicBool::new(false));
+        let compute_flag = Arc::clone(&compute_ran);
+        let io_flag = Arc::clone(&io_ran);
+        services
+            .spawn_compute(Box::new(move || {
+                compute_flag.store(true, Ordering::Release);
+            }))
+            .expect("spawn must be admitted");
+        services
+            .spawn_io(Box::pin(async move {
+                io_flag.store(true, Ordering::Release);
+            }))
+            .expect("spawn must be admitted");
+
+        assert!(
+            !compute_ran.load(Ordering::Acquire) && !io_ran.load(Ordering::Acquire),
+            "deterministic host work must not run before it is driven"
+        );
+        deterministic.run_until_idle();
+        assert!(compute_ran.load(Ordering::Acquire));
+        assert!(io_ran.load(Ordering::Acquire));
+        assert!(
+            !services.default_pools_started(),
+            "host injection must never construct the default pools"
+        );
+    }
+
+    /// Default pools are lazy: constructing the services starts no worker
+    /// threads; the first spawn on a lane starts exactly that lane.
+    #[test]
+    fn default_pools_start_lazily_on_first_spawn() {
+        let services = ExecutionServices::with_defaults();
+        assert!(
+            !services.default_pools_started(),
+            "construction must not start worker threads"
+        );
+        services
+            .spawn_compute(Box::new(|| {}))
+            .expect("spawn must be admitted");
+        assert!(services.default_pools_started());
+        services.shutdown(Duration::from_secs(5));
+    }
+
+    /// The frame lane needs no pool: with the compute admission window full
+    /// and every worker parked, frame-thread work (an `AsyncDriver` poll on
+    /// this thread) still completes immediately. This pins the structural
+    /// half of "background work cannot starve frame-required compute" — the
+    /// sizing half is `compute_pool_sizing_leaves_owner_thread_headroom`.
+    #[test]
+    fn frame_lane_makes_progress_while_background_lanes_are_saturated() {
+        let services = ExecutionServices::with_limits(None, AdmissionLimits { compute: 2, io: 2 });
+        let gate = Arc::new(AtomicBool::new(false));
+        for _ in 0..2 {
+            let gate = Arc::clone(&gate);
+            services
+                .spawn_compute(Box::new(move || {
+                    while !gate.load(Ordering::Acquire) {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                }))
+                .expect("within the admission window");
+        }
+        assert_eq!(
+            services.spawn_compute(Box::new(|| {})),
+            Err(SpawnError::Saturated),
+            "background lane is saturated"
+        );
+
+        // Frame-lane work: an AsyncDriver task polled on THIS thread.
+        let driver = flui_scheduler::AsyncDriver::new();
+        let done = Arc::new(AtomicBool::new(false));
+        let done_for_task = Arc::clone(&done);
+        let _token = driver.spawn_local(Box::pin(async move {
+            done_for_task.store(true, Ordering::Release);
+        }));
+        assert_eq!(driver.poll_ready(), 1);
+        assert!(
+            done.load(Ordering::Acquire),
+            "the frame lane must complete without waiting for pool capacity"
+        );
+
+        gate.store(true, Ordering::Release);
+        services.shutdown(Duration::from_secs(5));
+    }
+
+    /// Shutdown is idempotent and a shutdown'd default backend refuses work
+    /// even if a stale caller re-checks after the pools are closed.
+    #[test]
+    fn shutdown_is_idempotent() {
+        let services = ExecutionServices::with_defaults();
+        services
+            .spawn_compute(Box::new(|| {}))
+            .expect("spawn must be admitted");
+        services.shutdown(Duration::from_secs(5));
+        services.shutdown(Duration::from_secs(5));
+        assert_eq!(
+            services.spawn_io(Box::pin(async {})),
+            Err(SpawnError::ShuttingDown)
+        );
+    }
+
+    // ── deterministic executor semantics ────────────────────────────────────
+
+    #[test]
+    fn deterministic_runs_in_fifo_spawn_order() {
+        let deterministic = DeterministicExecutors::new();
+        let order = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        for index in 0..4 {
+            let order = Arc::clone(&order);
+            deterministic
+                .spawn_job(Box::new(move || order.lock().push(index)))
+                .expect("deterministic spawn is unbounded");
+        }
+        deterministic.run_until_idle();
+        assert_eq!(*order.lock(), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn deterministic_parks_pending_futures_until_woken() {
+        let deterministic = DeterministicExecutors::new();
+        let polls = Arc::new(AtomicUsize::new(0));
+        let finish = Arc::new(AtomicBool::new(false));
+        let waker_slot: Arc<parking_lot::Mutex<Option<std::task::Waker>>> =
+            Arc::new(parking_lot::Mutex::new(None));
+
+        let polls_for_future = Arc::clone(&polls);
+        let finish_for_future = Arc::clone(&finish);
+        let waker_for_future = Arc::clone(&waker_slot);
+        deterministic
+            .spawn_future(Box::pin(std::future::poll_fn(move |context| {
+                polls_for_future.fetch_add(1, Ordering::Relaxed);
+                if finish_for_future.load(Ordering::Acquire) {
+                    std::task::Poll::Ready(())
+                } else {
+                    *waker_for_future.lock() = Some(context.waker().clone());
+                    std::task::Poll::Pending
+                }
+            })))
+            .expect("deterministic spawn is unbounded");
+
+        deterministic.run_until_idle();
+        assert_eq!(polls.load(Ordering::Relaxed), 1, "one poll, then parked");
+        deterministic.run_until_idle();
+        assert_eq!(polls.load(Ordering::Relaxed), 1, "no wake ⇒ no poll");
+
+        finish.store(true, Ordering::Release);
+        waker_slot
+            .lock()
+            .as_ref()
+            .expect("waker stored")
+            .wake_by_ref();
+        deterministic.run_until_idle();
+        assert_eq!(polls.load(Ordering::Relaxed), 2);
+        assert_eq!(deterministic.pending(), (0, 0));
+    }
+
+    /// Bounded wait for cross-thread effects (default pools run on worker
+    /// threads). Panics after 10s so a broken test fails loudly instead of
+    /// hanging the suite.
+    fn wait_until(condition: impl Fn() -> bool) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !condition() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "condition not reached within 10s"
+            );
+            std::thread::sleep(Duration::from_millis(2));
+        }
+    }
+}

--- a/crates/flui-app/src/app/execution.rs
+++ b/crates/flui-app/src/app/execution.rs
@@ -96,6 +96,15 @@ pub enum SpawnError {
     /// work is admitted.
     #[error("execution services are shutting down; new work is refused")]
     ShuttingDown,
+    /// The lane's worker pool could not be started — the OS refused thread
+    /// creation (resource exhaustion). An environment failure, not a bug
+    /// (see `docs/PANIC-POLICY.md`): the pool slot stays unstarted, so a
+    /// later spawn retries once resources free up.
+    #[error(
+        "the executor lane's worker pool could not be started (OS thread/resource \
+         exhaustion); a later spawn may succeed"
+    )]
+    Unavailable,
 }
 
 /// Host-provided worker pool for the **asynchronous compute** work class.
@@ -308,9 +317,8 @@ impl DefaultPools {
         }
     }
 
-    /// Handle to the IO runtime, starting it on first use. `None` once the
-    /// slot is closed by shutdown.
-    fn io_handle(&self) -> Option<tokio::runtime::Handle> {
+    /// Handle to the IO runtime, starting it on first use.
+    fn io_handle(&self) -> Result<tokio::runtime::Handle, SpawnError> {
         Self::handle_of(&self.io, || {
             tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(IO_WORKER_THREADS)
@@ -320,9 +328,8 @@ impl DefaultPools {
         })
     }
 
-    /// Handle to the compute runtime, starting it on first use. `None` once
-    /// the slot is closed by shutdown.
-    fn compute_handle(&self) -> Option<tokio::runtime::Handle> {
+    /// Handle to the compute runtime, starting it on first use.
+    fn compute_handle(&self) -> Result<tokio::runtime::Handle, SpawnError> {
         Self::handle_of(&self.compute, || {
             let workers = default_compute_worker_count(
                 std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
@@ -336,23 +343,34 @@ impl DefaultPools {
         })
     }
 
+    /// `Err(ShuttingDown)` once the slot is closed by shutdown;
+    /// `Err(Unavailable)` when the OS refuses to start the pool — an
+    /// environment failure, not an invariant, so no panic
+    /// (`docs/PANIC-POLICY.md`): the slot stays `NotStarted` and a later
+    /// spawn retries.
     fn handle_of(
         slot: &parking_lot::Mutex<PoolSlot>,
         build: impl FnOnce() -> std::io::Result<tokio::runtime::Runtime>,
-    ) -> Option<tokio::runtime::Handle> {
+    ) -> Result<tokio::runtime::Handle, SpawnError> {
         let mut slot = slot.lock();
         match &*slot {
-            PoolSlot::Running(runtime) => Some(runtime.handle().clone()),
-            PoolSlot::Closed => None,
-            PoolSlot::NotStarted => {
-                let runtime = build().expect(
-                    "BUG: building a tokio runtime must succeed on any platform \
-                     this crate targets short of OS thread exhaustion",
-                );
-                let handle = runtime.handle().clone();
-                *slot = PoolSlot::Running(runtime);
-                Some(handle)
-            }
+            PoolSlot::Running(runtime) => Ok(runtime.handle().clone()),
+            PoolSlot::Closed => Err(SpawnError::ShuttingDown),
+            PoolSlot::NotStarted => match build() {
+                Ok(runtime) => {
+                    let handle = runtime.handle().clone();
+                    *slot = PoolSlot::Running(runtime);
+                    Ok(handle)
+                }
+                Err(error) => {
+                    tracing::error!(
+                        %error,
+                        "failed to start a background worker pool; refusing the spawn \
+                         (the slot stays unstarted, a later spawn retries)"
+                    );
+                    Err(SpawnError::Unavailable)
+                }
+            },
         }
     }
 
@@ -400,8 +418,10 @@ impl ExecutionServices {
         }
     }
 
-    /// Whether this instance routes to host-injected pools (`false`) or owns
-    /// the default pools (`true`).
+    /// Whether this instance executes background work on FLUI's own backend
+    /// (`true` — the lazily-started default pools on native targets,
+    /// sequential in-place execution on wasm32) rather than routing it to
+    /// host-injected pools (`false`).
     pub(crate) fn owns_default_pools(&self) -> bool {
         !matches!(self.backend, Backend::Host(_))
     }
@@ -430,9 +450,9 @@ impl ExecutionServices {
             match &self.backend {
                 Backend::Host(host) => host.compute.spawn_job(wrapped),
                 Backend::Default(pools) => {
-                    let Some(handle) = pools.compute_handle() else {
-                        return Err(SpawnError::ShuttingDown);
-                    };
+                    // On `Err`, dropping `wrapped` drops the admission
+                    // guard captured inside it — the slot is released.
+                    let handle = pools.compute_handle()?;
                     handle.spawn(async move { wrapped() });
                     Ok(())
                 }
@@ -481,9 +501,9 @@ impl ExecutionServices {
             match &self.backend {
                 Backend::Host(host) => host.io.spawn_future(wrapped),
                 Backend::Default(pools) => {
-                    let Some(handle) = pools.io_handle() else {
-                        return Err(SpawnError::ShuttingDown);
-                    };
+                    // On `Err`, dropping `wrapped` drops the admission
+                    // guard captured inside it — the slot is released.
+                    let handle = pools.io_handle()?;
                     handle.spawn(wrapped);
                     Ok(())
                 }
@@ -616,6 +636,16 @@ impl Drop for ExecutionServices {
 /// each pass). Doubles as the reference implementation proving the
 /// [`HostComputePool`]/[`HostIoPool`] contract is implementable outside
 /// FLUI.
+///
+/// # Single-driver contract
+///
+/// Clones share one queue set: spawning from any thread — including from
+/// inside driven work — is always fine. **Driving** is exclusive: at most
+/// one [`run_until_idle`](Self::run_until_idle) may be in flight at a time,
+/// and a second concurrent or reentrant call panics (`BUG:`) rather than
+/// risk silently cancelling the first driver's in-flight task. Two
+/// interleaved drivers would also not be *deterministic*, which is this
+/// type's entire point.
 #[derive(Clone, Default)]
 pub struct DeterministicExecutors {
     inner: Arc<DeterministicShared>,
@@ -625,6 +655,9 @@ pub struct DeterministicExecutors {
 struct DeterministicShared {
     jobs: parking_lot::Mutex<std::collections::VecDeque<ComputeJob>>,
     tasks: parking_lot::Mutex<Vec<DeterministicTask>>,
+    /// Exclusivity latch for [`DeterministicExecutors::run_until_idle`] —
+    /// see the type's "Single-driver contract" doc section.
+    driving: AtomicBool,
 }
 
 struct DeterministicTask {
@@ -670,13 +703,44 @@ impl DeterministicExecutors {
     /// repeating until a full pass makes no progress. Futures that returned
     /// `Pending` without an intervening wake stay parked (they are not spun
     /// on). Returns the number of jobs run plus polls made.
+    ///
+    /// # Panics
+    ///
+    /// Panics (`BUG:`) if a drive is already in flight — from another
+    /// thread, or reentrantly from inside driven work. See the type's
+    /// "Single-driver contract" doc section: a second driver could observe
+    /// the first's checked-out task slot and silently cancel it, and
+    /// interleaved drivers are not deterministic. Spawning during a drive
+    /// is always fine; driving is what must be exclusive.
     pub fn run_until_idle(&self) -> usize {
+        assert!(
+            !self.inner.driving.swap(true, Ordering::AcqRel),
+            "BUG: DeterministicExecutors::run_until_idle called while a drive is \
+             already in flight -- this executor has a single-driver contract: one \
+             drive at a time, never from inside driven work"
+        );
+        /// Clears the latch on every exit path, including an unwind out of
+        /// a driven job's own panic.
+        struct DriveGuard<'latch>(&'latch AtomicBool);
+        impl Drop for DriveGuard<'_> {
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::Release);
+            }
+        }
+        let _driving = DriveGuard(&self.inner.driving);
+
         let mut steps = 0;
         loop {
             let mut progressed = false;
 
-            // Compute jobs first, FIFO.
-            while let Some(job) = self.inner.jobs.lock().pop_front() {
+            // Compute jobs first, FIFO. The pop is its own statement so the
+            // lock guard drops BEFORE the job runs — a `while let` scrutinee
+            // temporary would live across the loop body, and a job that
+            // spawns (same lock) would then deadlock on this non-reentrant
+            // mutex. Pinned by `deterministic_job_may_spawn_during_drive`.
+            loop {
+                let job = self.inner.jobs.lock().pop_front();
+                let Some(job) = job else { break };
                 job();
                 steps += 1;
                 progressed = true;
@@ -1223,6 +1287,116 @@ mod tests {
         deterministic.run_until_idle();
         assert_eq!(polls.load(Ordering::Relaxed), 2);
         assert_eq!(deterministic.pending(), (0, 0));
+    }
+
+    /// The single-driver contract is loud: a reentrant drive (here from
+    /// inside a driven compute job) panics with a `BUG:` message instead of
+    /// silently cancelling the outer drive's in-flight work. Fails without
+    /// the `driving` latch — the nested call would simply run.
+    #[test]
+    #[should_panic(expected = "single-driver contract")]
+    fn deterministic_reentrant_drive_panics_instead_of_corrupting() {
+        let deterministic = DeterministicExecutors::new();
+        let inner = deterministic.clone();
+        deterministic
+            .spawn_job(Box::new(move || {
+                let _ = inner.run_until_idle();
+            }))
+            .expect("deterministic spawn is unbounded");
+        deterministic.run_until_idle();
+    }
+
+    /// Spawning from inside driven work is explicitly allowed (only
+    /// *driving* is exclusive): a job that spawns a follow-up job must not
+    /// deadlock on the queue lock, and the follow-up runs within the same
+    /// drive. Fails (by deadlock-timeout) if the job queue's lock guard is
+    /// held across the job call.
+    #[test]
+    fn deterministic_job_may_spawn_during_drive() {
+        let deterministic = DeterministicExecutors::new();
+        let inner = deterministic.clone();
+        let child_ran = Arc::new(AtomicBool::new(false));
+        let child_flag = Arc::clone(&child_ran);
+        deterministic
+            .spawn_job(Box::new(move || {
+                let child_flag = Arc::clone(&child_flag);
+                inner
+                    .spawn_job(Box::new(move || {
+                        child_flag.store(true, Ordering::Release);
+                    }))
+                    .expect("deterministic spawn is unbounded");
+            }))
+            .expect("deterministic spawn is unbounded");
+
+        deterministic.run_until_idle();
+        assert!(
+            child_ran.load(Ordering::Acquire),
+            "a job spawned during the drive runs within that same drive"
+        );
+        assert_eq!(deterministic.pending(), (0, 0));
+    }
+
+    /// The latch clears on unwind: after a driven job panics, a later
+    /// drive on the same executor works instead of tripping the guard.
+    #[test]
+    fn deterministic_drive_recovers_after_a_panicking_job() {
+        let deterministic = DeterministicExecutors::new();
+        deterministic
+            .spawn_job(Box::new(|| panic!("job panic (expected by this test)")))
+            .expect("deterministic spawn is unbounded");
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            deterministic.run_until_idle();
+        }));
+        assert!(unwound.is_err(), "the driven job's panic propagates");
+
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_for_job = Arc::clone(&ran);
+        deterministic
+            .spawn_job(Box::new(move || ran_for_job.store(true, Ordering::Release)))
+            .expect("deterministic spawn is unbounded");
+        deterministic.run_until_idle();
+        assert!(
+            ran.load(Ordering::Acquire),
+            "the latch must clear on unwind"
+        );
+    }
+
+    /// Pool-start failure is an environment error, not a panic
+    /// (`docs/PANIC-POLICY.md`): the spawn is refused with `Unavailable`,
+    /// the slot stays unstarted, and a later attempt (resources freed)
+    /// succeeds. Driven through `handle_of`'s injected builder because a
+    /// REAL tokio build failure needs OS thread/resource exhaustion, which
+    /// no test can produce deterministically without destabilizing the
+    /// process it runs in.
+    #[test]
+    fn pool_start_failure_refuses_the_spawn_and_recovers() {
+        let slot = parking_lot::Mutex::new(PoolSlot::NotStarted);
+
+        let result = DefaultPools::handle_of(&slot, || {
+            Err(std::io::Error::other(
+                "simulated: OS refused thread creation",
+            ))
+        });
+        assert_eq!(result.err(), Some(SpawnError::Unavailable));
+        assert!(
+            matches!(&*slot.lock(), PoolSlot::NotStarted),
+            "a failed start must leave the slot unstarted for a later retry"
+        );
+
+        let recovered = DefaultPools::handle_of(&slot, || {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .thread_name("flui-test-recovery")
+                .build()
+        });
+        assert!(
+            recovered.is_ok(),
+            "once the environment recovers, the same slot must start normally"
+        );
+        // Tear the started runtime down non-blockingly.
+        if let Some(runtime) = slot.lock().take_runtime() {
+            runtime.shutdown_background();
+        }
     }
 
     /// Bounded wait for cross-thread effects (default pools run on worker

--- a/crates/flui-app/src/app/mod.rs
+++ b/crates/flui-app/src/app/mod.rs
@@ -12,6 +12,7 @@
 
 mod config;
 pub mod direct;
+pub(crate) mod execution;
 pub(crate) mod hot_reload;
 pub(crate) mod logging;
 pub(crate) mod media_query_root;
@@ -25,6 +26,10 @@ pub(crate) mod window_registry;
 
 pub use config::{AppConfig, DiagnosticsProfile};
 pub use direct::run_direct;
+pub use execution::{
+    ComputeJob, DeterministicExecutors, HostComputePool, HostExecutors, HostIoPool, IoFuture,
+    SpawnError,
+};
 #[cfg(all(
     not(target_os = "android"),
     not(target_os = "ios"),

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -1707,6 +1707,12 @@ fn install_platform_realm(
         // it does not matter whether a prior realm on this thread already
         // triggered it.
         let _ = state.ensure_services();
+        // Same known-point discipline for the loop-scoped execution
+        // services (issue #557): resolved here (host-injected if the
+        // bootstrap stashed `AppConfig::executors`, default pools
+        // otherwise), never ambiently. Cheap — default pools start worker
+        // threads on first background spawn, not here.
+        let _ = state.ensure_execution();
         displaced
     });
     // Destructors may re-enter platform/framework code (the same invariant
@@ -2536,6 +2542,13 @@ fn drain_owner_inbox(realm: &super::ui_realm::UiRealm) -> bool {
     realm.take_redraw_request()
 }
 
+/// Per-pool grace deadline for joining running background work at full
+/// loop-exit teardown. Bounds a hung compute job's ability to wedge process
+/// exit; running work that finishes sooner ends shutdown sooner (the
+/// deadline is a cap, not a sleep).
+#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
+const EXECUTION_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn teardown_platform_realm() {
     let realms = APP_RUNTIME.with(|slot| {
@@ -2576,6 +2589,17 @@ fn teardown_platform_realm() {
     // Destructors may re-enter platform/framework code. Drop only after the
     // TLS borrow and incarnation identity have been released.
     drop(realms);
+
+    // Execution-services shutdown (issue #557): the whole loop is exiting,
+    // so stop background admission, cancel outstanding work, and join
+    // running work bounded by a per-pool grace deadline. Loop-scoped like
+    // the clipboard below — hot-restart never reaches this function, so a
+    // reinstalled realm keeps its pools. A teardown path that skips this
+    // (panic mid-teardown) still tears the pools down non-blockingly via
+    // `ExecutionServices`' own `Drop`.
+    APP_RUNTIME.with(|slot| {
+        slot.borrow().shutdown_execution(EXECUTION_SHUTDOWN_GRACE);
+    });
 
     // ADR-0034's install/teardown symmetry: the event loop has exited (this
     // runs from both `run_desktop` and `run_android`, after their respective
@@ -2636,6 +2660,58 @@ mod realm_dispatch_tests {
 
     fn install_test_realm() -> RealmDispatcher {
         install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &test_window())
+    }
+
+    /// Installing a realm resolves the loop-scoped execution services
+    /// (issue #557) at the same known point as `SharedEngineServices` — and
+    /// full loop-exit teardown shuts them down: afterwards the services are
+    /// still resolved (nothing can silently rebuild pools on an exiting
+    /// loop) but refuse every spawn.
+    ///
+    /// If reverted: remove the `ensure_execution` call from
+    /// `install_platform_realm` and the first assertion fails; remove the
+    /// `shutdown_execution` call from `teardown_platform_realm` and the
+    /// refusal assertion fails.
+    #[test]
+    fn install_resolves_execution_services_and_teardown_shuts_them_down() {
+        use crate::app::execution::SpawnError;
+
+        APP_RUNTIME.with(|slot| {
+            assert!(
+                slot.borrow().execution().is_none(),
+                "no execution services before any realm is installed"
+            );
+        });
+
+        install_test_realm();
+        APP_RUNTIME.with(|slot| {
+            let state = slot.borrow();
+            let services = state
+                .execution()
+                .expect("install_platform_realm must resolve execution services");
+            assert!(services.owns_default_pools());
+            assert!(
+                !services.default_pools_started(),
+                "resolution must not start worker threads; pools start on first spawn"
+            );
+        });
+
+        teardown_platform_realm();
+        APP_RUNTIME.with(|slot| {
+            let state = slot.borrow();
+            let services = state
+                .execution()
+                .expect("teardown leaves the shut-down services in place");
+            assert_eq!(
+                services.spawn_compute(Box::new(|| {})),
+                Err(SpawnError::ShuttingDown),
+                "background admission must be closed after full loop-exit teardown"
+            );
+            assert_eq!(
+                services.spawn_io(Box::pin(async {})),
+                Err(SpawnError::ShuttingDown)
+            );
+        });
     }
 
     /// A second realm installed on the same thread (hot-restart; sequential
@@ -8791,6 +8867,14 @@ where
         // `AppRuntime`, invisible to the platform layer) can veto an exit
         // the backend would otherwise take unconditionally.
         install_exit_policy_hook(config.exit_policy);
+
+        // 0b2. Stash host-injected executors (issue #557) BEFORE the realm
+        // install below resolves the loop's execution services — the order
+        // that makes `ensure_execution` route background work to the host's
+        // pools instead of constructing the default ones.
+        if let Some(host) = config.executors.clone() {
+            APP_RUNTIME.with(|slot| slot.borrow_mut().install_host_executors(host));
+        }
 
         // 0c. This window's device-recovery backoff, constructed here (not
         // down at step 6 alongside the renderer it paces) so the

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -2591,14 +2591,19 @@ fn teardown_platform_realm() {
     drop(realms);
 
     // Execution-services shutdown (issue #557): the whole loop is exiting,
-    // so stop background admission, cancel outstanding work, and join
-    // running work bounded by a per-pool grace deadline. Loop-scoped like
-    // the clipboard below — hot-restart never reaches this function, so a
-    // reinstalled realm keeps its pools. A teardown path that skips this
-    // (panic mid-teardown) still tears the pools down non-blockingly via
+    // so stop background admission, cancel outstanding work, join running
+    // work bounded by a per-pool grace deadline, and CLEAR the slot — a
+    // second platform loop hosted on this same thread later (an embedder
+    // running `run_app` twice in one process) must re-resolve fresh
+    // services at its own realm install, not inherit an instance whose
+    // admission is permanently closed. Loop-scoped like the clipboard
+    // below — hot-restart never reaches this function, so a reinstalled
+    // realm keeps its pools. A teardown path that skips this (panic
+    // mid-teardown) still tears the pools down non-blockingly via
     // `ExecutionServices`' own `Drop`.
     APP_RUNTIME.with(|slot| {
-        slot.borrow().shutdown_execution(EXECUTION_SHUTDOWN_GRACE);
+        slot.borrow_mut()
+            .shutdown_execution(EXECUTION_SHUTDOWN_GRACE);
     });
 
     // ADR-0034's install/teardown symmetry: the event loop has exited (this
@@ -2664,17 +2669,20 @@ mod realm_dispatch_tests {
 
     /// Installing a realm resolves the loop-scoped execution services
     /// (issue #557) at the same known point as `SharedEngineServices` — and
-    /// full loop-exit teardown shuts them down: afterwards the services are
-    /// still resolved (nothing can silently rebuild pools on an exiting
-    /// loop) but refuse every spawn.
+    /// full loop-exit teardown shuts them down AND clears the slot, so a
+    /// SECOND platform loop hosted on this same thread (an embedder running
+    /// `run_app` twice in one process; a headless-restart harness) gets
+    /// fresh, working services that honor its own injected executors
+    /// instead of inheriting an instance whose admission is permanently
+    /// closed.
     ///
     /// If reverted: remove the `ensure_execution` call from
     /// `install_platform_realm` and the first assertion fails; remove the
-    /// `shutdown_execution` call from `teardown_platform_realm` and the
-    /// refusal assertion fails.
+    /// `shutdown_execution` call from `teardown_platform_realm` (or make it
+    /// leave the slot filled) and the second loop's assertions fail.
     #[test]
     fn install_resolves_execution_services_and_teardown_shuts_them_down() {
-        use crate::app::execution::SpawnError;
+        use crate::app::execution::DeterministicExecutors;
 
         APP_RUNTIME.with(|slot| {
             assert!(
@@ -2683,6 +2691,7 @@ mod realm_dispatch_tests {
             );
         });
 
+        // ── first loop: default pools ───────────────────────────────────
         install_test_realm();
         APP_RUNTIME.with(|slot| {
             let state = slot.borrow();
@@ -2698,20 +2707,40 @@ mod realm_dispatch_tests {
 
         teardown_platform_realm();
         APP_RUNTIME.with(|slot| {
+            assert!(
+                slot.borrow().execution().is_none(),
+                "full loop-exit teardown must clear the slot, not leave a dead instance"
+            );
+        });
+
+        // ── second loop on the same thread: its own injected executors ──
+        let deterministic = DeterministicExecutors::new();
+        APP_RUNTIME.with(|slot| {
+            slot.borrow_mut()
+                .install_host_executors(deterministic.host_executors());
+        });
+        install_test_realm();
+        let ran = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        APP_RUNTIME.with(|slot| {
             let state = slot.borrow();
             let services = state
                 .execution()
-                .expect("teardown leaves the shut-down services in place");
-            assert_eq!(
-                services.spawn_compute(Box::new(|| {})),
-                Err(SpawnError::ShuttingDown),
-                "background admission must be closed after full loop-exit teardown"
+                .expect("the second loop's install must re-resolve execution services");
+            assert!(
+                !services.owns_default_pools(),
+                "the second loop's injected executors must be honored, not ignored as late"
             );
-            assert_eq!(
-                services.spawn_io(Box::pin(async {})),
-                Err(SpawnError::ShuttingDown)
-            );
+            let ran_for_job = std::sync::Arc::clone(&ran);
+            services
+                .spawn_compute(Box::new(move || {
+                    ran_for_job.store(true, std::sync::atomic::Ordering::Release);
+                }))
+                .expect("the second loop's admission must be open");
         });
+        deterministic.run_until_idle();
+        assert!(ran.load(std::sync::atomic::Ordering::Acquire));
+
+        teardown_platform_realm();
     }
 
     /// A second realm installed on the same thread (hot-restart; sequential

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -70,6 +70,8 @@ use flui_semantics::AccessibilityFeatures;
 use parking_lot::{Mutex, RwLock};
 
 #[cfg(not(target_os = "ios"))]
+use super::execution::{ExecutionServices, HostExecutors};
+#[cfg(not(target_os = "ios"))]
 use super::runner::{RealmTask, SurfaceApplier};
 #[cfg(not(target_os = "ios"))]
 use super::ui_realm::UiRealm;
@@ -670,6 +672,20 @@ pub(crate) struct AppRuntime {
     /// Process-level engine services. Deliberately **not** resolved in
     /// [`AppRuntime::new`] -- see [`AppRuntime::ensure_services`] for why.
     services: OnceCell<SharedEngineServices>,
+    /// The loop-scoped background execution services (issue #557): both
+    /// background work-class lanes, their bounded admission, and the
+    /// shutdown protocol. Built at realm install
+    /// ([`Self::ensure_execution`]) from either the host-injected
+    /// [`HostExecutors`] stashed by [`Self::install_host_executors`] or the
+    /// lazily-started default pools. Loop-scoped like `owner_platform`:
+    /// hot-restart hosts a fresh realm on the same loop and must not
+    /// rebuild pools, so realm teardown never touches this — only full
+    /// loop-exit teardown shuts it down ([`Self::shutdown_execution`]).
+    execution: OnceCell<ExecutionServices>,
+    /// Host executors received from `AppConfig` before the first realm
+    /// install resolves `execution`. Taken by [`Self::ensure_execution`];
+    /// ignored (with a warning) if execution services already exist.
+    pending_host_executors: Option<HostExecutors>,
     /// Whether a redraw has been requested since the last
     /// [`Self::mark_rendered`] — the loop-scoped half of the retired
     /// `AppBinding.needs_redraw` flag, re-homed here as part of `AppBinding`'s
@@ -733,6 +749,8 @@ impl AppRuntime {
             iterating_all_realms: false,
             pending_realm_mutations: Vec::new(),
             services: OnceCell::new(),
+            execution: OnceCell::new(),
+            pending_host_executors: None,
             needs_redraw: Arc::new(AtomicBool::new(false)),
             redraw_window: Arc::new(Mutex::new(None)),
             platform_clipboard: Arc::new(Mutex::new(None)),
@@ -773,6 +791,94 @@ impl AppRuntime {
     #[cfg(test)]
     pub(super) fn services_resolved(&self) -> bool {
         self.services.get().is_some()
+    }
+
+    /// Stash the host's executors ahead of the first realm install (the
+    /// bootstrap step that resolves [`Self::ensure_execution`]). Called by
+    /// the runner when `AppConfig::executors` is `Some` — before
+    /// `install_platform_realm`, so the resolved services route to the host
+    /// instead of constructing the default pools.
+    ///
+    /// A stash arriving after execution services already exist is ignored
+    /// with a warning rather than rebuilt: pools may already be running
+    /// work, and silently swapping executors mid-run would strand it.
+    // Its one production caller (bootstrap_desktop's config wiring) is
+    // desktop-only; android/wasm have no host-injection entry point yet.
+    #[cfg_attr(
+        not(any(test, all(not(target_os = "android"), not(target_arch = "wasm32")))),
+        expect(
+            dead_code,
+            reason = "host executors are injected via AppConfig on the desktop bootstrap \
+                      only; android/web bootstraps gain the wiring with their own \
+                      host-injection slice"
+        )
+    )]
+    pub(super) fn install_host_executors(&mut self, host: HostExecutors) {
+        if self.execution.get().is_some() {
+            tracing::warn!(
+                "install_host_executors called after execution services were \
+                 already resolved; the injected executors are ignored"
+            );
+            return;
+        }
+        self.pending_host_executors = Some(host);
+    }
+
+    /// Resolves and caches the loop-scoped [`ExecutionServices`] on first
+    /// call (host-injected if [`Self::install_host_executors`] stashed a
+    /// bundle, default pools otherwise); returns the cached value on every
+    /// later call. Called from `install_platform_realm` alongside
+    /// [`Self::ensure_services`] — a realm is actually being installed, so
+    /// this loop genuinely hosts application work. Cheap either way: the
+    /// default pools start worker threads lazily, on first background
+    /// spawn, never here.
+    pub(super) fn ensure_execution(&mut self) -> &ExecutionServices {
+        let host = self.pending_host_executors.take();
+        self.execution.get_or_init(|| match host {
+            Some(host) => ExecutionServices::with_host(host),
+            None => ExecutionServices::with_defaults(),
+        })
+    }
+
+    /// The resolved execution services, if any. `None` before the first
+    /// realm install and on a loop (like `run_direct`'s) that never installs
+    /// a realm.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the background lanes' production callers are issue #558's \
+                      task/worker/service lifecycles; until then only tests read \
+                      the resolved services back"
+        )
+    )]
+    pub(super) fn execution(&self) -> Option<&ExecutionServices> {
+        self.execution.get()
+    }
+
+    /// Shut down the execution services: stop admission, cancel outstanding
+    /// work, join running work bounded by `grace` per pool. Runs at full
+    /// loop-exit teardown (`teardown_platform_realm`), never at per-realm
+    /// teardown — see the `execution` field's doc. After this, background
+    /// spawns refuse with `SpawnError::ShuttingDown`; the `OnceCell` stays
+    /// filled so nothing can silently rebuild pools on a loop that is
+    /// exiting. A drop without this explicit call still tears the pools
+    /// down non-blockingly (`ExecutionServices`' own `Drop`).
+    // Its production caller (teardown_platform_realm) is not compiled on
+    // wasm32, where shutdown is a no-op by construction (sequential
+    // execution; nothing to join).
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(test)),
+        expect(
+            dead_code,
+            reason = "full loop-exit teardown (the caller) does not exist on wasm32; \
+                      the wasm backend has nothing to cancel or join"
+        )
+    )]
+    pub(super) fn shutdown_execution(&self, grace: std::time::Duration) {
+        if let Some(services) = self.execution.get() {
+            services.shutdown(grace);
+        }
     }
 
     /// True if `phase` is one of the phases `with_owner_platform`'s fence (c)
@@ -1750,6 +1856,85 @@ mod identity_tests {
         assert_ne!(
             realm_a, realm_b,
             "every mint must produce a fresh generation, never repeating"
+        );
+    }
+}
+
+#[cfg(test)]
+mod execution_wiring_tests {
+    use super::*;
+    use crate::app::execution::DeterministicExecutors;
+
+    #[test]
+    fn ensure_execution_defaults_to_owned_pools() {
+        let mut runtime = AppRuntime::new();
+        assert!(
+            runtime.execution().is_none(),
+            "nothing resolved before ensure"
+        );
+        let services = runtime.ensure_execution();
+        assert!(
+            services.owns_default_pools(),
+            "with no stashed host executors, the runtime owns the default pools"
+        );
+    }
+
+    /// The injection order the bootstrap relies on: a host bundle stashed
+    /// BEFORE the first `ensure_execution` makes the resolved services route
+    /// to the host — the default pools are never constructed.
+    #[test]
+    fn stashed_host_executors_win_over_default_pools() {
+        let deterministic = DeterministicExecutors::new();
+        let mut runtime = AppRuntime::new();
+        runtime.install_host_executors(deterministic.host_executors());
+        let services = runtime.ensure_execution();
+        assert!(
+            !services.owns_default_pools(),
+            "a stashed host bundle must be the resolved backend"
+        );
+        assert!(!services.default_pools_started());
+
+        // Round-trip: work spawned through the resolved services runs on
+        // the injected executor, when IT is driven.
+        let ran = std::sync::Arc::new(AtomicBool::new(false));
+        let ran_for_job = std::sync::Arc::clone(&ran);
+        services
+            .spawn_compute(Box::new(move || {
+                ran_for_job.store(true, Ordering::Release);
+            }))
+            .expect("spawn must be admitted");
+        assert!(!ran.load(Ordering::Acquire));
+        deterministic.run_until_idle();
+        assert!(ran.load(Ordering::Acquire));
+    }
+
+    /// A bundle arriving after resolution is ignored, never a silent rebuild
+    /// that would strand running pools.
+    #[test]
+    fn late_host_executors_are_ignored() {
+        let mut runtime = AppRuntime::new();
+        let _ = runtime.ensure_execution();
+        runtime.install_host_executors(DeterministicExecutors::new().host_executors());
+        let services = runtime.ensure_execution();
+        assert!(
+            services.owns_default_pools(),
+            "executors injected after resolution must not replace the live backend"
+        );
+    }
+
+    /// `shutdown_execution` leaves the resolved services in place but
+    /// refusing: nothing can silently rebuild pools on an exiting loop.
+    #[test]
+    fn shutdown_execution_refuses_later_spawns() {
+        let mut runtime = AppRuntime::new();
+        let _ = runtime.ensure_execution();
+        runtime.shutdown_execution(std::time::Duration::from_secs(5));
+        let services = runtime
+            .execution()
+            .expect("shutdown must not clear the resolved slot");
+        assert_eq!(
+            services.spawn_compute(Box::new(|| {})),
+            Err(crate::app::execution::SpawnError::ShuttingDown)
         );
     }
 }

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -680,7 +680,10 @@ pub(crate) struct AppRuntime {
     /// lazily-started default pools. Loop-scoped like `owner_platform`:
     /// hot-restart hosts a fresh realm on the same loop and must not
     /// rebuild pools, so realm teardown never touches this — only full
-    /// loop-exit teardown shuts it down ([`Self::shutdown_execution`]).
+    /// loop-exit teardown shuts it down AND clears this slot
+    /// ([`Self::shutdown_execution`]), so a later second loop on this same
+    /// thread re-resolves fresh services instead of inheriting a dead
+    /// instance.
     execution: OnceCell<ExecutionServices>,
     /// Host executors received from `AppConfig` before the first realm
     /// install resolves `execution`. Taken by [`Self::ensure_execution`];
@@ -856,14 +859,25 @@ impl AppRuntime {
         self.execution.get()
     }
 
-    /// Shut down the execution services: stop admission, cancel outstanding
-    /// work, join running work bounded by `grace` per pool. Runs at full
-    /// loop-exit teardown (`teardown_platform_realm`), never at per-realm
-    /// teardown — see the `execution` field's doc. After this, background
-    /// spawns refuse with `SpawnError::ShuttingDown`; the `OnceCell` stays
-    /// filled so nothing can silently rebuild pools on a loop that is
-    /// exiting. A drop without this explicit call still tears the pools
-    /// down non-blockingly (`ExecutionServices`' own `Drop`).
+    /// Shut down the execution services and **reset the slot**: stop
+    /// admission, cancel outstanding work, join running work bounded by
+    /// `grace` per pool, then take the shut-down instance out of the
+    /// `OnceCell` (dropping it — its pools are already closed, so the drop
+    /// is a no-op) and discard any never-resolved host-executor stash. Runs
+    /// at full loop-exit teardown (`teardown_platform_realm`), never at
+    /// per-realm teardown — see the `execution` field's doc.
+    ///
+    /// Resetting the slot (rather than leaving the dead instance in place)
+    /// is load-bearing for a SECOND platform loop hosted on this same
+    /// thread later — an embedder running `run_app` twice in one process,
+    /// or a headless-restart harness: the next loop's realm install must
+    /// re-resolve a fresh, working `ExecutionServices` (honoring any newly
+    /// stashed `HostExecutors`), not inherit an instance whose admission is
+    /// permanently closed. Nothing rebuilds pools on the loop that is
+    /// exiting either way: `ensure_execution` (the only resolver) runs only
+    /// from a realm install, and this loop is past its last one. A teardown
+    /// path that skips this call still tears pools down non-blockingly
+    /// (`ExecutionServices`' own `Drop`).
     // Its production caller (teardown_platform_realm) is not compiled on
     // wasm32, where shutdown is a no-op by construction (sequential
     // execution; nothing to join).
@@ -875,8 +889,12 @@ impl AppRuntime {
                       the wasm backend has nothing to cancel or join"
         )
     )]
-    pub(super) fn shutdown_execution(&self, grace: std::time::Duration) {
-        if let Some(services) = self.execution.get() {
+    pub(super) fn shutdown_execution(&mut self, grace: std::time::Duration) {
+        // A stash the exiting loop never resolved must not leak into the
+        // next loop's resolution: injection is per-run configuration, and
+        // the next `run_*` stashes its own config's bundle if it has one.
+        self.pending_host_executors = None;
+        if let Some(services) = self.execution.take() {
             services.shutdown(grace);
         }
     }
@@ -1922,19 +1940,53 @@ mod execution_wiring_tests {
         );
     }
 
-    /// `shutdown_execution` leaves the resolved services in place but
-    /// refusing: nothing can silently rebuild pools on an exiting loop.
+    /// `shutdown_execution` shuts the services down AND clears the slot,
+    /// so the next loop on this thread re-resolves fresh, working services
+    /// — including honoring a host bundle stashed for that next loop. A
+    /// shutdown that left the dead instance in place would refuse every
+    /// spawn of the second loop and silently ignore its injected
+    /// executors.
     #[test]
-    fn shutdown_execution_refuses_later_spawns() {
+    fn shutdown_execution_resets_the_slot_for_a_later_loop() {
         let mut runtime = AppRuntime::new();
         let _ = runtime.ensure_execution();
         runtime.shutdown_execution(std::time::Duration::from_secs(5));
-        let services = runtime
-            .execution()
-            .expect("shutdown must not clear the resolved slot");
-        assert_eq!(
-            services.spawn_compute(Box::new(|| {})),
-            Err(crate::app::execution::SpawnError::ShuttingDown)
+        assert!(
+            runtime.execution().is_none(),
+            "loop-exit shutdown must clear the slot, not leave a dead instance"
+        );
+
+        // "Second loop": a fresh install with its own injected executors.
+        let deterministic = DeterministicExecutors::new();
+        runtime.install_host_executors(deterministic.host_executors());
+        let services = runtime.ensure_execution();
+        assert!(
+            !services.owns_default_pools(),
+            "the second loop's host bundle must be honored, not ignored as late"
+        );
+        let ran = std::sync::Arc::new(AtomicBool::new(false));
+        let ran_for_job = std::sync::Arc::clone(&ran);
+        services
+            .spawn_compute(Box::new(move || {
+                ran_for_job.store(true, Ordering::Release);
+            }))
+            .expect("the second loop's admission must be open");
+        deterministic.run_until_idle();
+        assert!(ran.load(Ordering::Acquire));
+    }
+
+    /// A host stash the exiting loop never resolved is discarded at
+    /// shutdown: injection is per-run configuration, and the next run
+    /// stashes its own.
+    #[test]
+    fn shutdown_execution_discards_an_unresolved_stash() {
+        let mut runtime = AppRuntime::new();
+        runtime.install_host_executors(DeterministicExecutors::new().host_executors());
+        runtime.shutdown_execution(std::time::Duration::from_secs(5));
+        let services = runtime.ensure_execution();
+        assert!(
+            services.owns_default_pools(),
+            "a stash for a torn-down loop must not leak into the next loop's resolution"
         );
     }
 }

--- a/crates/flui-app/src/lib.rs
+++ b/crates/flui-app/src/lib.rs
@@ -47,6 +47,14 @@ pub use app::{
     AppConfig, DiagnosticsProfile, RootRenderElement, RootRenderView, run_app, run_app_with_config,
     run_direct,
 };
+// Host-injected execution seam (issue #557): an embedded host provides its
+// own worker pools via `AppConfig::with_executors`, and the runtime's
+// default pools are then never constructed. `DeterministicExecutors` is the
+// single-threaded reference implementation for tests and reproducible hosts.
+pub use app::{
+    ComputeJob, DeterministicExecutors, HostComputePool, HostExecutors, HostIoPool, IoFuture,
+    SpawnError,
+};
 // Multi-window policy knobs (issue #555's embedder-facing seam) — not
 // available on iOS, where `AppRuntime`/`UiRealm`'s realm-hosting machinery
 // itself is not compiled (see `runtime::ExitPolicy`'s own doc).

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -98,7 +98,6 @@ libc = "0.2"
 # Native-only async dependencies (not available on wasm32)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
-num_cpus = "1.16"
 
 # Web/WASM platform
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/flui-platform/src/executor.rs
+++ b/crates/flui-platform/src/executor.rs
@@ -3,7 +3,11 @@
 //! Provides the background executor used for thread-safe asynchronous work.
 //! It returns [`Task<T>`] handles for awaiting results.
 
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{
+    future::Future,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use tokio::runtime::Runtime;
 
@@ -12,6 +16,15 @@ use crate::{
     traits::PlatformExecutor,
 };
 
+/// Worker threads in the lazily-started runtime. Deliberately small: since
+/// the unified execution services (issue #557) the loop-scoped `AppRuntime`
+/// owns the process's real worker pools, and this executor remains only as
+/// the `Platform::background_executor` compatibility surface (a
+/// removal-target — see `docs/runtime-contract.toml`) for platform-internal
+/// marshaling and tests. It must never again claim a full-core pool per
+/// platform instance.
+const WORKER_THREADS: usize = 2;
+
 /// Background executor for multi-threaded async tasks
 ///
 /// Spawns tasks on a multi-threaded tokio runtime. Returns [`Task<T>`] handles
@@ -19,37 +32,58 @@ use crate::{
 ///
 /// # Thread Pool Configuration
 ///
-/// - **Worker threads**: `num_cpus::get()` (typically 4-16 on modern systems)
-/// - **Thread names**: `flui-background-N` for easy identification in profilers
+/// - **Lazy**: constructing the executor starts no threads; the runtime is
+///   built on the first call that needs it (spawn/timer/block/handle). A
+///   platform that constructs this executor but never uses it — every
+///   FLUI-managed run since the unified execution services (issue #557) —
+///   pays nothing.
+/// - **Worker threads**: `WORKER_THREADS` (2 — small and fixed rather than
+///   core-count sized; see that private const's doc for why)
+/// - **Thread names**: `flui-platform-bg-N` for identification in profilers
 /// - **Runtime features**: All async features enabled (I/O, timers, etc.)
 #[derive(Clone)]
 pub struct BackgroundExecutor {
-    runtime: Arc<Runtime>,
+    runtime: Arc<OnceLock<Runtime>>,
 }
 
 impl BackgroundExecutor {
-    /// Create a new background executor with multi-threaded runtime
+    /// Create a new background executor. Cheap: no threads are started
+    /// until the first call that needs the runtime.
+    pub fn new() -> Self {
+        BackgroundExecutor {
+            runtime: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// The lazily-started runtime.
     ///
     /// # Panics
     ///
-    /// Panics if the runtime cannot be created (extremely rare — would indicate
-    /// system resource exhaustion or OS-level threading issues).
-    pub fn new() -> Self {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(num_cpus::get())
-            .thread_name("flui-background")
-            .enable_all()
-            .build()
-            .expect("Failed to create background runtime");
+    /// Panics if the runtime cannot be created (extremely rare — would
+    /// indicate system resource exhaustion or OS-level threading issues).
+    fn runtime(&self) -> &Runtime {
+        self.runtime.get_or_init(|| {
+            tracing::info!(
+                worker_threads = WORKER_THREADS,
+                "starting the platform background runtime on first use"
+            );
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(WORKER_THREADS)
+                .thread_name("flui-platform-bg")
+                .enable_all()
+                .build()
+                .expect(
+                    "BUG: building a tokio runtime must succeed on any platform this \
+                     crate targets short of OS thread exhaustion",
+                )
+        })
+    }
 
-        tracing::info!(
-            "Created BackgroundExecutor with {} worker threads",
-            num_cpus::get()
-        );
-
-        BackgroundExecutor {
-            runtime: Arc::new(runtime),
-        }
+    /// Whether the runtime has been started. Test seam for the laziness
+    /// contract; production code has no reason to ask.
+    #[cfg(test)]
+    fn runtime_started(&self) -> bool {
+        self.runtime.get().is_some()
     }
 
     /// Spawn an async task on the thread pool
@@ -59,7 +93,7 @@ impl BackgroundExecutor {
         &self,
         future: impl Future<Output = R> + Send + 'static,
     ) -> Task<R> {
-        let handle = self.runtime.spawn(future);
+        let handle = self.runtime().spawn(future);
         Task::from_handle(handle)
     }
 
@@ -88,12 +122,12 @@ impl BackgroundExecutor {
     /// Useful for bridging async code in synchronous contexts (e.g., tests).
     /// Do NOT call from within an async context — it will panic.
     pub fn block<R>(&self, future: impl Future<Output = R>) -> R {
-        self.runtime.block_on(future)
+        self.runtime().block_on(future)
     }
 
     /// Get a handle to the underlying async runtime
     pub fn handle(&self) -> &tokio::runtime::Handle {
-        self.runtime.handle()
+        self.runtime().handle()
     }
 }
 
@@ -105,7 +139,7 @@ impl std::fmt::Debug for BackgroundExecutor {
 
 impl PlatformExecutor for BackgroundExecutor {
     fn spawn(&self, task: Box<dyn FnOnce() + Send>) {
-        self.runtime.spawn(async move {
+        self.runtime().spawn(async move {
             task();
         });
     }
@@ -122,6 +156,20 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
+
+    /// Constructing the executor must not start the runtime (every platform
+    /// backend constructs one at platform init; FLUI-managed runs never use
+    /// it, and must not pay threads for it); the first use starts it.
+    #[test]
+    fn test_background_executor_starts_lazily_on_first_use() {
+        let executor = BackgroundExecutor::new();
+        assert!(
+            !executor.runtime_started(),
+            "construction must not start worker threads"
+        );
+        executor.spawn(async {}).detach();
+        assert!(executor.runtime_started());
+    }
 
     #[test]
     fn test_background_executor_spawn() {

--- a/docs/adr/ADR-0047-unified-execution-services.md
+++ b/docs/adr/ADR-0047-unified-execution-services.md
@@ -1,0 +1,73 @@
+# ADR-0047: Unified execution services under `AppRuntime`
+
+*Background execution is one loop-scoped service owned by `AppRuntime`, not a per-platform possession: work is classified by deadline and behavior (frame-required compute, asynchronous compute, IO), admission is bounded, shutdown cancels-then-joins under a deadline, and an embedded host can inject its own pools — in which case FLUI never constructs its default ones. The per-platform full-core `BackgroundExecutor` is defanged (lazy, small) ahead of its removal.*
+
+---
+
+- **Status:** Accepted (2026-08-18)
+- **Date:** 2026-08-18
+- **Deciders:** @vanyastaff
+- **Scope:** background execution topology — `crates/flui-app/src/app/execution.rs`, `AppRuntime`'s ownership/teardown wiring, `AppConfig::with_executors`, `crates/flui-platform/src/executor.rs`
+- **Related:** [ADR-0027](ADR-0027-owner-affine-ui-realms.md) (runtime/scheduling topology is a sanctioned leapfrog zone — Flutter is not the reference here); [Runtime Architecture Execution Plan](../research/2026-08-01-runtime-architecture-execution-plan.md) ("Unify worker, I/O, and service execution with host injection"); [Runtime Dependency Adoption Guide](../research/2026-08-01-runtime-dependency-adoption-guide.md) (`tokio-util` adoption, "another async runtime: do not add"); `docs/runtime-contract.toml` (`execution-services-owned-by-app-runtime`)
+- **Issue:** [#557](https://github.com/vanyastaff/flui/issues/557) — on the Runtime.1 critical path between singleton retirement (#553) and the task/worker/service lifecycles (#558) / threaded raster lane (#559)
+
+---
+
+## Context
+
+Before this change, background execution was a per-platform possession with no policy:
+
+1. **Every platform backend constructed a full-core Tokio runtime at platform init** (`BackgroundExecutor::new()` with `num_cpus::get()` workers, eagerly, in `WinitPlatform`/`WindowsPlatform`/`MacOSPlatform` constructors) — and production never called `Platform::background_executor()` at all. Managed runs paid a core-count thread pool for nothing, and any second pool (a host's, flui-assets' bridge) stacked on top.
+2. **Priority was informational.** `spawn_with_priority` discarded its argument; the public `Priority` enum promised behavior that did not exist.
+3. **No injection seam.** An embedded host running its own executor (a game engine, an editor) had no way to lend it to FLUI; embedding FLUI meant oversubscribing the machine.
+4. **No admission, cancellation, tracking, or shutdown contract.** `Task::drop` did not cancel; nothing joined outstanding work at exit; queues were unbounded.
+
+The runtime architecture study's target is explicit: *"Work is classified by deadline and behavior, not arbitrary user priority: frame-critical compute, asynchronous compute, I/O, and durable services"*, with host-provided executor/task pools as a required embedding capability. ADR-0027 sanctions diverging from Flutter here — Flutter has no contract for this at all.
+
+## Decision
+
+### One owner, no ambient reach
+
+`AppRuntime` — the loop-scoped composition root — owns exactly one `ExecutionServices` value (`app/execution.rs`, `pub(crate)`). It is resolved at the same known point as `SharedEngineServices` (realm install, `ensure_execution`), shut down at full loop-exit teardown, and reachable only by injection. There is no global accessor, no thread-local, and no way for a library crate to reach the pools. Realms and presentations will receive capability handles from it when #558 defines them; they do not resolve it themselves.
+
+### Work classes are lanes, not a priority enum
+
+| Class | Where it runs | API |
+|---|---|---|
+| Frame-required compute | The owner thread itself: the frame pipeline plus `AsyncDriver`'s mid-frame poll | none here — deliberately not spawnable onto a pool |
+| Asynchronous compute | Bounded worker pool, `default_compute_worker_count` workers (`available_parallelism − IO_WORKER_THREADS − 1`, min 1), `flui-compute` threads, lazily started | `spawn_compute(ComputeJob)` |
+| IO | Small fixed async runtime, 2 `flui-io` workers, lazily started | `spawn_io(IoFuture)` |
+| Durable services | **Not this ADR** — issue #558's lifecycle work | — |
+
+"Background work cannot starve frame-required compute" therefore has two halves, each pinned by a test: *structural* (the frame lane never runs on these pools, so pool saturation cannot block it — `frame_lane_makes_progress_while_background_lanes_are_saturated`) and *sizing* (the background lanes together leave the owner thread a hardware thread — `compute_pool_sizing_leaves_owner_thread_headroom`). There is no user-facing priority parameter; scheduling policy derives from the class chosen at the call site.
+
+### Bounded admission, cancellation, deadline-bounded shutdown
+
+Both lanes count in-flight work against a cap; a full lane refuses with `SpawnError::Saturated` (backpressure, not queue growth). Shutdown is staged, per the adoption guide's shape: **stop admission** (later spawns get `SpawnError::ShuttingDown`) → **cancel** (a `tokio_util::sync::CancellationToken` wrapper travels with every unit of work: queued compute jobs skip, IO futures resolve early and drop at their await point) → **join** running work, bounded by a per-pool grace deadline (`shutdown_timeout`; 5s at loop exit). The cancellation wrapper is load-bearing precisely for *host-injected* pools, whose tasks FLUI cannot drop any other way (`shutdown_cancels_work_handed_to_host_pools` fails without it). `ExecutionServices::drop` is the non-blocking last resort (`shutdown_background`), mirroring flui-assets' bridge-runtime discipline.
+
+### Host injection avoids duplicate pools
+
+`AppConfig::with_executors(HostExecutors)` carries two runtime-neutral trait objects (`HostComputePool`, `HostIoPool` — boxed-closure and boxed-future contracts, deliberately not Tokio types, per the adoption guide's "the contract is an injected executor and must remain runtime-neutral"). The bootstrap stashes them into `AppRuntime` *before* realm install resolves the services; with a host present the default pools are **never constructed** — pinned by `host_injection_routes_work_and_never_starts_default_pools`. FLUI's admission and cancellation wrappers apply identically on top of host pools, so the observable contract does not depend on who owns the threads.
+
+### Determinism and wasm
+
+`DeterministicExecutors` (public) is a single-threaded FIFO implementation of the same seam — work runs only inside `run_until_idle()`, on the calling thread, in spawn order. The admission/shutdown conformance tests run against both the default pools and this injected implementation. On wasm32 the same `ExecutionServices` API is sequential: compute runs inline at the spawn site, IO goes to the browser microtask queue via `wasm_bindgen_futures::spawn_local`, and shutdown stops admission only (queued microtasks cannot be revoked; there is nothing to join).
+
+### The platform executor is defanged ahead of removal
+
+`BackgroundExecutor` (already classified removal-target under #557 in `docs/runtime-contract.toml`) no longer claims a full-core pool per platform instance: construction starts zero threads (lazy `OnceLock`), and the pool that starts on first *use* is a small fixed size (2 workers). FLUI-managed runs never use it, so they never start it. Its deletion — together with `flui_platform::Task`/`Priority` — is the follow-up slice, not this one: those surfaces are only lint-gated on Windows/macOS and their internal consumers (prompt marshaling) deserve their own change.
+
+## Alternatives considered
+
+- **One shared runtime for both background classes.** Fewer threads, but a CPU-bound closure occupying an async worker starves IO futures — exactly the class-interference the issue exists to prevent. Two pools with a joint sizing budget keep the isolation and still bound total threads.
+- **`rayon` for the compute pool.** Explicitly deferred by the adoption guide until the serial/parallel job-graph spike (#562) proves crossover thresholds. A Tokio multi-thread runtime used as a plain worker pool costs nothing extra here and avoids a new dependency with no proven consumer.
+- **Per-realm (rather than loop-scoped) pools.** Worker threads are a machine-level resource; N realms with N pools recreates the oversubscription problem one level down. Realms get capability handles (#558), not pools.
+- **A tokio `Handle` as the injection type.** Simplest, but freezes Tokio into the public embedding contract; the guide forbids it. The trait seam costs one `Box` per spawn on a path that is per-job, not per-frame.
+- **Keeping `Priority` public with implemented semantics.** Rejected by the study: deadline/behavior classes, chosen at the call site, replace user-guessed priorities. `Priority`'s retirement rides the platform-surface removal slice.
+
+## Consequences
+
+- A managed desktop run now materializes **zero** background worker threads until the first background spawn, instead of `num_cpus` per platform instance at init.
+- Issues #558 (Task/Worker/Service lifecycles, per-task handles, versioned results, owner-lifetime cancellation) and #559 (raster lane) build on these lanes; until they land the spawn lanes have no shipped production caller — an `expect(dead_code)` in `execution.rs` errors the moment one appears, forcing that attribute's removal. A breaking reshape of the seam when those consumers prove it wrong is expected and preferred over shims.
+- Named residuals: flui-assets' bridged decode path still lazily starts its own single-worker runtime when no handle is injected (1 thread, not full-core; wiring it to the IO lane needs a flui-app → flui-assets edge decision — follow-up under #557); `Priority`/`Task`/`BackgroundExecutor` remain public removal-targets until the follow-up slice.
+- `tokio-util` (default features, `CancellationToken` only) enters the workspace with this — its sanctioned first owning work per the adoption guide.

--- a/docs/panic-policy-allowlist.txt
+++ b/docs/panic-policy-allowlist.txt
@@ -81,7 +81,6 @@ crates/flui-material/src/tab_controller.rs 1
 crates/flui-material/src/tabs.rs 5
 crates/flui-material/src/theme.rs 1
 crates/flui-painting/src/text_painter/measure.rs 5
-crates/flui-platform/src/executor.rs 1
 crates/flui-platform/src/platforms/android/memory.rs 2
 crates/flui-platform/src/platforms/macos/view.rs 2
 crates/flui-platform/src/platforms/macos/window.rs 2

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1028,7 +1028,9 @@ sized to leave the owner thread a hardware thread: \
 `default_compute_worker_count`) and IO (small fixed async runtime) -- with \
 bounded admission (`SpawnError::Saturated`), a shutdown protocol \
 (stop admission -> cancel via `CancellationToken` -> join running work \
-bounded by a grace deadline, run at full loop-exit teardown), and host \
+bounded by a grace deadline, run at full loop-exit teardown, which also \
+CLEARS the slot so a second loop hosted later on the same thread \
+re-resolves fresh services honoring its own injected executors), and host \
 injection (`AppConfig::with_executors` / `HostExecutors`): with an injected \
 host the default pools are NEVER constructed, and cancellation still \
 reaches work handed to pools FLUI does not own (the wrapper's cancellation \
@@ -2359,7 +2361,7 @@ contains = "ComputeJob, DeterministicExecutors, HostComputePool, HostExecutors, 
 classification = "experimental"
 thread_affinity = "HostExecutors is Clone + Send + Sync (Arc-bundled trait objects); pool implementations run work on any thread; FLUI's cancellation/admission wrappers travel with the work"
 owner = "the host-injection seam for background execution (issue #557, ADR-0047) — consumed at bootstrap via AppConfig::with_executors, resolved once per loop into AppRuntime's ExecutionServices"
-failure_semantics = "spawns return Result<(), SpawnError> (Saturated | ShuttingDown, #[non_exhaustive] thiserror); refused work is dropped, destructors run"
+failure_semantics = "spawns return Result<(), SpawnError> (Saturated | ShuttingDown | Unavailable, #[non_exhaustive] thiserror); refused work is dropped, destructors run; Unavailable = the OS refused pool-thread creation (environment error per docs/PANIC-POLICY.md, never a panic) and the unstarted slot is preserved so a later spawn retries"
 consumers = [
     "AppRuntime (resolution + shutdown)",
     "embedded hosts (none in-tree yet — the host-driven runtime entry point is later Runtime.1 work)",

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -94,6 +94,7 @@ declarations = [
     "pub mod bindings;",
     "pub mod embedder;",
     "pub use app::{ AppConfig, DiagnosticsProfile, RootRenderElement, RootRenderView, run_app, run_app_with_config, run_direct, };",
+    "pub use app::{ ComputeJob, DeterministicExecutors, HostComputePool, HostExecutors, HostIoPool, IoFuture, SpawnError, };",
     "pub use app::{ExitPolicy, WindowPolicy};",
     "pub use app::open_secondary_window;",
     "pub use app::{run_app_android, run_app_android_with_config};",
@@ -110,6 +111,7 @@ declarations = [
     "pub mod runner;",
     "pub use config::{AppConfig, DiagnosticsProfile};",
     "pub use direct::run_direct;",
+    "pub use execution::{ ComputeJob, DeterministicExecutors, HostComputePool, HostExecutors, HostIoPool, IoFuture, SpawnError, };",
     "pub use runner::{run_app_android, run_app_android_with_config};",
     "pub use runner::open_secondary_window;",
     "pub use runner::{run_app_impl as run_app, run_app_with_config_impl as run_app_with_config};",
@@ -1015,6 +1017,70 @@ state = "planned"
 domain = "shared-engine"
 owner_issue = 557
 mechanical = false
+
+[[contract]]
+key = "execution-services-owned-by-app-runtime"
+statement = """
+Background execution is owned by the loop-scoped `AppRuntime`, never \
+ambient (ADR-0047): one `ExecutionServices` value per loop carries the two \
+background work-class lanes -- asynchronous compute (bounded worker pool, \
+sized to leave the owner thread a hardware thread: \
+`default_compute_worker_count`) and IO (small fixed async runtime) -- with \
+bounded admission (`SpawnError::Saturated`), a shutdown protocol \
+(stop admission -> cancel via `CancellationToken` -> join running work \
+bounded by a grace deadline, run at full loop-exit teardown), and host \
+injection (`AppConfig::with_executors` / `HostExecutors`): with an injected \
+host the default pools are NEVER constructed, and cancellation still \
+reaches work handed to pools FLUI does not own (the wrapper's cancellation \
+point, pinned by `shutdown_cancels_work_handed_to_host_pools`). \
+Frame-required compute is not a lane here by design -- it is the owner \
+thread plus `AsyncDriver`'s mid-frame poll, structurally independent of \
+these pools (pinned by \
+`frame_lane_makes_progress_while_background_lanes_are_saturated`). The \
+per-platform `BackgroundExecutor` no longer claims a full-core pool per \
+platform instance: it is lazy (zero threads until first use -- \
+FLUI-managed runs never use it) and small, pending its removal under this \
+issue's follow-up slice. `DeterministicExecutors` is the single-threaded \
+FIFO reference implementation of the injection seam; the admission/shutdown \
+conformance tests run against both backends. Wasm32 keeps the same API \
+with sequential execution (compute inline at the spawn site, IO via \
+`spawn_local`; shutdown stops admission only). \
+\
+**Named gaps, stated not silently assumed:** (1) the spawn lanes have no \
+shipped production caller yet -- the consumers are issue #558's \
+task/worker/service lifecycles and #559's raster lane, the next items on \
+this same critical path; an `expect(dead_code)` in `app/execution.rs` \
+errors the moment #558 wires one, forcing the attribute's removal. \
+(2) `flui_platform::Priority` remains public and informational -- its \
+"tested behavior or not public" criterion is deferred to the follow-up \
+slice that retires the `BackgroundExecutor`/`Task`/`Priority` surfaces \
+(already classified removal-target below). (3) flui-assets' bridged decode \
+path still starts its own single-worker runtime when no handle is \
+injected -- a 1-thread residual, not a full-core pool; wiring it to the \
+unified IO lane needs a flui-app -> flui-assets edge decision and is \
+deferred to the same follow-up. (4) per-task cancellation handles and \
+versioned results are #558's Task surface, deliberately not frozen here.\
+"""
+state = "partial"
+domain = "application"
+owner_issue = 557
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/execution.rs", contains = "pub(crate) struct ExecutionServices" },
+    { kind = "symbol", file = "crates/flui-app/src/app/execution.rs", contains = "pub(crate) fn default_compute_worker_count" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(super) fn ensure_execution" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn compute_pool_sizing_leaves_owner_thread_headroom" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn conformance_no_admission_after_shutdown" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn conformance_admission_is_bounded_and_released" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn shutdown_joins_running_compute_work" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn shutdown_cancels_work_handed_to_host_pools" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn host_injection_routes_work_and_never_starts_default_pools" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn default_pools_start_lazily_on_first_spawn" },
+    { kind = "test", file = "crates/flui-app/src/app/execution.rs", contains = "fn frame_lane_makes_progress_while_background_lanes_are_saturated" },
+    { kind = "test", file = "crates/flui-app/src/app/runtime.rs", contains = "fn stashed_host_executors_win_over_default_pools" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn install_resolves_execution_services_and_teardown_shuts_them_down" },
+    { kind = "test", file = "crates/flui-platform/src/executor.rs", contains = "fn test_background_executor_starts_lazily_on_first_use" },
+]
 
 [[contract]]
 key = "channel-identity-lifetime-boundary"
@@ -2285,6 +2351,36 @@ consumers = ["flui-app prelude", "flui facade via app module"]
 owner_issue = 553
 
 [[surface]]
+path = "flui_app::{HostExecutors, HostComputePool, HostIoPool, ComputeJob, IoFuture, SpawnError}"
+crate = "flui-app"
+kind = "type"
+declared_in = "crates/flui-app/src/lib.rs"
+contains = "ComputeJob, DeterministicExecutors, HostComputePool, HostExecutors, HostIoPool, IoFuture,"
+classification = "experimental"
+thread_affinity = "HostExecutors is Clone + Send + Sync (Arc-bundled trait objects); pool implementations run work on any thread; FLUI's cancellation/admission wrappers travel with the work"
+owner = "the host-injection seam for background execution (issue #557, ADR-0047) — consumed at bootstrap via AppConfig::with_executors, resolved once per loop into AppRuntime's ExecutionServices"
+failure_semantics = "spawns return Result<(), SpawnError> (Saturated | ShuttingDown, #[non_exhaustive] thiserror); refused work is dropped, destructors run"
+consumers = [
+    "AppRuntime (resolution + shutdown)",
+    "embedded hosts (none in-tree yet — the host-driven runtime entry point is later Runtime.1 work)",
+]
+owner_issue = 557
+notes = "Experimental until the host-driven runtime surface exists and the two-consumer rule is met; a breaking reshape when #558's task/worker/service lifecycles land is expected and preferred over shims."
+
+[[surface]]
+path = "flui_app::DeterministicExecutors"
+crate = "flui-app"
+kind = "type"
+declared_in = "crates/flui-app/src/app/execution.rs"
+contains = "pub struct DeterministicExecutors"
+classification = "experimental"
+thread_affinity = "Clone + Send + Sync queues; work executes only inside run_until_idle, on the calling thread, FIFO"
+owner = "single-threaded deterministic reference implementation of the host-injection seam — the 'injected deterministic executor passes the same tests' acceptance evidence, and the reproducible-execution option for host tests"
+failure_semantics = "spawns are unbounded and infallible at this layer; FLUI's ExecutionServices admission bounds still apply above it"
+consumers = ["execution conformance tests", "runtime wiring tests"]
+owner_issue = 557
+
+[[surface]]
 path = "flui_app::embedder"
 crate = "flui-app"
 kind = "module"
@@ -2441,7 +2537,7 @@ owner = "per-platform executor construction — moves to host-injected runtime e
 failure_semantics = "spawn-shaped; no admission control or cancellation contract"
 consumers = ["flui-assets decode path", "prompt marshaling (Windows)"]
 owner_issue = 557
-notes = "workspace-layers.toml disposition 'narrow' for flui-platform names exactly this loss."
+notes = "workspace-layers.toml disposition 'narrow' for flui-platform names exactly this loss. Defanged by #557's first slice ahead of removal: construction is lazy (zero threads until first use — FLUI-managed runs never call it, so they never start it) and the pool shrank from num_cpus workers to a small fixed count; AppRuntime's ExecutionServices (ADR-0047) now owns the process's real worker pools."
 
 [[surface]]
 path = "flui_platform::Task"


### PR DESCRIPTION
Part of #557 — the first slice: the unified executor seam, default pools under `AppRuntime`, and host injection. **Not** `Closes #557`: two acceptance criteria are explicitly deferred (table below).

## Design (ADR-0047)

Work is classified by **deadline and behavior**, not user priority — the study's model, sanctioned as a leapfrog zone by ADR-0027 (Flutter is not the reference for executor topology):

| Class | Where it runs | API |
|---|---|---|
| Frame-required compute | Owner thread (frame pipeline + `AsyncDriver` mid-frame poll) | none — deliberately not spawnable onto a pool |
| Asynchronous compute | Bounded pool, `available_parallelism − 3` workers (min 1), lazy | `ExecutionServices::spawn_compute` |
| IO | 2-worker async runtime, lazy | `ExecutionServices::spawn_io` |
| Durable services | issue #558 | — |

- **Ownership:** one `ExecutionServices` per loop, owned by `AppRuntime` (`ensure_execution` at realm install, `shutdown_execution` at loop-exit teardown). No global accessor, no ambient reach; library crates cannot see the pools.
- **Admission:** both lanes bounded; full lane ⇒ `SpawnError::Saturated` (work dropped, destructors run).
- **Shutdown:** stop admission (`SpawnError::ShuttingDown`) → cancel (`tokio_util::sync::CancellationToken` wrapper travels with every unit of work) → join running work, deadline-bounded (`shutdown_timeout`, 5 s at teardown). `Drop` is the non-blocking last resort.
- **Host injection:** `AppConfig::with_executors(HostExecutors)` — runtime-neutral `HostComputePool`/`HostIoPool` trait objects (per the adoption guide: no tokio types in the contract). With a host present the default pools are **never constructed**; FLUI's admission + cancellation wrappers still apply on top.
- **Determinism:** `DeterministicExecutors` — single-threaded FIFO reference implementation of the seam; the conformance tests run against both it and the default pools.
- **wasm32:** same API, sequential (compute inline, IO via `spawn_local`, shutdown = stop admission).
- **Platform defang:** `BackgroundExecutor` (removal-target under #557) is now lazy — construction starts zero threads, so a managed desktop run no longer pays a full-core tokio pool per platform instance at init — and its pool shrank to 2 fixed workers. Its rewritten `expect()` retires the crate's panic-policy allowlist entry (shrink-only ratchet).

New workspace dependency: `tokio-util` (default features, `CancellationToken` only) — its sanctioned first owning work per the runtime dependency adoption guide; no `rt`/`TaskTracker` until #558 needs it.

## Acceptance criteria (issue #557)

| Criterion | Status |
|---|---|
| One default runtime owns process worker pools | **Met** for what a managed run materializes: `AppRuntime`'s `ExecutionServices` owns the only worker pools a managed run can start (platform executors now lazy + unused there; flui-assets' 1-worker bridge residual named below) |
| Background work cannot starve frame-critical compute | **Met**, two halves each pinned: structural (frame lane runs on the owner thread, test drives `AsyncDriver` to completion with both lanes saturated) + sizing (pool policy leaves the owner thread a hardware thread) |
| Priority has tested behavior or is not public | **Deferred** — `flui_platform::Priority` stays public-informational until the `BackgroundExecutor`/`Task`/`Priority` removal slice (surfaces already classified removal-target, owner #557) |
| Shutdown cancels and joins tracked work | **Met** — staged shutdown; join pinned by `shutdown_joins_running_compute_work`, cancellation pinned on host pools (where FLUI cannot drop tasks) by `shutdown_cancels_work_handed_to_host_pools` |
| Host injection avoids duplicate full-core pools | **Met** — `host_injection_routes_work_and_never_starts_default_pools` + `stashed_host_executors_win_over_default_pools`; residual: flui-assets bridge may lazily start **1** worker thread (not full-core), wiring it to the IO lane deferred (needs a flui-app→flui-assets edge decision) |
| Wasm uses the same API with sequential execution | **Met at API/compile level** — same `ExecutionServices` surface, sequential backend; `cargo check -p flui-app --target wasm32-unknown-unknown` green. No wasm *runtime* test exists (stated, not claimed) |

Also deferred by design: per-task cancellation handles and versioned results (issue #558's Task/Worker/Service surface — the lanes' production spawn callers arrive there; an `expect(dead_code)` in `execution.rs` errors the moment #558 wires one, forcing its removal).

## Evidence

**Executable, born-red (each verified failing under an Edit-tool sabotage of exactly the claimed behavior, then green restored):**
- `compute_pool_sizing_leaves_owner_thread_headroom` — red when sizing returns all cores
- `conformance_admission_is_bounded_and_released` + `default_pool_admission_saturates_while_workers_are_parked` — red when admission never refuses
- `conformance_no_admission_after_shutdown` — red when the accepting gate is bypassed
- `shutdown_joins_running_compute_work` — red when join becomes `shutdown_background`
- `shutdown_cancels_work_handed_to_host_pools` — red when the `CancellationToken` wrapper is removed (added precisely because the default-pool cancel test stayed green under that sabotage — runtime drop masks the token there; the host-pool oracle discriminates)
- `host_injection_routes_work_and_never_starts_default_pools` — red when injected executors are ignored
- `default_pools_start_lazily_on_first_spawn` / `test_background_executor_starts_lazily_on_first_use` (flui-platform) — red under eager construction
- `stashed_host_executors_win_over_default_pools` — red when `ensure_execution` drops the stash
- `install_resolves_execution_services_and_teardown_shuts_them_down` — red in both directions (install without `ensure_execution`; teardown without `shutdown_execution`)

**Pins (green-by-construction, labeled as such):** `frame_lane_makes_progress_while_background_lanes_are_saturated` (frame lane has no pool dependency to sabotage without rewriting `AsyncDriver`), `conformance_spawned_*` round-trips, deterministic FIFO/parking semantics, `shutdown_is_idempotent`.

**Lint/compile-only evidence:** wasm32 backend (checked, not executed); Windows/macOS/Android platform code untouched by this change beyond the shared `executor.rs`, which the cross-typecheck job lints.

**Registry:** new `execution-services-owned-by-app-runtime` contract (state `partial`, named gaps enumerated) + 2 new classified surfaces (experimental) + export-manifest updates in `docs/runtime-contract.toml`; `runtime-conformance-check` green.

## Gates

`just ci` → exit 0 (fmt, inventory, runtime-conformance, panic-policy, port-check, clippy, doc-strict, 9162+34+255 tests, doctests). Additionally: `cargo clippy -p flui-app --all-targets -- -D warnings`, `cargo clippy -p flui-platform --all-features --all-targets -- -D warnings`, `cargo check -p flui-app --target wasm32-unknown-unknown`, `taplo fmt --check`, `typos` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
