### PR TITLE
feat(app): the native frame paths adopt the raster mailbox — ADR-0045's inline lane goes live (part of #559)

### DIFF
--- a/crates/flui-app/src/app/mod.rs
+++ b/crates/flui-app/src/app/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod logging;
 pub(crate) mod media_query_root;
 pub(crate) mod presentation;
 pub(crate) mod presentation_forest;
+pub(crate) mod raster_lane;
 pub mod runner;
 pub(crate) mod runtime;
 pub(crate) mod semantics_host;

--- a/crates/flui-app/src/app/raster_lane.rs
+++ b/crates/flui-app/src/app/raster_lane.rs
@@ -50,9 +50,9 @@ use std::sync::Arc;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crossbeam_channel::Receiver;
+use flui_engine::{EngineError, RasterBackend};
 #[cfg(not(target_arch = "wasm32"))]
 use flui_engine::{FrameDropReason, PumpOutcome, RasterAck, RasterHandle, RasterOwner};
-use flui_engine::{EngineError, RasterBackend};
 #[cfg(not(target_arch = "wasm32"))]
 use flui_foundation::{FrameEpoch, FrameStamp, GpuResourceGeneration, PresentationAddress};
 use flui_layer::Scene;

--- a/crates/flui-app/src/app/raster_lane.rs
+++ b/crates/flui-app/src/app/raster_lane.rs
@@ -1,0 +1,676 @@
+//! The inline raster lane — the app-side adopter of `flui_engine`'s raster
+//! mailbox protocol (ADR-0045).
+//!
+//! [`RasterLane`] wraps a [`RasterOwner`] whose pump runs synchronously on
+//! the owner (UI) thread — `RasterMode::Inline` in ADR-0045's terms, the
+//! first-class mode wasm forces unconditionally and macOS is pinned to by an
+//! upstream `wgpu-hal` constraint (issue #653). Every production frame the
+//! desktop and Android runners submit now crosses the raster boundary as an
+//! owned [`SceneSnapshot`] stamped with a [`FrameStamp`], is checked against
+//! the lane's single [`SurfaceGeneration`] counter, and is rendered by
+//! [`RasterOwner::pump`] — the same protocol a dedicated raster thread will
+//! drive via `run_until_shutdown`, so threading the lane later changes who
+//! calls `pump`, not what a frame is.
+//!
+//! # What the lane owns, and what stays outside
+//!
+//! Per ADR-0045 decision 1, the lane owns the backend (`RasterOwner`
+//! solely owns its `RasterBackend`); the platform remains the authority for
+//! the surface size. [`LaneStamp::physical_size`] is exactly the
+//! owner-affine surface-size cell that decision names: the platform resize
+//! path writes it (through [`RasterResizeHook::apply`]) and layout reads it
+//! (through [`FrameSink::surface_size`]) — the backend's own `size()` is no
+//! longer a layout input on this path, so layout never reaches across the
+//! raster boundary for a number the platform already knows.
+//!
+//! # Generation discipline
+//!
+//! Every [`SurfaceGeneration`] mint routes through the mailbox's one
+//! counter (ADR-0045 decision 4):
+//!
+//! - a platform resize mints eagerly via [`RasterHandle::resize`] and the
+//!   returned value is stored in [`LaneStamp::surface_generation`] so the
+//!   very next frame is stamped with it, before the pump has even applied
+//!   the resize (generation-forward, no handshake);
+//! - a mid-render surface loss mints inside the pump's render-failure path;
+//!   the lane observes the rejection ([`PumpOutcome::SurfaceOutdated`]) and
+//!   re-adopts [`SurfaceState::required_generation`] before the retry;
+//! - device-loss recovery recreates the surface, so
+//!   [`RasterLane::note_surface_recreated`] mints through the same resize
+//!   entry point at the platform's latest known size.
+//!
+//! No component keeps a private counter, and a frame stamped with a stale
+//! or zero generation is rejected before `render_scene` is ever called.
+
+// The mailbox-lane half of this module is not wired on wasm32: the web
+// runner still drives the direct sink (see `FrameSink`'s doc), so the lane
+// machinery is compiled out there rather than left as dead code.
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crossbeam_channel::Receiver;
+#[cfg(not(target_arch = "wasm32"))]
+use flui_engine::{FrameDropReason, PumpOutcome, RasterAck, RasterHandle, RasterOwner};
+use flui_engine::{EngineError, RasterBackend};
+#[cfg(not(target_arch = "wasm32"))]
+use flui_foundation::{FrameEpoch, FrameStamp, GpuResourceGeneration, PresentationAddress};
+use flui_layer::Scene;
+#[cfg(not(target_arch = "wasm32"))]
+use flui_layer::{DamageRegion, SceneSnapshot};
+#[cfg(not(target_arch = "wasm32"))]
+use parking_lot::Mutex;
+
+/// What one submitted frame did, as the realm's frame transaction needs to
+/// classify it: the same five behavioral buckets
+/// `UiRealm::render_frame_entered`'s arms already distinguish, produced
+/// uniformly by both the direct backend path and the raster-lane path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubmitVerdict {
+    /// The frame rendered and reached `present()`.
+    Presented,
+    /// The frame rendered successfully but never presented (no damage, or
+    /// an occluded surface) — no vsync block happened, so the caller's
+    /// no-present fallback pacing applies.
+    NoPresent,
+    /// The surface this frame was produced against is gone, outdated, or
+    /// misconfigured (surface lost, validation failure, or a stale
+    /// [`flui_foundation::SurfaceGeneration`] stamp). A retry against the
+    /// reconfigured/restamped surface can succeed, so the caller arms one
+    /// and retains the frame's input epochs.
+    SurfaceStale,
+    /// The GPU device was lost. Recovery is the runner's job
+    /// (`render_frame_with_device_recovery`); the caller arms a retry and
+    /// retains the frame's input epochs.
+    DeviceLost,
+    /// The frame failed in a way no retry can fix this frame (a generic
+    /// render error, or a refused submit). No retry is armed.
+    Failed,
+}
+
+/// The seam `UiRealm`'s frame transaction submits through: the surface size
+/// layout must use, and the submit itself.
+///
+/// Two implementations exist, both production paths:
+///
+/// - [`RasterLane`] — the raster-mailbox path the desktop and Android
+///   runners drive (ADR-0045's inline lane);
+/// - [`DirectSink`] — the pre-mailbox direct call into a
+///   [`RasterBackend`], still used by the web runner (whose renderer
+///   arrives asynchronously and recovers across an `.await`, a shape the
+///   lane does not yet accommodate) and by tests that pin the realm's frame
+///   transaction against scripted backends.
+///
+/// Both feed the same realm-side classification arms via [`SubmitVerdict`],
+/// so the retry/telemetry semantics cannot drift between them.
+pub(crate) trait FrameSink {
+    /// Physical surface size in pixels, as layout's root constraints input.
+    fn surface_size(&mut self) -> (u32, u32);
+
+    /// Submit one composited scene for rasterization and classify what
+    /// happened.
+    fn submit(&mut self, scene: Scene) -> SubmitVerdict;
+}
+
+/// Owner-affine stamp state shared between the lane and the platform's
+/// resize hook.
+///
+/// Everything that touches it runs on the owner thread in practice, but
+/// the platform's frame/resize callback registrations require `Send`
+/// closures, so it is `Arc`-shared behind a private, uncontended
+/// `parking_lot::Mutex` (never exposed — SP-6) rather than `Rc`/`Cell`.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+pub(crate) struct LaneStamp {
+    inner: Mutex<LaneStampInner>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy)]
+struct LaneStampInner {
+    /// The [`flui_foundation::SurfaceGeneration`] the next submitted frame
+    /// is stamped with — the latest value minted through the mailbox's one
+    /// counter that this side has observed.
+    surface_generation: flui_foundation::SurfaceGeneration,
+    /// The platform-authoritative physical surface size (ADR-0045
+    /// decision 1's owner-affine surface-size cell): written by the
+    /// platform resize path, read by layout. Deliberately NOT read back
+    /// from the backend — the backend's applied size can lag a coalesced,
+    /// not-yet-pumped resize, and layout must always use the size the
+    /// platform most recently announced.
+    physical_size: (u32, u32),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl LaneStamp {
+    fn surface_generation(&self) -> flui_foundation::SurfaceGeneration {
+        self.inner.lock().surface_generation
+    }
+
+    fn set_surface_generation(&self, generation: flui_foundation::SurfaceGeneration) {
+        self.inner.lock().surface_generation = generation;
+    }
+
+    fn physical_size(&self) -> (u32, u32) {
+        self.inner.lock().physical_size
+    }
+}
+
+/// The platform resize path's entry into the lane: mints a fresh
+/// [`flui_foundation::SurfaceGeneration`] through the mailbox's one counter
+/// and updates the shared stamp state, without touching the backend — the
+/// pump applies the actual surface reconfiguration before the next render.
+///
+/// Cheap to clone into the surface-applier closure; holds no backend and no
+/// lock beyond the mailbox's own internal one.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+pub(crate) struct RasterResizeHook {
+    handle: RasterHandle,
+    stamp: Arc<LaneStamp>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl RasterResizeHook {
+    /// Coalesces a resize into the mailbox, adopts the minted generation
+    /// for the next frame's stamp, and records the platform's new size as
+    /// the layout authority.
+    ///
+    /// The mint and the stamp adoption are two separate critical sections
+    /// (the mailbox's own lock, then this stamp's); that is safe for the
+    /// same reason [`RasterHandle::resize`]'s own doc gives — a frame is
+    /// always stamped with whatever this side most recently observed, and
+    /// an interleaving that stamps an older mint is ordinary staleness the
+    /// pump rejects, never a false accept.
+    pub(crate) fn apply(&self, width: u32, height: u32) {
+        let generation = self.handle.resize(width, height);
+        let mut inner = self.stamp.inner.lock();
+        inner.surface_generation = generation;
+        inner.physical_size = (width, height);
+        drop(inner);
+        tracing::debug!(
+            width,
+            height,
+            surface_generation = ?generation,
+            "raster lane: resize requested, next frame stamps the minted generation"
+        );
+    }
+}
+
+/// The inline raster lane: a [`RasterOwner`] pumped synchronously on the
+/// owner thread, plus the stamp state that keeps its frames fresh.
+///
+/// See the module docs for the full ownership and generation story.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct RasterLane<B: RasterBackend> {
+    owner: RasterOwner<B>,
+    handle: RasterHandle,
+    ack_rx: Receiver<RasterAck>,
+    /// Held so an eventual shutdown-complete signal has a live receiver;
+    /// the inline lane never blocks on it (the owner is dropped on this
+    /// same thread instead).
+    _shutdown_rx: Receiver<()>,
+    address: PresentationAddress,
+    epoch: FrameEpoch,
+    stamp: Arc<LaneStamp>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<B: RasterBackend> RasterLane<B> {
+    /// Builds the lane around `backend`, bound to `address`, with the
+    /// window's initial physical size.
+    ///
+    /// Mints the first real [`flui_foundation::SurfaceGeneration`] by
+    /// routing the initial size through [`RasterHandle::resize`] — the same
+    /// entry point every later platform resize uses — so the first frame is
+    /// never stamped [`flui_foundation::SurfaceGeneration::ZERO`] (which
+    /// the pump rejects outright, by design).
+    pub(crate) fn new(backend: B, address: PresentationAddress, width: u32, height: u32) -> Self {
+        let (owner, handle, ack_rx, shutdown_rx) = RasterOwner::new(backend, address);
+        let generation = handle.resize(width, height);
+        let stamp = Arc::new(LaneStamp {
+            inner: Mutex::new(LaneStampInner {
+                surface_generation: generation,
+                physical_size: (width, height),
+            }),
+        });
+        Self {
+            owner,
+            handle,
+            ack_rx,
+            _shutdown_rx: shutdown_rx,
+            address,
+            epoch: FrameEpoch::ZERO,
+            stamp,
+        }
+    }
+
+    /// The resize entry point for the platform's surface applier.
+    pub(crate) fn resize_hook(&self) -> RasterResizeHook {
+        RasterResizeHook {
+            handle: self.handle.clone(),
+            stamp: Arc::clone(&self.stamp),
+        }
+    }
+
+    /// Scoped access to the wrapped backend, for backend-specific concerns
+    /// the raster protocol does not cover (device-loss recovery, the
+    /// hot-reload plugin's direct scene path, test-state reads).
+    pub(crate) fn with_backend<R>(&mut self, f: impl FnOnce(&mut B) -> R) -> R {
+        self.owner.with_backend(f)
+    }
+
+    /// Whether the backend currently reports its GPU device lost.
+    pub(crate) fn is_device_lost(&mut self) -> bool {
+        self.owner.with_backend(|backend| backend.is_device_lost())
+    }
+
+    /// Records that device-loss recovery rebuilt the surface: mints a fresh
+    /// generation through the same mailbox counter a resize uses (ADR-0045
+    /// decision 4 names recovery's surface recreation as a mint site), at
+    /// the platform's latest known size — NOT the backend's readback, which
+    /// predates any resize that arrived while the device was down.
+    pub(crate) fn note_surface_recreated(&mut self) {
+        let (width, height) = self.stamp.physical_size();
+        let generation = self.handle.resize(width, height);
+        self.stamp.set_surface_generation(generation);
+        tracing::info!(
+            width,
+            height,
+            surface_generation = ?generation,
+            "raster lane: surface recreated by device recovery, generation re-minted"
+        );
+    }
+
+    /// Drains the lossy telemetry ack channel into trace events.
+    ///
+    /// Inline, the producer and consumer share one thread, so the drain is
+    /// bounded by the handful of acks a single pump can emit — no
+    /// concurrent producer can extend it.
+    fn drain_acks(&self) {
+        for ack in self.ack_rx.try_iter() {
+            tracing::trace!(?ack, "raster lane: ack");
+        }
+    }
+
+    /// Stamps, submits, and synchronously pumps one frame, classifying the
+    /// outcome for the realm's frame transaction.
+    fn submit_and_pump(&mut self, scene: Scene) -> SubmitVerdict {
+        self.epoch = self.epoch.next();
+        let epoch = self.epoch;
+        let stamp = FrameStamp::new(
+            self.address,
+            epoch,
+            self.stamp.surface_generation(),
+            // The windowed backend is not `GpuServices`-backed yet, so both
+            // sides of the resource-generation compare sit at `ZERO` — the
+            // typed "no shared GPU services bound" state that axis's own
+            // doc defines, not a bypass of the check.
+            GpuResourceGeneration::ZERO,
+        );
+        let snapshot = SceneSnapshot::new(stamp, DamageRegion::Full, scene);
+        if let Err(error) = self.handle.submit(snapshot) {
+            // Inline, the owner lives in this very struct, so
+            // `OwnerGone`/`ShuttingDown` can only mean teardown is already
+            // underway and `AddressMismatch` cannot happen (the stamp above
+            // is built from this lane's own bound address).
+            tracing::error!(%error, "raster lane: frame submit refused");
+            self.drain_acks();
+            return SubmitVerdict::Failed;
+        }
+        let outcome = self.owner.pump();
+        self.drain_acks();
+        match outcome {
+            PumpOutcome::Presented { .. } => {
+                // `PumpOutcome::Presented` classifies a successful render
+                // attempt; whether the frame actually reached `present()`
+                // rides the reliable completion slot (see
+                // `RasterOwner::pump`'s own comment at its `Ok(did_present)`
+                // arm). The pacing decision must read that bit, never infer
+                // it from the outcome name.
+                let presented = self
+                    .handle
+                    .surface_state()
+                    .last_completion
+                    .is_some_and(|completion| completion.epoch == epoch && completion.presented);
+                if presented {
+                    SubmitVerdict::Presented
+                } else {
+                    SubmitVerdict::NoPresent
+                }
+            }
+            PumpOutcome::SurfaceOutdated { stale, current, .. } => {
+                // Covers both a stale-stamp rejection and a mid-render
+                // surface loss/validation failure (the pump mints a fresh
+                // generation on that path). Either way the retry must stamp
+                // the generation the owner now requires.
+                let required = self.handle.surface_state().required_generation;
+                self.stamp.set_surface_generation(required);
+                tracing::debug!(
+                    ?stale,
+                    ?current,
+                    adopted = ?required,
+                    "raster lane: surface stale, restamped for retry"
+                );
+                SubmitVerdict::SurfaceStale
+            }
+            PumpOutcome::ResourceOutdated { .. } => {
+                // Unreachable until the windowed backend binds `GpuServices`
+                // generations (both sides sit at `ZERO` today); classified
+                // as stale-surface semantics — retry after rebinding —
+                // rather than silently dropped, so the arm stays honest if
+                // that wiring lands without this match being revisited.
+                tracing::warn!("raster lane: frame rejected on the GPU-resource axis");
+                SubmitVerdict::SurfaceStale
+            }
+            PumpOutcome::DeviceLost { .. } => SubmitVerdict::DeviceLost,
+            PumpOutcome::Dropped { reason, .. } => {
+                debug_assert!(
+                    !matches!(reason, FrameDropReason::Superseded),
+                    "BUG: an inline submit-then-pump cannot be superseded — nothing else \
+                     submits between the two calls on one thread"
+                );
+                SubmitVerdict::Failed
+            }
+            // `Idle`/`ShutdownComplete`: an accepted inline submit is
+            // pumped by the very next call on this same thread, so
+            // observing no frame means the mailbox protocol was violated.
+            // The wildcard also absorbs any future `#[non_exhaustive]`
+            // variant, which this lane must classify deliberately before
+            // relying on it — `Failed` (no retry armed) is the conservative
+            // default until then.
+            _ => {
+                tracing::error!(
+                    ?outcome,
+                    "raster lane: unclassified pump outcome right after an accepted submit"
+                );
+                SubmitVerdict::Failed
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<B: RasterBackend> FrameSink for RasterLane<B> {
+    fn surface_size(&mut self) -> (u32, u32) {
+        self.stamp.physical_size()
+    }
+
+    fn submit(&mut self, scene: Scene) -> SubmitVerdict {
+        self.submit_and_pump(scene)
+    }
+}
+
+/// The direct, pre-mailbox submit path: renders through a borrowed
+/// [`RasterBackend`] on the calling thread with no stamping and no
+/// generation checks. See [`FrameSink`]'s doc for who still uses it and
+/// why.
+pub(crate) struct DirectSink<'a, R: RasterBackend> {
+    renderer: &'a mut R,
+}
+
+impl<'a, R: RasterBackend> DirectSink<'a, R> {
+    #[cfg_attr(
+        all(not(target_arch = "wasm32"), not(test)),
+        expect(
+            dead_code,
+            reason = "constructed by UiRealm::render_frame_entered, whose native production \
+                      callers moved to the raster lane -- see FrameSink's own doc for who \
+                      still drives this path"
+        )
+    )]
+    pub(crate) fn new(renderer: &'a mut R) -> Self {
+        Self { renderer }
+    }
+}
+
+impl<R: RasterBackend> FrameSink for DirectSink<'_, R> {
+    fn surface_size(&mut self) -> (u32, u32) {
+        self.renderer.size()
+    }
+
+    fn submit(&mut self, scene: Scene) -> SubmitVerdict {
+        self.renderer.mark_full_repaint();
+        match self.renderer.render_scene(&scene) {
+            Ok(true) => SubmitVerdict::Presented,
+            Ok(false) => SubmitVerdict::NoPresent,
+            Err(EngineError::SurfaceLost) => {
+                tracing::debug!("surface lost during render");
+                SubmitVerdict::SurfaceStale
+            }
+            Err(EngineError::SurfaceValidation) => {
+                tracing::error!("surface validation error - surface misconfig");
+                SubmitVerdict::SurfaceStale
+            }
+            Err(EngineError::DeviceLost) => SubmitVerdict::DeviceLost,
+            Err(error) => {
+                tracing::error!(?error, "render error (non-recoverable this frame)");
+                SubmitVerdict::Failed
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use flui_foundation::{PresentationId, RealmId, SurfaceGeneration};
+    use flui_layer::{CanvasLayer, Layer};
+    use flui_types::Size;
+
+    use super::*;
+
+    fn test_address() -> PresentationAddress {
+        PresentationAddress {
+            realm_id: RealmId::new(1),
+            presentation_id: PresentationId::new(1),
+        }
+    }
+
+    fn test_scene() -> Scene {
+        Scene::from_layer(Size::ZERO, Layer::from(CanvasLayer::new()), 0)
+    }
+
+    /// A scripted backend for lane-behavior tests: every render outcome is
+    /// queued up front, and the applied state (resize calls, render calls)
+    /// is observable afterwards.
+    struct ScriptedBackend {
+        outcomes: std::collections::VecDeque<Result<bool, EngineError>>,
+        render_calls: u32,
+        resizes: Vec<(u32, u32)>,
+        lost: bool,
+    }
+
+    impl ScriptedBackend {
+        fn presenting() -> Self {
+            Self {
+                outcomes: std::collections::VecDeque::new(),
+                render_calls: 0,
+                resizes: Vec::new(),
+                lost: false,
+            }
+        }
+
+        fn queue(mut self, outcome: Result<bool, EngineError>) -> Self {
+            self.outcomes.push_back(outcome);
+            self
+        }
+    }
+
+    impl RasterBackend for ScriptedBackend {
+        fn render_scene(&mut self, _scene: &Scene) -> Result<bool, EngineError> {
+            self.render_calls += 1;
+            self.outcomes.pop_front().unwrap_or(Ok(true))
+        }
+        fn resize(&mut self, width: u32, height: u32) {
+            self.resizes.push((width, height));
+        }
+        fn is_device_lost(&self) -> bool {
+            self.lost
+        }
+        fn mark_dirty(&mut self, _rect: flui_types::Rect<flui_types::geometry::Pixels>) {}
+        fn mark_full_repaint(&mut self) {}
+        fn has_damage(&self) -> bool {
+            true
+        }
+        fn size(&self) -> (u32, u32) {
+            (100, 100)
+        }
+        fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_presented_frame_classifies_presented_and_renders_through_the_mailbox() {
+        let mut lane = RasterLane::new(ScriptedBackend::presenting(), test_address(), 640, 480);
+        let verdict = lane.submit_and_pump(test_scene());
+        assert_eq!(verdict, SubmitVerdict::Presented);
+        lane.with_backend(|backend| {
+            assert_eq!(
+                backend.render_calls, 1,
+                "the scene reached the backend through the mailbox pump"
+            );
+            assert_eq!(
+                backend.resizes,
+                vec![(640, 480)],
+                "the construction-time mint's resize was applied before the first render"
+            );
+        });
+    }
+
+    #[test]
+    fn a_no_present_completion_classifies_no_present() {
+        let backend = ScriptedBackend::presenting().queue(Ok(false));
+        let mut lane = RasterLane::new(backend, test_address(), 640, 480);
+        assert_eq!(lane.submit_and_pump(test_scene()), SubmitVerdict::NoPresent);
+    }
+
+    #[test]
+    fn the_resize_hook_mints_forward_and_the_next_frame_is_accepted() {
+        let mut lane = RasterLane::new(ScriptedBackend::presenting(), test_address(), 640, 480);
+        let before = lane.stamp.surface_generation();
+        let hook = lane.resize_hook();
+        hook.apply(1024, 768);
+        let after = lane.stamp.surface_generation();
+        assert!(
+            after > before,
+            "a resize mints a strictly newer generation ({after} vs {before})"
+        );
+        assert_eq!(
+            lane.surface_size(),
+            (1024, 768),
+            "layout reads the platform's announced size before any pump applies it"
+        );
+        // The frame stamped with the fresh mint is accepted by the pump that
+        // applies the resize in the same pass — generation-forward, no
+        // handshake.
+        assert_eq!(lane.submit_and_pump(test_scene()), SubmitVerdict::Presented);
+        lane.with_backend(|backend| {
+            assert_eq!(
+                backend.resizes.last(),
+                Some(&(1024, 768)),
+                "the pump applied the coalesced resize before rendering"
+            );
+        });
+    }
+
+    #[test]
+    fn a_mid_render_surface_loss_restamps_and_the_retry_is_accepted() {
+        let backend = ScriptedBackend::presenting().queue(Err(EngineError::SurfaceLost));
+        let mut lane = RasterLane::new(backend, test_address(), 640, 480);
+        let stamped_before = lane.stamp.surface_generation();
+
+        assert_eq!(
+            lane.submit_and_pump(test_scene()),
+            SubmitVerdict::SurfaceStale
+        );
+        let restamped = lane.stamp.surface_generation();
+        assert!(
+            restamped > stamped_before,
+            "the lane adopted the loss-minted generation for the retry"
+        );
+
+        // The retry (the next queued outcome defaults to Ok(true)) renders
+        // against the restamped generation instead of being rejected.
+        assert_eq!(lane.submit_and_pump(test_scene()), SubmitVerdict::Presented);
+    }
+
+    #[test]
+    fn a_device_loss_classifies_device_lost_and_recovery_reminting_unblocks() {
+        let backend = ScriptedBackend::presenting().queue(Err(EngineError::DeviceLost));
+        let mut lane = RasterLane::new(backend, test_address(), 640, 480);
+
+        assert_eq!(
+            lane.submit_and_pump(test_scene()),
+            SubmitVerdict::DeviceLost
+        );
+        assert!(
+            lane.handle.surface_state().device_lost,
+            "the reliable slot reports the loss"
+        );
+
+        // The runner's recovery path re-mints after rebuilding the surface.
+        lane.note_surface_recreated();
+        assert_eq!(
+            lane.submit_and_pump(test_scene()),
+            SubmitVerdict::Presented,
+            "a recovered lane renders again"
+        );
+        lane.with_backend(|backend| {
+            assert_eq!(
+                backend.resizes.last(),
+                Some(&(640, 480)),
+                "recovery re-minted at the platform's latest size"
+            );
+        });
+    }
+
+    #[test]
+    fn recovery_reminting_uses_the_platform_size_not_the_backend_readback() {
+        // A resize arrives while the device is down; recovery must re-mint
+        // at THAT size, never the backend's stale readback (100x100 here).
+        let backend = ScriptedBackend::presenting().queue(Err(EngineError::DeviceLost));
+        let mut lane = RasterLane::new(backend, test_address(), 640, 480);
+        assert_eq!(
+            lane.submit_and_pump(test_scene()),
+            SubmitVerdict::DeviceLost
+        );
+        lane.resize_hook().apply(1920, 1080);
+        lane.note_surface_recreated();
+        assert_eq!(lane.submit_and_pump(test_scene()), SubmitVerdict::Presented);
+        lane.with_backend(|backend| {
+            assert_eq!(
+                backend.resizes.last(),
+                Some(&(1920, 1080)),
+                "the re-mint carried the platform's latest announced size"
+            );
+        });
+    }
+
+    #[test]
+    fn a_zero_generation_stamp_is_rejected_not_rendered() {
+        // Force the stamp back to ZERO to prove the pump's rejection is
+        // live on this path (the constructor exists precisely so production
+        // never starts there).
+        let mut lane = RasterLane::new(ScriptedBackend::presenting(), test_address(), 640, 480);
+        lane.stamp.set_surface_generation(SurfaceGeneration::ZERO);
+        assert_eq!(
+            lane.submit_and_pump(test_scene()),
+            SubmitVerdict::SurfaceStale
+        );
+        lane.with_backend(|backend| {
+            assert_eq!(
+                backend.render_calls, 0,
+                "a ZERO-stamped frame must never reach render_scene"
+            );
+        });
+    }
+
+    #[test]
+    fn a_generic_render_failure_classifies_failed() {
+        let backend = ScriptedBackend::presenting().queue(Err(EngineError::Timeout));
+        let mut lane = RasterLane::new(backend, test_address(), 640, 480);
+        assert_eq!(lane.submit_and_pump(test_scene()), SubmitVerdict::Failed);
+    }
+}

--- a/crates/flui-app/src/app/raster_lane.rs
+++ b/crates/flui-app/src/app/raster_lane.rs
@@ -7,7 +7,7 @@
 //! upstream `wgpu-hal` constraint (issue #653). Every production frame the
 //! desktop and Android runners submit now crosses the raster boundary as an
 //! owned [`SceneSnapshot`] stamped with a [`FrameStamp`], is checked against
-//! the lane's single [`SurfaceGeneration`] counter, and is rendered by
+//! the lane's single [`flui_foundation::SurfaceGeneration`] counter, and is rendered by
 //! [`RasterOwner::pump`] — the same protocol a dedicated raster thread will
 //! drive via `run_until_shutdown`, so threading the lane later changes who
 //! calls `pump`, not what a frame is.
@@ -25,7 +25,7 @@
 //!
 //! # Generation discipline
 //!
-//! Every [`SurfaceGeneration`] mint routes through the mailbox's one
+//! Every [`flui_foundation::SurfaceGeneration`] mint routes through the mailbox's one
 //! counter (ADR-0045 decision 4):
 //!
 //! - a platform resize mints eagerly via [`RasterHandle::resize`] and the
@@ -34,7 +34,7 @@
 //!   the resize (generation-forward, no handshake);
 //! - a mid-render surface loss mints inside the pump's render-failure path;
 //!   the lane observes the rejection ([`PumpOutcome::SurfaceOutdated`]) and
-//!   re-adopts [`SurfaceState::required_generation`] before the retry;
+//!   re-adopts [`flui_engine::SurfaceState::required_generation`] before the retry;
 //! - device-loss recovery recreates the surface, so
 //!   [`RasterLane::note_surface_recreated`] mints through the same resize
 //!   entry point at the platform's latest known size.

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -8267,9 +8267,14 @@ mod device_recovery_tests {
         let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert!(outcome.presented, "Ok(true) reaches present()");
-        assert_eq!(lane.with_backend(|b| b.render_calls), 1, "the scene reached render_scene");
         assert_eq!(
-            lane.with_backend(|b| b.recover_attempts), 0,
+            lane.with_backend(|b| b.render_calls),
+            1,
+            "the scene reached render_scene"
+        );
+        assert_eq!(
+            lane.with_backend(|b| b.recover_attempts),
+            0,
             "no recovery on a healthy device"
         );
         assert!(
@@ -8300,7 +8305,8 @@ mod device_recovery_tests {
         let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            lane.with_backend(|b| b.recover_attempts), 1,
+            lane.with_backend(|b| b.recover_attempts),
+            1,
             "the pre-frame loss is recovered"
         );
         assert!(
@@ -8308,7 +8314,8 @@ mod device_recovery_tests {
             "the scripted successful recovery cleared the lost flag"
         );
         assert_eq!(
-            lane.with_backend(|b| b.render_calls), 1,
+            lane.with_backend(|b| b.render_calls),
+            1,
             "after a successful recovery the SAME frame renders — no extra wake needed"
         );
         assert!(outcome.presented, "the recovered frame reaches present()");
@@ -8376,7 +8383,8 @@ mod device_recovery_tests {
         // full repaint for whatever gets submitted next, but nothing
         // submits at all without this).
         assert_eq!(
-            lane.with_backend(|b| b.render_calls), 2,
+            lane.with_backend(|b| b.render_calls),
+            2,
             "a successful recovery must force the recovered device's next frame to reach \
              render_scene, not silently stay Idle"
         );
@@ -8407,7 +8415,11 @@ mod device_recovery_tests {
         let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert!(!outcome.presented, "a still-lost device presents nothing");
-        assert_eq!(lane.with_backend(|b| b.recover_attempts), 1, "the recovery was attempted");
+        assert_eq!(
+            lane.with_backend(|b| b.recover_attempts),
+            1,
+            "the recovery was attempted"
+        );
         // The fix this test exists to pin: the earlier version of this
         // function returned `false` here WITHOUT calling
         // `render_frame_entered` at all on a still-lost device, so
@@ -8416,7 +8428,8 @@ mod device_recovery_tests {
         // deadlines, coalesced pointer moves, and every Vsync ticker all
         // depend on it).
         assert_eq!(
-            lane.with_backend(|b| b.render_calls), 1,
+            lane.with_backend(|b| b.render_calls),
+            1,
             "render_frame_entered must run even when the pre-frame recovery attempt \
              failed — a dead device must not stop the non-GPU half of the frame"
         );
@@ -8466,7 +8479,8 @@ mod device_recovery_tests {
         let second = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            lane.with_backend(|b| b.recover_attempts), 1,
+            lane.with_backend(|b| b.recover_attempts),
+            1,
             "a wake before the backoff's deadline must not touch the renderer at all — the \
              whole point of a deadline CHECK over a sleep is that a still-too-early wake \
              costs nothing"
@@ -8560,12 +8574,14 @@ mod device_recovery_tests {
         let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            lane.with_backend(|b| b.recover_attempts), 2,
+            lane.with_backend(|b| b.recover_attempts),
+            2,
             "the device recovered pre-frame, died again mid-frame, and must be attempted \
              a SECOND time in the same call"
         );
         assert_eq!(
-            lane.with_backend(|b| b.render_calls), 1,
+            lane.with_backend(|b| b.render_calls),
+            1,
             "the frame still rendered exactly once"
         );
         assert!(
@@ -8598,7 +8614,8 @@ mod device_recovery_tests {
         let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            lane.with_backend(|b| b.render_calls), 1,
+            lane.with_backend(|b| b.render_calls),
+            1,
             "the frame rendered before the loss landed"
         );
         assert!(
@@ -8606,7 +8623,8 @@ mod device_recovery_tests {
             "the frame that rendered still reaches present()"
         );
         assert_eq!(
-            lane.with_backend(|b| b.recover_attempts), 1,
+            lane.with_backend(|b| b.recover_attempts),
+            1,
             "the mid-frame loss is recovered after the render"
         );
         assert!(
@@ -8647,7 +8665,8 @@ mod device_recovery_tests {
         let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            lane.with_backend(|b| b.render_calls), 1,
+            lane.with_backend(|b| b.render_calls),
+            1,
             "the frame rendered before the loss landed"
         );
         assert!(
@@ -8655,7 +8674,8 @@ mod device_recovery_tests {
             "the frame that rendered still reaches present()"
         );
         assert_eq!(
-            lane.with_backend(|b| b.recover_attempts), 1,
+            lane.with_backend(|b| b.recover_attempts),
+            1,
             "the mid-frame loss is recovered after the render"
         );
         assert!(

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -7688,13 +7688,15 @@ struct FrameRecoveryOutcome {
     next_attempt_at: Option<web_time::Instant>,
 }
 
-/// Drive one frame through `realm` against `renderer`, rebuilding a lost
-/// device around it.
+/// Drive one frame through `realm` against `lane`'s raster mailbox,
+/// rebuilding a lost device around it.
 ///
 /// A device already lost at frame start gets a backoff-gated recovery
-/// attempt here, BEFORE [`super::ui_realm::UiRealm::render_frame_entered`]
-/// — but `render_frame_entered` runs regardless of whether that attempt
-/// happened or what it returned. Skipping it on a still-lost device was the
+/// attempt here, BEFORE [`super::ui_realm::UiRealm::render_frame_on_lane`]
+/// (the mailbox-driving twin of `render_frame_entered` — this doc refers to
+/// the pair interchangeably below) — but that frame drive runs regardless
+/// of whether that attempt happened or what it returned. Skipping it on a
+/// still-lost device was the
 /// original bug this function fixes: `render_frame_entered` is the only
 /// caller of `drain_deferred_arena_resolutions`, `flush_pending_moves`,
 /// `draw_frame_entered`, and `mouse_tracker().update_all_devices()`, all of
@@ -7741,25 +7743,34 @@ struct FrameRecoveryOutcome {
 /// loss was even noticed, so there is no known-blank backing store to force
 /// a fresh submit for.
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
-fn render_frame_with_device_recovery<R>(
+fn render_frame_with_device_recovery<B>(
     realm: &super::ui_realm::UiRealm,
-    renderer: &mut R,
+    lane: &mut super::raster_lane::RasterLane<B>,
     backoff: &DeviceRecoveryBackoff,
     now: web_time::Instant,
 ) -> FrameRecoveryOutcome
 where
-    R: flui_engine::RasterBackend + DeviceRecovery,
+    B: flui_engine::RasterBackend + DeviceRecovery,
 {
     let mut just_failed = false;
     let mut next_attempt_at = None;
 
-    if renderer.is_device_lost() {
-        match attempt_device_recovery(renderer, backoff, now) {
-            // Pre-frame only: nothing has presented since the device died,
-            // so the recovered backing store needs a genuinely fresh
-            // submit — see `UiRealm::mark_primary_needs_full_repaint`'s
-            // own doc for why `request_redraw` alone does not get one.
-            RecoveryAttempt::Recovered => realm.mark_primary_needs_full_repaint(),
+    if lane.is_device_lost() {
+        match lane.with_backend(|renderer| attempt_device_recovery(renderer, backoff, now)) {
+            RecoveryAttempt::Recovered => {
+                // Recovery rebuilt the surface, so the lane re-mints its
+                // `SurfaceGeneration` through the mailbox's one counter
+                // (ADR-0045 decision 4 names recovery's surface recreation
+                // as a mint site) — without this, the recovered lane's
+                // next frame would still stamp the pre-loss generation.
+                lane.note_surface_recreated();
+                // Pre-frame only: nothing has presented since the device
+                // died, so the recovered backing store needs a genuinely
+                // fresh submit — see `UiRealm::mark_primary_needs_full_
+                // repaint`'s own doc for why `request_redraw` alone does
+                // not get one.
+                realm.mark_primary_needs_full_repaint();
+            }
             RecoveryAttempt::Failed(deadline) => {
                 just_failed = true;
                 next_attempt_at = Some(deadline);
@@ -7768,17 +7779,21 @@ where
         }
     }
 
-    let presented = realm.render_frame_entered(renderer);
+    let presented = realm.render_frame_on_lane(lane);
 
-    if next_attempt_at.is_none() && renderer.is_device_lost() {
-        match attempt_device_recovery(renderer, backoff, now) {
-            // Post-frame (mid-frame loss) success arms NOTHING, unlike the
-            // pre-frame case above: the frame that just ran already had
+    if next_attempt_at.is_none() && lane.is_device_lost() {
+        match lane.with_backend(|renderer| attempt_device_recovery(renderer, backoff, now)) {
+            // Post-frame (mid-frame loss) success arms NO repaint, unlike
+            // the pre-frame case above: the frame that just ran already had
             // its own chance to present before the loss was noticed, so
             // there is no known-blank backing store to force a fresh
             // submit for here — forcing one anyway would just be a
             // spurious extra repaint with no correctness reason behind it.
-            RecoveryAttempt::Recovered => {}
+            // The generation re-mint is NOT skippable the same way: the
+            // recovery rebuilt the surface either way, and the next frame
+            // (whenever something else dirties the tree) must stamp the
+            // post-recovery generation.
+            RecoveryAttempt::Recovered => lane.note_surface_recreated(),
             RecoveryAttempt::Failed(deadline) => {
                 just_failed = true;
                 next_attempt_at = Some(deadline);
@@ -7877,6 +7892,22 @@ mod device_recovery_tests {
         realm
     }
 
+    /// Wraps a scripted backend in the raster lane the production frame
+    /// path drives (`render_frame_with_device_recovery` takes a lane, not
+    /// a bare backend, since the desktop/Android runners adopted the
+    /// mailbox) — the size matches the scripted backends' own `size()`.
+    fn lane_over<B: RasterBackend>(backend: B) -> super::super::raster_lane::RasterLane<B> {
+        super::super::raster_lane::RasterLane::new(
+            backend,
+            flui_foundation::PresentationAddress {
+                realm_id: flui_foundation::RealmId::new(1),
+                presentation_id: flui_foundation::PresentationId::new(1),
+            },
+            800,
+            600,
+        )
+    }
+
     struct ScriptedDeviceBackend {
         /// Current device-lost flag (what `RasterBackend::is_device_lost` reports).
         lost: bool,
@@ -7953,17 +7984,17 @@ mod device_recovery_tests {
     #[test]
     fn a_healthy_device_renders_without_any_recovery() {
         let realm = mount_root();
-        let mut backend = ScriptedDeviceBackend::healthy();
+        let mut lane = lane_over(ScriptedDeviceBackend::healthy());
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert!(outcome.presented, "Ok(true) reaches present()");
-        assert_eq!(backend.render_calls, 1, "the scene reached render_scene");
+        assert_eq!(lane.with_backend(|b| b.render_calls), 1, "the scene reached render_scene");
         assert_eq!(
-            backend.recover_attempts, 0,
+            lane.with_backend(|b| b.recover_attempts), 0,
             "no recovery on a healthy device"
         );
         assert!(
@@ -7983,26 +8014,26 @@ mod device_recovery_tests {
     #[test]
     fn a_pre_frame_loss_with_a_successful_recovery_renders_the_same_frame_and_arms_nothing() {
         let realm = mount_root();
-        let mut backend = ScriptedDeviceBackend {
+        let mut lane = lane_over(ScriptedDeviceBackend {
             lost: true,
             ..ScriptedDeviceBackend::healthy()
-        };
+        });
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            backend.recover_attempts, 1,
+            lane.with_backend(|b| b.recover_attempts), 1,
             "the pre-frame loss is recovered"
         );
         assert!(
-            !backend.lost,
+            !lane.with_backend(|b| b.lost),
             "the scripted successful recovery cleared the lost flag"
         );
         assert_eq!(
-            backend.render_calls, 1,
+            lane.with_backend(|b| b.render_calls), 1,
             "after a successful recovery the SAME frame renders — no extra wake needed"
         );
         assert!(outcome.presented, "the recovered frame reaches present()");
@@ -8031,7 +8062,7 @@ mod device_recovery_tests {
     #[test]
     fn a_successful_recovery_forces_the_recovered_devices_next_frame_to_actually_paint() {
         let realm = mount_root();
-        let mut backend = ScriptedDeviceBackend::healthy();
+        let mut lane = lane_over(ScriptedDeviceBackend::healthy());
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
@@ -8041,20 +8072,22 @@ mod device_recovery_tests {
         // definitely false going into the recovery below — otherwise this
         // test could pass by riding the mount's own leftover demand
         // instead of proving what the recovery success arm itself does.
-        let warm_up = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let warm_up = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
         assert!(
             warm_up.presented,
             "precondition: the mount's own first frame presented"
         );
-        assert_eq!(backend.render_calls, 1);
+        assert_eq!(lane.with_backend(|b| b.render_calls), 1);
 
         // Now the device dies and recovers, with NOTHING else marking the
         // tree dirty in between (no input, no animation, no resize).
-        backend.lost = true;
-        backend.scene_outcome = Some(Ok(true));
-        backend.recover_outcome = Some(Ok(()));
+        lane.with_backend(|b| {
+            b.lost = true;
+            b.scene_outcome = Some(Ok(true));
+            b.recover_outcome = Some(Ok(()));
+        });
 
-        let recovery = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let recovery = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         // The fix this test pins: `wake_frame()` alone (the realm-level
         // flag plus a platform poke) does NOT set `PresentationState::
@@ -8068,7 +8101,7 @@ mod device_recovery_tests {
         // full repaint for whatever gets submitted next, but nothing
         // submits at all without this).
         assert_eq!(
-            backend.render_calls, 2,
+            lane.with_backend(|b| b.render_calls), 2,
             "a successful recovery must force the recovered device's next frame to reach \
              render_scene, not silently stay Idle"
         );
@@ -8081,7 +8114,7 @@ mod device_recovery_tests {
     #[test]
     fn a_pre_frame_loss_with_a_failing_recovery_still_renders_the_frame_and_backs_off() {
         let realm = mount_root();
-        let mut backend = ScriptedDeviceBackend {
+        let mut lane = lane_over(ScriptedDeviceBackend {
             lost: true,
             // The real `Renderer::acquire_surface_texture` bails on the
             // `device_lost` flag before touching the GPU — scripted here
@@ -8091,15 +8124,15 @@ mod device_recovery_tests {
             recover_outcome: Some(Err(EngineError::DeviceLost)),
             recover_clears_lost: false,
             ..ScriptedDeviceBackend::healthy()
-        };
+        });
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert!(!outcome.presented, "a still-lost device presents nothing");
-        assert_eq!(backend.recover_attempts, 1, "the recovery was attempted");
+        assert_eq!(lane.with_backend(|b| b.recover_attempts), 1, "the recovery was attempted");
         // The fix this test exists to pin: the earlier version of this
         // function returned `false` here WITHOUT calling
         // `render_frame_entered` at all on a still-lost device, so
@@ -8108,7 +8141,7 @@ mod device_recovery_tests {
         // deadlines, coalesced pointer moves, and every Vsync ticker all
         // depend on it).
         assert_eq!(
-            backend.render_calls, 1,
+            lane.with_backend(|b| b.render_calls), 1,
             "render_frame_entered must run even when the pre-frame recovery attempt \
              failed — a dead device must not stop the non-GPU half of the frame"
         );
@@ -8132,31 +8165,33 @@ mod device_recovery_tests {
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let mut backend = ScriptedDeviceBackend {
+        let mut lane = lane_over(ScriptedDeviceBackend {
             lost: true,
             scene_outcome: Some(Err(EngineError::DeviceLost)),
             recover_outcome: Some(Err(EngineError::DeviceLost)),
             recover_clears_lost: false,
             ..ScriptedDeviceBackend::healthy()
-        };
-        let first = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        });
+        let first = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
         assert!(
             first.just_failed,
             "precondition: the first attempt genuinely failed"
         );
-        assert_eq!(backend.recover_attempts, 1);
+        assert_eq!(lane.with_backend(|b| b.recover_attempts), 1);
 
         // Refilled so a genuine second attempt, if this test's premise is
         // wrong, fails loudly on its own assertions below rather than
         // panicking on a `.take()` of `None`.
-        backend.scene_outcome = Some(Err(EngineError::DeviceLost));
-        backend.recover_outcome = Some(Err(EngineError::DeviceLost));
+        lane.with_backend(|b| {
+            b.scene_outcome = Some(Err(EngineError::DeviceLost));
+            b.recover_outcome = Some(Err(EngineError::DeviceLost));
+        });
 
         // Same instant, well before the backoff's own deadline (BASE, 16ms).
-        let second = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let second = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            backend.recover_attempts, 1,
+            lane.with_backend(|b| b.recover_attempts), 1,
             "a wake before the backoff's deadline must not touch the renderer at all — the \
              whole point of a deadline CHECK over a sleep is that a still-too-early wake \
              costs nothing"
@@ -8242,24 +8277,24 @@ mod device_recovery_tests {
     #[test]
     fn a_pre_frame_recovery_success_does_not_block_a_fresh_mid_frame_loss() {
         let realm = mount_root();
-        let mut backend = AlwaysRecoversButDiesOnFirstRenderBackend::new();
+        let mut lane = lane_over(AlwaysRecoversButDiesOnFirstRenderBackend::new());
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            backend.recover_attempts, 2,
+            lane.with_backend(|b| b.recover_attempts), 2,
             "the device recovered pre-frame, died again mid-frame, and must be attempted \
              a SECOND time in the same call"
         );
         assert_eq!(
-            backend.render_calls, 1,
+            lane.with_backend(|b| b.render_calls), 1,
             "the frame still rendered exactly once"
         );
         assert!(
-            !backend.lost,
+            !lane.with_backend(|b| b.lost),
             "the second, post-frame recovery attempt succeeded"
         );
         assert!(
@@ -8275,20 +8310,20 @@ mod device_recovery_tests {
     #[test]
     fn a_mid_frame_loss_with_a_failing_recovery_backs_off() {
         let realm = mount_root();
-        let mut backend = ScriptedDeviceBackend {
+        let mut lane = lane_over(ScriptedDeviceBackend {
             lose_on_render: true,
             recover_outcome: Some(Err(EngineError::DeviceLost)),
             recover_clears_lost: false,
             ..ScriptedDeviceBackend::healthy()
-        };
+        });
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            backend.render_calls, 1,
+            lane.with_backend(|b| b.render_calls), 1,
             "the frame rendered before the loss landed"
         );
         assert!(
@@ -8296,7 +8331,7 @@ mod device_recovery_tests {
             "the frame that rendered still reaches present()"
         );
         assert_eq!(
-            backend.recover_attempts, 1,
+            lane.with_backend(|b| b.recover_attempts), 1,
             "the mid-frame loss is recovered after the render"
         );
         assert!(
@@ -8326,18 +8361,18 @@ mod device_recovery_tests {
     #[test]
     fn a_mid_frame_loss_with_a_successful_recovery_arms_nothing() {
         let realm = mount_root();
-        let mut backend = ScriptedDeviceBackend {
+        let mut lane = lane_over(ScriptedDeviceBackend {
             lose_on_render: true,
             ..ScriptedDeviceBackend::healthy()
-        };
+        });
         realm.mark_rendered();
         let backoff = DeviceRecoveryBackoff::new();
         let now = Instant::now();
 
-        let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert_eq!(
-            backend.render_calls, 1,
+            lane.with_backend(|b| b.render_calls), 1,
             "the frame rendered before the loss landed"
         );
         assert!(
@@ -8345,11 +8380,11 @@ mod device_recovery_tests {
             "the frame that rendered still reaches present()"
         );
         assert_eq!(
-            backend.recover_attempts, 1,
+            lane.with_backend(|b| b.recover_attempts), 1,
             "the mid-frame loss is recovered after the render"
         );
         assert!(
-            !backend.lost,
+            !lane.with_backend(|b| b.lost),
             "the scripted successful recovery cleared the lost flag"
         );
         assert!(
@@ -8417,15 +8452,15 @@ mod device_recovery_tests {
         // worst case for the deleted early return, and the one production
         // scenario (driver still mid-reset) this fix must keep advancing
         // through.
-        let mut backend = ScriptedDeviceBackend {
+        let mut lane = lane_over(ScriptedDeviceBackend {
             lost: true,
             scene_outcome: Some(Err(EngineError::DeviceLost)),
             recover_outcome: Some(Err(EngineError::DeviceLost)),
             recover_clears_lost: false,
             ..ScriptedDeviceBackend::healthy()
-        };
+        });
 
-        let _ = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let _ = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
 
         assert!(
             long_press_fired.load(std::sync::atomic::Ordering::SeqCst),
@@ -8455,14 +8490,14 @@ mod device_recovery_tests {
         let mut now = Instant::now();
 
         for frame in 1..=3u32 {
-            let mut backend = ScriptedDeviceBackend {
+            let mut lane = lane_over(ScriptedDeviceBackend {
                 lost: true,
                 scene_outcome: Some(Err(EngineError::DeviceLost)),
                 recover_outcome: Some(Err(EngineError::DeviceLost)),
                 recover_clears_lost: false,
                 ..ScriptedDeviceBackend::healthy()
-            };
-            let _ = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+            });
+            let _ = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
             assert!(
                 realm.needs_redraw(),
                 "needs_redraw must still be armed after frame {frame} against a \
@@ -8525,8 +8560,8 @@ mod device_recovery_tests {
         // called directly, bypassing the closure's own gate, the same way
         // every wake in production reaches this function only once
         // `wake_action` has already decided `Render`.
-        let mut backend = permanently_dead_backend();
-        let seed = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let mut lane = lane_over(permanently_dead_backend());
+        let seed = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
         assert!(
             seed.just_failed,
             "precondition: wake 1 is a genuine failure"
@@ -8583,9 +8618,9 @@ mod device_recovery_tests {
                 })
             };
 
-            let mut backend = permanently_dead_backend();
-            let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
-            if backend.recover_attempts == 1 {
+            let mut lane = lane_over(permanently_dead_backend());
+            let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
+            if lane.with_backend(|b| b.recover_attempts) == 1 {
                 total_attempts += 1;
                 armed_deadlines.push(
                     outcome
@@ -8652,8 +8687,8 @@ mod device_recovery_tests {
             }
         }
 
-        let mut backend = permanently_dead_backend();
-        let seed = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
+        let mut lane = lane_over(permanently_dead_backend());
+        let seed = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
         assert!(
             seed.just_failed,
             "precondition: wake 1 is a genuine failure"
@@ -8689,9 +8724,9 @@ mod device_recovery_tests {
                 }) + super::NO_PRESENT_FALLBACK_PACE
             };
 
-            let mut backend = permanently_dead_backend();
-            let outcome = render_frame_with_device_recovery(&realm, &mut backend, &backoff, now);
-            if backend.recover_attempts == 1 {
+            let mut lane = lane_over(permanently_dead_backend());
+            let outcome = render_frame_with_device_recovery(&realm, &mut lane, &backoff, now);
+            if lane.with_backend(|b| b.recover_attempts) == 1 {
                 total_attempts += 1;
             }
             poke_pending = outcome.just_failed;
@@ -9073,22 +9108,42 @@ where
             }
         });
 
-        // 4. Wrap renderer for callback sharing
-        let renderer = Arc::new(Mutex::new(renderer));
+        // 4. Adopt the raster mailbox (ADR-0045's inline lane). The lane's
+        // owner SOLELY owns the renderer from here on: the platform resize
+        // path holds only the lane's mailbox handle plus the owner-affine
+        // stamp/size state, and the frame closure below drives every
+        // submit through the mailbox pump — an owned, stamped
+        // `SceneSnapshot` per frame, checked against the lane's single
+        // `SurfaceGeneration` counter. `Arc<Mutex<RasterLane>>` mirrors the
+        // `Arc<Mutex<Renderer>>` it replaces (the platform's callback
+        // registrations require `Send` closures even though they only ever
+        // fire on this owner thread); a reentrant frame dispatch — already
+        // skipped upstream by the empty-slot drain protection — degrades to
+        // a skipped frame at the `try_lock` below instead of a same-thread
+        // lock deadlock.
+        let lane = Arc::new(Mutex::new(super::raster_lane::RasterLane::new(
+            renderer,
+            realm_dispatch.address,
+            phys_size.width.0 as u32,
+            phys_size.height.0 as u32,
+        )));
 
         // Install the registration-lifetime surface applier alongside the
         // realm (cleared together at teardown): a `Resized` event takes it
         // out of the TLS slot, calls it, and restores it (see
         // `PlatformToUi::run`'s `Resized` arm) rather than capturing the
-        // renderer inside the event payload itself.
+        // lane inside the event payload itself. The hook mints the frame
+        // stamp's next `SurfaceGeneration` and records the platform's new
+        // size as layout's authority; the backend surface itself is
+        // reconfigured by the lane's next pump, before the next render.
         {
-            let renderer_resize = Arc::clone(&renderer);
+            let resize_hook = lane.lock().resize_hook();
             install_surface_applier(
                 realm_dispatch.address.realm_id,
                 move |size, scale_factor| {
                     let w = (size.width.0 * scale_factor) as u32;
                     let h = (size.height.0 * scale_factor) as u32;
-                    renderer_resize.lock().resize(w, h);
+                    resize_hook.apply(w, h);
                 },
             );
         }
@@ -9102,13 +9157,13 @@ where
             DispatchEventResult::resolved(false, true)
         }));
 
-        // 6. Register frame callback -> scheduler + UiRealm::render_frame_entered()
-        let renderer_frame = Arc::clone(&renderer);
+        // 6. Register frame callback -> scheduler + UiRealm::render_frame_on_lane()
+        let lane_frame = Arc::clone(&lane);
         let worker_reload_frame = worker_reload.clone();
         // Reuses the SAME backoff constructed at step 0c (already wired
         // into the wake-deadline hook above) — not a fresh one.
         window.on_request_frame(Box::new(move || {
-            let renderer_frame = Arc::clone(&renderer_frame);
+            let lane_frame = Arc::clone(&lane_frame);
             let worker_reload_frame = worker_reload_frame.clone();
             let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
             let _ = dispatch_platform_realm(
@@ -9241,10 +9296,24 @@ where
                             // frame builds anyway, see this function's own doc for why),
                             // and AFTER when the wgpu device-lost callback fired
                             // mid-frame — see `render_frame_with_device_recovery`.
-                            let mut r = renderer_frame.lock();
+                            let Some(mut lane) = lane_frame.try_lock() else {
+                                // A reentrant frame dispatch that slipped past the
+                                // empty-slot drain protection upstream: skip this
+                                // nested frame rather than deadlock mid-pump; the
+                                // outer dispatch still completes its own.
+                                tracing::error!(
+                                    "frame skipped: raster lane already held by an \
+                                     outer frame dispatch"
+                                );
+                                return FrameRecoveryOutcome {
+                                    presented: false,
+                                    just_failed: false,
+                                    next_attempt_at: None,
+                                };
+                            };
                             render_frame_with_device_recovery(
                                 realm,
-                                &mut *r,
+                                &mut *lane,
                                 &device_recovery_backoff,
                                 now,
                             )
@@ -10233,20 +10302,30 @@ where
         }
         let realm_dispatch = install_platform_realm(ui_realm, &window);
 
-        // 4. Wrap renderer for callback sharing
-        let renderer = Arc::new(Mutex::new(renderer));
+        // 4. Adopt the raster mailbox (ADR-0045's inline lane) — the same
+        // ownership shape as the desktop bootstrap: the lane's owner solely
+        // owns the renderer, the resize path holds only the mailbox handle
+        // plus the owner-affine stamp/size state, and every frame submit
+        // below crosses the raster boundary as an owned, stamped
+        // `SceneSnapshot`.
+        let lane = Arc::new(Mutex::new(super::raster_lane::RasterLane::new(
+            renderer,
+            realm_dispatch.address,
+            phys_size.width.0 as u32,
+            phys_size.height.0 as u32,
+        )));
 
         // Install the registration-lifetime surface applier alongside the
         // realm (cleared together at teardown) — see the desktop bootstrap's
         // matching comment for the take/call/restore protocol this feeds.
         {
-            let renderer_resize = Arc::clone(&renderer);
+            let resize_hook = lane.lock().resize_hook();
             install_surface_applier(
                 realm_dispatch.address.realm_id,
                 move |size, scale_factor| {
                     let w = (size.width.0 * scale_factor) as u32;
                     let h = (size.height.0 * scale_factor) as u32;
-                    renderer_resize.lock().resize(w, h);
+                    resize_hook.apply(w, h);
                 },
             );
         }
@@ -10261,12 +10340,12 @@ where
         }));
 
         // 6. Register frame callback -- with hot-reload plugin override
-        let renderer_frame = Arc::clone(&renderer);
+        let lane_frame = Arc::clone(&lane);
         let hot_reload_frame = hot_reload.clone();
         // Reuses the SAME backoff constructed at step 0b (already wired
         // into the wake-deadline hook above) — not a fresh one.
         window.on_request_frame(Box::new(move || {
-            let renderer_frame = Arc::clone(&renderer_frame);
+            let lane_frame = Arc::clone(&lane_frame);
             let hot_reload_frame = hot_reload_frame.clone();
             let device_recovery_backoff = Arc::clone(&device_recovery_backoff);
             let _ = dispatch_platform_realm(
@@ -10281,17 +10360,30 @@ where
                     // regardless of which rendering path this frame takes.
                     let inbox_redraw = drain_owner_inbox(realm);
 
-                    let mut r = renderer_frame.lock();
-                    let (w, h) = r.size();
-
                     // If a scene plugin is live it owns this presentation frame,
                     // but the callback still executes inside the realm entry
                     // scope. Always `false` in a build without the `hot-reload`
-                    // feature.
-                    if hot_reload_frame.try_render_frame(&mut *r, w as f32, h as f32) {
-                        return;
+                    // feature. The plugin renders through the backend directly
+                    // (its own diagnostic scene, not a realm-produced frame),
+                    // so it goes through the lane's scoped backend access —
+                    // per ADR-0045 decision 6 the plugin path is one of the
+                    // named inline-only lanes.
+                    {
+                        let Some(mut lane) = lane_frame.try_lock() else {
+                            tracing::error!(
+                                "frame skipped: raster lane already held by an outer \
+                                 frame dispatch"
+                            );
+                            return;
+                        };
+                        let plugin_rendered = lane.with_backend(|r| {
+                            let (w, h) = r.size();
+                            hot_reload_frame.try_render_frame(r, w as f32, h as f32)
+                        });
+                        if plugin_rendered {
+                            return;
+                        }
                     }
-                    drop(r);
 
                     let has_pending = realm.has_pending_work();
                     // See the desktop closure's matching comment: a wake-
@@ -10380,10 +10472,16 @@ where
                             // Device-loss recovery around the frame, same
                             // shape as the desktop path — see
                             // `render_frame_with_device_recovery`.
-                            let mut r = renderer_frame.lock();
+                            let Some(mut lane) = lane_frame.try_lock() else {
+                                tracing::error!(
+                                    "frame skipped: raster lane already held by an \
+                                     outer frame dispatch"
+                                );
+                                return;
+                            };
                             let _ = render_frame_with_device_recovery(
                                 realm,
-                                &mut *r,
+                                &mut *lane,
                                 &device_recovery_backoff,
                                 now,
                             );

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -33,7 +33,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use flui_animation::Vsync;
-use flui_engine::{EngineError, RasterBackend};
+use flui_engine::RasterBackend;
+#[cfg(test)]
+use flui_engine::EngineError;
 use flui_foundation::{PresentationId, RealmId};
 use flui_interaction::{FocusManager, GestureBinding, InteractionLane};
 use flui_layer::Scene;
@@ -2582,20 +2584,53 @@ impl UiRealm {
     /// still do all the work to produce frames, but those frames are never
     /// sent to the engine"), so a deferred presentation's segment can very
     /// much have produced a real `Painted` outcome here, and this check is
-    /// what keeps it off the engine. `SurfaceLost`/`DeviceLost`/
-    /// `SurfaceValidation`, a pipeline `Errored` outcome, and any other
-    /// render error all count as a dropped (not settled) frame, arming a
-    /// retry via [`Self::wake_frame`] instead of [`Self::mark_rendered`]'s
-    /// idle-clear — but only the three named submit failures additionally
-    /// re-dirty the pipeline via [`Self::mark_needs_full_repaint_for`]; see
-    /// the `retry_needs_repaint` binding below for why a pipeline `Errored`
-    /// outcome does not get the same treatment.
+    /// what keeps it off the engine. A stale/lost surface, a lost device,
+    /// and a pipeline `Errored` outcome all count as a dropped (not
+    /// settled) frame, arming a retry via [`Self::wake_frame`] instead of
+    /// [`Self::mark_rendered`]'s idle-clear — but only the submit-failure
+    /// verdicts (`SurfaceStale`/`DeviceLost`) additionally re-dirty the
+    /// pipeline via [`Self::mark_needs_full_repaint_for`]; see the
+    /// `retry_needs_repaint` binding below for why a pipeline `Errored`
+    /// outcome (and a generic `Failed` submit) does not get the same
+    /// treatment.
     #[tracing::instrument(level = "debug", skip_all)]
+    #[cfg_attr(
+        all(not(target_arch = "wasm32"), not(test)),
+        expect(
+            dead_code,
+            reason = "the direct-sink entry point is the web runner's production frame path \
+                      (wasm32) and the scripted-backend test seam; native production drives \
+                      render_frame_on_lane instead -- see FrameSink's own doc"
+        )
+    )]
     pub(crate) fn render_frame_entered<R: RasterBackend>(&self, renderer: &mut R) -> bool {
+        self.render_frame_with_sink(&mut super::raster_lane::DirectSink::new(renderer))
+    }
+
+    /// [`Self::render_frame_entered`], driven through the raster mailbox:
+    /// the desktop/Android runners' canonical frame path (ADR-0045's inline
+    /// lane). The scene crosses the raster boundary as an owned, stamped
+    /// `SceneSnapshot` and is rendered by the lane's own pump; the direct
+    /// entry point above remains for the web runner and for tests that pin
+    /// this transaction against scripted backends — both feed the same
+    /// classification arms below, so the retry/telemetry semantics cannot
+    /// drift between the two.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) fn render_frame_on_lane<B: RasterBackend>(
+        &self,
+        lane: &mut super::raster_lane::RasterLane<B>,
+    ) -> bool {
+        self.render_frame_with_sink(lane)
+    }
+
+    /// The shared frame transaction behind both entry points above. See
+    /// [`Self::render_frame_entered`]'s doc for the step-by-step contract.
+    fn render_frame_with_sink<S: super::raster_lane::FrameSink>(&self, sink: &mut S) -> bool {
         self.gestures().drain_deferred_arena_resolutions();
         self.gestures().flush_pending_moves();
 
-        let (width, height) = renderer.size();
+        let (width, height) = sink.surface_size();
         let dpr = self
             .presentations
             .primary()
@@ -2665,8 +2700,8 @@ impl UiRealm {
         let mut retry_needed = any_failed;
         // Tracks a NARROWER condition than `retry_needed`: whether the
         // eventual retry also needs [`Self::mark_needs_full_repaint_for`]
-        // to have something to redo. Only the three submit-failure arms
-        // below (`SurfaceLost`/`DeviceLost`/`SurfaceValidation`) set this —
+        // to have something to redo. Only the submit-failure arms below
+        // (`SurfaceStale`/`DeviceLost`) set this —
         // deliberately NOT `errored` (a `FramePaintOutcome::Errored`
         // outcome, i.e. `run_frame_with_layout_builders` itself returned
         // `Err`): on that path `render_scene` is never called at all, so
@@ -2679,17 +2714,25 @@ impl UiRealm {
         // still paying its cost every wake. That arm keeps its PRE-#637
         // behavior unchanged: `wake_frame()` only, same as `main`.
         let mut retry_needs_repaint = false;
+        use super::raster_lane::SubmitVerdict;
         if should_send
-            && let FramePaintOutcome::Painted(ref scene) = outcome
+            && let FramePaintOutcome::Painted(scene) = outcome
             && scene.has_content()
         {
-            renderer.mark_full_repaint();
-            let render_result = renderer.render_scene(scene);
-            // Telemetry: sampled AFTER `render_scene` returns, never before
-            // it -- on the production wgpu backend, a `Ok(true)` result
-            // means `render_scene` itself called `output.present()`, which
+            let frame_number = scene.frame_number();
+            // The scene is handed over BY VALUE: on the raster-lane path it
+            // crosses the raster boundary as an owned, stamped
+            // `SceneSnapshot` (the mailbox seam's own no-`Arc<Scene>`
+            // contract); the direct path borrows it internally and drops it
+            // when the render returns.
+            let render_verdict = sink.submit(scene);
+            // Telemetry: sampled AFTER the submit returns, never before
+            // it -- on the production wgpu backend, a `Presented` verdict
+            // means the backend called `output.present()`, which
             // under the default `Fifo` presentation mode BLOCKS until the
-            // next vsync before returning. Sampling before the call (as an
+            // next vsync before returning (on the inline raster lane the
+            // pump runs synchronously inside `submit`, so that block still
+            // lands within this call). Sampling before the call (as an
             // earlier version of this method did) understates every
             // "input-to-present"/"produce-to-present" latency by up to a
             // full frame interval -- it would measure submit, not present,
@@ -2697,40 +2740,39 @@ impl UiRealm {
             // `input_to_present_histogram`/`produce_to_present_histogram`
             // names (and `FrameSnapshot::submit_at`'s own doc) already
             // claim the present-inclusive meaning. Sampling once, here,
-            // after the call returns -- for EVERY outcome, not just
-            // `Ok(true)` -- keeps that claim true uniformly: a failure
-            // arm's `submit_at` is likewise "whenever `render_scene`
-            // finished attempting this submit", including whatever work
-            // (partial blocking, driver validation) it did before failing.
-            // Never recorded for `Ok(false)` (no damage/occluded, nothing
+            // after the call returns -- for EVERY verdict, not just
+            // `Presented` -- keeps that claim true uniformly: a failure
+            // arm's `submit_at` is likewise "whenever the backend finished
+            // attempting this submit", including whatever work (partial
+            // blocking, driver validation) it did before failing. Never
+            // recorded for `NoPresent` (no damage/occluded, nothing
             // actually reached the backend): that branch's pending input
             // epochs stay buffered on the clock for whichever later pump
             // does submit, per `FrameClock::record_frame`'s own doc.
             let submit_at = producer.clock().now();
-            match render_result {
-                Ok(did_present) => {
-                    presented = did_present;
-                    if did_present {
-                        producer.record_frame_rendered();
-                        Self::record_submit_telemetry(
-                            producer,
-                            submit_at,
-                            PresentOutcome::Presented,
-                            EpochDisposition::Drain,
-                        );
-                        tracing::trace!(
-                            frame = scene.frame_number(),
-                            total = producer.frames_rendered(),
-                            "Frame rendered successfully"
-                        );
-                    } else {
-                        tracing::trace!(
-                            frame = scene.frame_number(),
-                            "Frame skipped: no damage or surface occluded (no present)"
-                        );
-                    }
+            match render_verdict {
+                SubmitVerdict::Presented => {
+                    presented = true;
+                    producer.record_frame_rendered();
+                    Self::record_submit_telemetry(
+                        producer,
+                        submit_at,
+                        PresentOutcome::Presented,
+                        EpochDisposition::Drain,
+                    );
+                    tracing::trace!(
+                        frame = frame_number,
+                        total = producer.frames_rendered(),
+                        "Frame rendered successfully"
+                    );
                 }
-                Err(EngineError::SurfaceLost) => {
+                SubmitVerdict::NoPresent => {
+                    tracing::trace!(
+                        frame = frame_number,
+                        "Frame skipped: no damage or surface occluded (no present)"
+                    );
+                }
+                SubmitVerdict::SurfaceStale => {
                     producer.record_frame_dropped();
                     // `Retain`, not `Drain`: this arm arms a retry
                     // (`retry_needed = true` below) via `wake_frame()`, and
@@ -2746,13 +2788,34 @@ impl UiRealm {
                     retry_needed = true;
                     // See `retry_needs_repaint`'s own binding above for why
                     // this arm (a genuine submit failure, not a pipeline
-                    // error) is one of the three that also re-dirties
+                    // error) is one of the arms that also re-dirties
                     // `producer`'s pipeline via
                     // `mark_needs_full_repaint_for` below.
+                    //
+                    // Covers a lost surface, a validation failure, and (on
+                    // the raster-lane path) a stale surface-generation
+                    // stamp — the lane has already restamped itself from
+                    // the mailbox's required generation, so the retry armed
+                    // here submits against the reconfigured surface. NOTE:
+                    // the wgpu backend does NOT yet reconfigure the surface
+                    // before a validation-failure retry's own acquire
+                    // attempt (`Renderer::acquire_surface_texture`'s
+                    // `Validation` arm gaining reconfigure-and-retry-once
+                    // ships separately, issue #626) — until it lands, that
+                    // flavor of armed retry re-attempts the identical
+                    // acquire and may keep failing, at the runner's
+                    // no-present throttle (~62 Hz), indefinitely; arming it
+                    // anyway is still strictly better than a permanently
+                    // dropped frame nothing ever retries. Whether that
+                    // steady state deserves its own backoff (like
+                    // `DeviceRecoveryBackoff` gates device recovery) is a
+                    // real question this arm does not answer.
                     retry_needs_repaint = true;
-                    tracing::debug!("Surface lost; frame dropped — retry armed via wake_frame()");
+                    tracing::debug!(
+                        "Surface stale/lost; frame dropped — retry armed via wake_frame()"
+                    );
                 }
-                Err(EngineError::DeviceLost) => {
+                SubmitVerdict::DeviceLost => {
                     producer.record_frame_dropped();
                     // `Retain`, not `Drain`: this arm now arms a retry
                     // (`retry_needed = true` below), and the eventual real
@@ -2787,58 +2850,7 @@ impl UiRealm {
                          attempted by the renderer owner"
                     );
                 }
-                Err(EngineError::SurfaceValidation) => {
-                    producer.record_frame_dropped();
-                    // `Retain`, not `Drain`: this arm now arms a retry, and
-                    // the eventual real submit that retry produces must
-                    // still find the epochs that arrived before this
-                    // failure — see `record_submit_telemetry`'s own doc.
-                    Self::record_submit_telemetry(
-                        producer,
-                        submit_at,
-                        PresentOutcome::Errored,
-                        EpochDisposition::Retain,
-                    );
-                    // Retry armed for the same reason as `DeviceLost`
-                    // above. NOTE: as of this change the wgpu backend does
-                    // NOT yet reconfigure the surface before the retry's
-                    // own acquire attempt — `Renderer::acquire_surface_
-                    // texture`'s `Validation` arm gaining its own
-                    // reconfigure-and-retry-once (with its own test) ships
-                    // separately. Until it lands, an armed retry here
-                    // re-attempts the identical acquire and may keep
-                    // failing; arming it anyway is still strictly better
-                    // than the alternative (a permanently dropped frame
-                    // with nothing ever retrying it), and gives a
-                    // transient validation error the chance to clear on a
-                    // later wake.
-                    //
-                    // Updated by issue #637: this NOTE was written when the
-                    // armed retry silently parked after one no-op frame (see
-                    // that issue) — "may keep failing" understated the old
-                    // behavior, since a parked retry could not keep doing
-                    // anything past its first no-op. Now that the retry
-                    // actually re-submits (`retry_needs_repaint` below), a
-                    // PERMANENTLY misconfigured surface genuinely repeats
-                    // this failure indefinitely, at `NO_PRESENT_FALLBACK_
-                    // PACE`'s ~62 Hz throttle (`runner.rs`) rather than a
-                    // busy spin — a real, continuous full-tree paint cost
-                    // that did not exist before this fix. Whether that
-                    // steady state should sit behind its own backoff (like
-                    // `DeviceRecoveryBackoff` already gates the pre-frame
-                    // device-recovery path) is a real question this change
-                    // does not answer — a working retry that costs CPU
-                    // indefinitely on a permanently broken surface is still
-                    // strictly better than one that silently gives up, but
-                    // is not obviously the final shape either.
-                    retry_needed = true;
-                    retry_needs_repaint = true;
-                    tracing::error!(
-                        "Surface validation error — surface misconfig; retry armed for \
-                         the next wake"
-                    );
-                }
-                Err(e) => {
+                SubmitVerdict::Failed => {
                     producer.record_frame_dropped();
                     Self::record_submit_telemetry(
                         producer,
@@ -2846,7 +2858,10 @@ impl UiRealm {
                         PresentOutcome::Errored,
                         EpochDisposition::Drain,
                     );
-                    tracing::error!(error = ?e, "Render error (non-recoverable this frame)");
+                    // The sink already logged the backend-specific error at
+                    // classification time; this records the transaction-
+                    // level consequence.
+                    tracing::error!("Render error (non-recoverable this frame)");
                 }
             }
         }
@@ -2861,8 +2876,8 @@ impl UiRealm {
             // `mark_rendered()` clears the flag having never reached
             // `render_scene`: one no-op frame, then the retry silently parks.
             //
-            // `retry_needs_repaint` (set only by the three submit-failure
-            // arms above, never by a pipeline `Errored` outcome — see that
+            // `retry_needs_repaint` (set only by the submit-failure arms
+            // above, never by a pipeline `Errored` outcome — see that
             // binding's own comment) gates
             // [`Self::mark_needs_full_repaint_for`], the same fix #630
             // already established for the pre-frame device-recovery-success

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -33,9 +33,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 use flui_animation::Vsync;
-use flui_engine::RasterBackend;
 #[cfg(test)]
 use flui_engine::EngineError;
+use flui_engine::RasterBackend;
 use flui_foundation::{PresentationId, RealmId};
 use flui_interaction::{FocusManager, GestureBinding, InteractionLane};
 use flui_layer::Scene;
@@ -554,18 +554,17 @@ impl std::fmt::Debug for UiRealm {
 /// Moved here from the retired `AppBinding`.
 enum FramePaintOutcome {
     /// A fresh layer tree was painted and turned into a `Scene`. Holds
-    /// `Scene` by value, not `Arc<Scene>`: the sole reader
-    /// (`render_frame_entered`, immediately below) borrows it and both are
-    /// dropped in the same call stack — nothing shares this value or
-    /// crosses a thread with it, so an `Arc` bought nothing here. `Scene`
-    /// is not `Sync` (`CompositionCallback` is `FnOnce + Send`, never
-    /// `Sync`), which is why wrapping it in `Arc` used to need a
+    /// `Scene` by value, not `Arc<Scene>`: the sole reader (the frame
+    /// transaction immediately below) MOVES it into the submit sink —
+    /// on the raster-lane path it crosses the raster boundary as an owned
+    /// `SceneSnapshot` (that type's own "never `Arc<Scene>`" contract in
+    /// `scene_snapshot.rs`), on the direct path it is borrowed internally
+    /// and dropped when the render returns. Nothing shares this value, so
+    /// an `Arc` bought nothing here. `Scene` is not `Sync`
+    /// (`CompositionCallback` is `FnOnce + Send`, never `Sync`), which is
+    /// why wrapping it in `Arc` used to need a
     /// `#[expect(clippy::arc_with_non_send_sync)]` at the construction
-    /// site below — removed along with the `Arc`. (`SceneSnapshot`'s own
-    /// "never `Arc<Scene>`" contract in `scene_snapshot.rs` is a related
-    /// but separate rule for the raster-mailbox seam; `SceneSnapshot` is
-    /// not on this call path at all — production has no consumer of it
-    /// yet.)
+    /// site below — removed along with the `Arc`.
     Painted(Scene),
     /// Nothing was dirty this frame; no new content to composite.
     Idle,
@@ -580,13 +579,16 @@ enum FramePaintOutcome {
 /// records, or merely reads them without consuming them.
 ///
 /// `Retain` exists for exactly one shape: a submit failure whose own caller
-/// has already armed a retry. **Three** arms in
-/// [`UiRealm::render_frame_entered`] are that shape — `SurfaceLost`,
-/// `DeviceLost` and `SurfaceValidation`. The latter two joined when device
-/// loss gained a retry at all; before that they drained, and this sentence
-/// named only `SurfaceLost`. Each is pinned by its own
+/// has already armed a retry. **Two** verdict arms in the frame transaction
+/// behind [`UiRealm::render_frame_entered`] are that shape —
+/// `SurfaceStale` (covering a lost surface, a validation failure, and a
+/// stale surface-generation stamp, which used to be two separate
+/// `SurfaceLost`/`SurfaceValidation` arms) and `DeviceLost`. `DeviceLost`
+/// and the validation flavor joined when device loss gained a retry at all;
+/// before that they drained, and this sentence named only `SurfaceLost`.
+/// Each underlying failure flavor is pinned by its own
 /// `*_retry_preserves_the_original_input_epoch_for_the_presented_frame`
-/// test, so flipping any of the three back to `Drain` turns one red — the
+/// test, so flipping either arm back to `Drain` turns one red — the
 /// invariant used to be documentation alone. Draining on such an arm
 /// leaves the
 /// eventual retry's own real submit with nothing pending to attribute to

--- a/crates/flui-app/tests/runner_frame_ordering.rs
+++ b/crates/flui-app/tests/runner_frame_ordering.rs
@@ -191,3 +191,53 @@ fn every_pump_async_arm_calls_finish_then_drive_async_tasks() {
          the app is backgrounded"
     );
 }
+
+/// The native (desktop/Android) production frame paths must drive the
+/// raster mailbox — every frame crossing to the backend as an owned,
+/// stamped `SceneSnapshot` through `RasterLane` (ADR-0045's inline lane) —
+/// never the pre-mailbox direct backend call. Only the web runner still
+/// takes the direct entry point, for a stated reason (its renderer arrives
+/// asynchronously and recovers across an `.await`, a shape the lane does
+/// not yet accommodate — see `FrameSink`'s own doc in `raster_lane.rs`).
+///
+/// Red-check: revert either native bootstrap to `Arc<Mutex<Renderer>>` +
+/// `render_frame_entered` and the corresponding count here breaks.
+#[test]
+fn native_frame_sites_drive_the_raster_mailbox_not_the_direct_backend() {
+    const RUNNER: &str = include_str!("../src/app/runner.rs");
+    let code_lines = production_lines(RUNNER);
+
+    let lane_constructions = code_lines
+        .iter()
+        .filter(|l| l.contains("RasterLane::new("))
+        .count();
+    assert_eq!(
+        lane_constructions, 2,
+        "expected exactly two PRODUCTION `RasterLane::new(` sites (the desktop and Android \
+         bootstraps each wrap their renderer in the raster mailbox); found \
+         {lane_constructions}"
+    );
+
+    let direct_entry_sites = code_lines
+        .iter()
+        .filter(|l| l.contains(".render_frame_entered("))
+        .count();
+    assert_eq!(
+        direct_entry_sites, 1,
+        "expected exactly one PRODUCTION `.render_frame_entered(` site (the web runner's \
+         direct-backend path, the only one with a stated reason to bypass the mailbox); \
+         found {direct_entry_sites} — a second site means a native path regressed to the \
+         pre-mailbox direct call"
+    );
+
+    let recovery_sites = code_lines
+        .iter()
+        .filter(|l| l.contains("render_frame_with_device_recovery("))
+        .count();
+    assert_eq!(
+        recovery_sites, 2,
+        "expected exactly two PRODUCTION `render_frame_with_device_recovery(` call sites \
+         (desktop and Android, each handing their raster lane to the recovery wrapper); \
+         found {recovery_sites}"
+    );
+}

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -962,8 +962,8 @@ by a threaded protocol harness so the protocol is not vacuously green under \
 the synchronous baseline. The latest frame completion is additionally \
 published through the reliable coalesced `SurfaceState` slot with the \
 backend's actual presented bit. This establishes the non-lossy input the \
-future threaded pacing predicate will consume; the shipping path still \
-bypasses `RasterOwner`, as the adjacent partial contract states.\
+future threaded pacing predicate will consume; the native shipping runners \
+now drive this seam inline, as the adjacent contract states.\
 """
 state = "implemented"
 domain = "raster"
@@ -981,16 +981,29 @@ evidence = [
 key = "raster-owner-in-shipping-path"
 statement = """
 The shipping runners must drive frames through the raster-owner mailbox seam \
-with the raster owner as sole `Renderer` owner. Today the desktop/Android \
-runners call `Renderer::render_scene` directly and the web runner shares an \
-`Arc<Mutex<Option<Renderer>>>`; `RasterOwner` has zero production consumers.\
+with the raster owner as sole `Renderer` owner. The desktop and Android \
+runners now do: `flui_app`'s `RasterLane` wraps `RasterOwner<Renderer>` as \
+the renderer's sole owner, every production frame crosses as an owned, \
+stamped `SceneSnapshot` through `RasterHandle::submit` + an inline pump, the \
+platform resize path mints `SurfaceGeneration` through the mailbox's one \
+counter, and layout reads the platform-authoritative surface-size cell \
+instead of the backend. Still partial: the web runner keeps the direct sink \
+(its renderer arrives asynchronously and recovers across an `.await`, a \
+shape the lane does not yet accommodate — stated in `FrameSink`'s doc), the \
+lane is pumped inline on the owner thread (no produce/present overlap; the \
+dedicated raster thread is ADR-0045's remaining ladder), and `RasterOptions` \
+still governs nothing.\
 """
 state = "partial"
 domain = "raster"
 owner_issue = 559
-mechanical = false
+mechanical = true
+mechanism = "source-text pin: runner_frame_ordering's native-sites-drive-the-mailbox count"
 evidence = [
-    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "Arc<Mutex<Option<Renderer>>>" },
+    { kind = "symbol", file = "crates/flui-app/src/app/raster_lane.rs", contains = "pub(crate) struct RasterLane" },
+    { kind = "test", file = "crates/flui-app/tests/runner_frame_ordering.rs", contains = "fn native_frame_sites_drive_the_raster_mailbox_not_the_direct_backend" },
+    { kind = "test", file = "crates/flui-app/src/app/raster_lane.rs", contains = "fn a_presented_frame_classifies_presented_and_renders_through_the_mailbox" },
+    { kind = "test", file = "crates/flui-app/src/app/raster_lane.rs", contains = "fn the_resize_hook_mints_forward_and_the_next_frame_is_accepted" },
 ]
 
 [[contract]]


### PR DESCRIPTION
# The native frame paths adopt the raster mailbox — ADR-0045's inline lane goes live

Part of #559 (issue tracked in ROADMAP/#566's Runtime.1 tracker; **recommend reopening** — the GitHub close on 2026-08-11 landed right after ladder slice 5 of 14, while the shipping path still bypassed `RasterOwner` entirely and #566 still lists #559 unchecked. This PR is the next slice: the first one that changes anything for a running application).

## What this does

Until now, every protocol property `RasterOwner` proves — latest-frame-wins, stale-generation rejection, the reliable completion slot, typed acks — had **zero production reach**: the desktop/Android runners called `Renderer::render_scene` directly through an `Arc<Mutex<Renderer>>`. This PR kills that bypass on both native paths:

- **`flui_app::app::raster_lane::RasterLane<B>`** (new) wraps `RasterOwner<B>` pumped **inline on the owner thread** (`RasterMode::Inline`, ADR-0045's first-class mode — the one wasm forces and macOS is pinned to by #653). The lane's owner is the renderer's **sole owner**; the old `Arc<Mutex<Renderer>>` sharing is gone.
- **Every production frame crosses the raster boundary as an owned, stamped `SceneSnapshot`** (`FrameStamp`: address + epoch + `SurfaceGeneration` + `GpuResourceGeneration`), submitted through `RasterHandle::submit` and rendered by `RasterOwner::pump`. Threading the lane later changes *who calls pump*, not *what a frame is*.
- **The platform resize path mints `SurfaceGeneration` through the mailbox's one counter** (ADR-0045 decision 4), generation-forward with no handshake: the resize hook stamps the minted value into the next frame before the pump has even applied the reconfigure.
- **Layout reads the platform-authoritative surface-size cell**, not the backend (`renderer.size()` is no longer a layout input on the lane path) — the "one fact, one place" repair ADR-0045 decision 1 names as mandatory under the split rule.
- **Device-loss recovery re-mints on surface recreation** (decision 4's recovery mint site), at the platform's latest announced size — never the backend's stale readback (pinned by a test where a resize arrives while the device is down).
- **One classification tail, two sinks.** `UiRealm`'s frame transaction now submits through a `FrameSink` seam with two production implementations: the lane (desktop/Android) and the direct sink (web). Both produce the same `SubmitVerdict`, so the delicate retry/telemetry arms (Retain-not-Drain on retryable failures, `retry_needs_repaint`, the wake-ordering rules) are shared code that cannot drift between paths.

## Topology decision — no new ADR

ADR-0045 is the raster topology record and already decides everything this slice implements (the split rule, the single generation counter, the inline lane as a first-class mode, macOS pinned inline per #653). It remains **Proposed** by its own terms until the ladder's threaded slice carries its ADR-0029 re-measurement; nothing here contradicts or supersedes it, so no ADR-0050 was minted.

The raster lane is **not** a Service on the #785/#791 executor seam: ADR-0045's own ladder makes the raster thread a dedicated, deadline-character thread driving `run_until_shutdown` — a generic pool is the wrong home for it, and inline (this slice) it is not a thread at all.

## Acceptance criteria of #559 — met / deferred

- ✅ **Stale surface/resource generations cannot publish** — now live in production, not just the harness: every native frame is stamp-checked before render (`a_zero_generation_stamp_is_rejected_not_rendered`, `a_mid_render_surface_loss_restamps_and_the_retry_is_accepted`).
- ✅ (partial) **Serial/synchronous raster remains a diagnostic backend** — the inline lane *is* the serial mode, first-class and shipping.
- ✅ **Threaded tests use barriers/channels, never sleeps** — unchanged from #674/#767; no sleeps added.
- ⬜ **UI and raster overlap measurably** — deferred: requires the ladder's remaining slices (baseline pacing measurement on this now-serial lane → wake relay → spawn the thread; the ladder's ordering constraint says the baseline must be taken *before* threading so the ADR-0029 amendment has a comparand).
- ⬜ **Multi-surface resize/suspend/close/device-loss race-freedom** — single-surface resize/close/device-loss are exercised (lane tests + live smoke); multi-surface is deferred with the rest of #555's known gap (secondary windows render no frames yet).
- ⬜ **p50/p95/p99 frame and input-to-present latency reported** — existing `frame_histogram` telemetry continues to work (present-inclusive `submit_at` semantics preserved under the lane — the inline pump blocks in `submit` exactly where `render_scene` used to); the dedicated percentile *reporting* surface is deferred.
- ⬜ **Shared device/queue under AppRuntime (`GpuServices`) wired to the windowed renderer** — deferred; the windowed `Renderer` is not `GpuServices`-backed yet, so both sides of the resource-generation axis sit at `ZERO` (the typed "no shared services bound" state, stated in code, not a silent bypass).
- ⬜ **`PipelineDepth` replacing `max_frames_in_flight`** — deferred; `RasterOptions` still governs nothing (the registry entry says so).
- ⬜ **Web runner adoption** — deferred with a stated reason (its renderer arrives asynchronously and recovers across an `.await`, a shape the lane does not yet accommodate); pinned by the mechanical guard so it cannot silently grow more direct-path callers.

## Born-red evidence

Each load-bearing line was sabotaged via edit and the pinning test confirmed red, then reverted:

1. Restamp-on-`SurfaceOutdated` removed → `a_mid_render_surface_loss_restamps_and_the_retry_is_accepted` fails.
2. Presented bit inferred from the pump outcome name instead of the reliable slot → `a_no_present_completion_classifies_no_present` fails.
3. Resize hook minting without adopting the generation → `the_resize_hook_mints_forward_and_the_next_frame_is_accepted` fails.

Plus a mechanical source-text guard (`native_frame_sites_drive_the_raster_mailbox_not_the_direct_backend`) that goes red if either native bootstrap regresses to the direct path, in the same style as the existing frame-ordering guards. The device-recovery contract tests were migrated to drive lanes (production shape), not kept on the retired bare-backend shape.

## Honest notes

- **Android is type-checked nowhere**: this environment lacks the NDK cross-compiler and CI has no flui-app Android job (pre-existing gap — cross-typecheck covers flui-platform only). The Android bootstrap edits mirror the desktop shape line-for-line and the desktop shape compiles and passes, but Android compilation is unverified.
- The lane's mailbox-machinery is compiled out on wasm32 (`#[cfg]`) rather than left as dead code there.
- `docs/runtime-contract.toml`'s `raster-owner-in-shipping-path` contract updated deliberately: now `partial` with mechanical evidence, stating exactly what is adopted and what is not.

## Gates

- `just ci` — foreground run, `JUST_CI_EXIT: 0` (fmt, inventory, runtime-conformance, port-check, clippy `-D warnings`, full test suite, doc-tests, strict rustdoc)
- `just live-smoke` — exit 0, all checks green through the adopted mailbox path: launch, mid-drag tracking, drag scroll, wheel scroll, drag-fling (24 presented frames), occlusion gating (zero GPU submissions while covered), unhide resume, clean close
- `just live-smoke-wayland` — SKIP, stated by the recipe itself: `weston` not on this machine's PATH; CI installs weston so it cannot silently skip there
- wasm32 `cargo check -p flui-app` — clean (lane machinery cfg'd out; direct sink remains the web path)
- Merged `origin/main` (incl. PR #791's service lifecycles) and re-ran the full gate after the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ta5tVUhEAFp17jeadPoxM
