### PR TITLE
fix(types): evaluate arcs in Path::contains — circular surfaces hit-test as the disc, not the inscribed diamond

### DIFF
--- a/crates/flui-material/tests/dialog.rs
+++ b/crates/flui-material/tests/dialog.rs
@@ -17,6 +17,12 @@ use flui_types::styling::BorderRadius;
 use flui_view::ViewExt;
 use flui_widgets::{ColoredBox, GestureDetector, SizedBox, Text};
 
+/// The corner probe both radius tests share, on the diagonal from the
+/// Material's top-left corner. See
+/// [`default_corner_radius_reaches_the_mounted_material`] for how it is
+/// derived from `p >= r * (1 - 1/sqrt(2))`.
+const PROBE: f32 = 7.6;
+
 /// `_DialogDefaultsM3`'s formatted `Debug` string for a resolved
 /// [`Color`](flui_types::Color) — the same helper `tests/card.rs`/
 /// `tests/elevated_button.rs` use for `RenderPhysicalShape`'s `"color"`
@@ -150,16 +156,17 @@ fn default_inset_padding_offsets_the_aligned_content_by_40x24() {
 /// `3.44.0`), proven against the REAL mounted `RenderPhysicalShape` clip via
 /// hit-testing — not `MaterialShape::to_rrect` computed in isolation.
 ///
-/// The probe point `(13, 13)` is chosen empirically (measured directly
-/// against `MaterialShape::to_path`/`Path::contains`, not derived from an
-/// idealized inscribed-circle formula — the corner's actual point-in-path
-/// test lands on the `x + y >= radius` side of a straight diagonal, not a
-/// true arc, at the tolerance these probes sit at): excluded at the 28dp
-/// default (`13 + 13 = 26 < 28`), included once the radius shrinks to 24dp
-/// (companion test
-/// `an_overridden_24dp_corner_radius_includes_the_same_probe_point` below,
-/// `13 + 13 = 26 >= 24`) — i.e. this probe is chosen specifically to flip if
-/// the default drifts from 28.0 to 24.0.
+/// The probe point `(7.6, 7.6)` is derived from the corner's real geometry
+/// rather than measured off whatever the containment test happened to do. A
+/// corner of radius `r` centres its arc at `(r, r)`, so a point `(p, p)` on
+/// the diagonal is inside exactly when `(r - p) * sqrt(2) <= r`, i.e. when
+/// `p >= r * (1 - 1/sqrt(2))` — `8.20` at 28dp and `7.03` at 24dp. Any probe
+/// strictly between those two thresholds is excluded at the default and
+/// included at the override (companion test
+/// `an_overridden_24dp_corner_radius_includes_the_same_probe_point` below),
+/// so it flips if the default ever drifts from 28.0 to 24.0. `7.6` sits mid
+/// band, ~0.6px clear on each side — comfortably more than the sub-pixel
+/// error of flattening the arc into chords.
 #[test]
 fn default_corner_radius_reaches_the_mounted_material() {
     let taps = Arc::new(AtomicUsize::new(0));
@@ -183,15 +190,15 @@ fn default_corner_radius_reaches_the_mounted_material() {
         .expect("Dialog must compose a Material surface");
     let origin = laid.absolute_offset(material);
 
-    laid.dispatch_pointer_down(origin.dx.get() + 13.0, origin.dy.get() + 13.0);
-    laid.dispatch_pointer_up(origin.dx.get() + 13.0, origin.dy.get() + 13.0);
+    laid.dispatch_pointer_down(origin.dx.get() + PROBE, origin.dy.get() + PROBE);
+    laid.dispatch_pointer_up(origin.dx.get() + PROBE, origin.dy.get() + PROBE);
 
     assert_eq!(
         taps.load(Ordering::SeqCst),
         0,
-        "_DialogDefaultsM3's 28dp corner radius must EXCLUDE a point 13px from the corner \
-         along the diagonal — the mounted Material's actual registered clip, not merely \
-         MaterialShape's geometry computed in isolation"
+        "_DialogDefaultsM3's 28dp corner radius must EXCLUDE a point {PROBE}px from the \
+         corner along the diagonal — the mounted Material's actual registered clip, not \
+         merely MaterialShape's geometry computed in isolation"
     );
 }
 
@@ -225,8 +232,8 @@ fn an_overridden_24dp_corner_radius_includes_the_same_probe_point() {
         .expect("Dialog must compose a Material surface");
     let origin = laid.absolute_offset(material);
 
-    laid.dispatch_pointer_down(origin.dx.get() + 13.0, origin.dy.get() + 13.0);
-    laid.dispatch_pointer_up(origin.dx.get() + 13.0, origin.dy.get() + 13.0);
+    laid.dispatch_pointer_down(origin.dx.get() + PROBE, origin.dy.get() + PROBE);
+    laid.dispatch_pointer_up(origin.dx.get() + PROBE, origin.dy.get() + PROBE);
 
     assert_eq!(
         taps.load(Ordering::SeqCst),

--- a/crates/flui-types/src/painting/path.rs
+++ b/crates/flui-types/src/painting/path.rs
@@ -607,12 +607,33 @@ impl Path {
                     subpath_open = true;
                 }
                 PathCommand::AddRect(rect) => {
+                    // A standalone shape ends whatever contour was open, so a
+                    // following arc starts fresh instead of chording back
+                    // across the shape. The tessellator does exactly this
+                    // (`builder.end(false)` then `has_begun = false`), and
+                    // containment has to agree with it or the hittable region
+                    // grows a wedge nothing paints.
+                    Self::end_open_contour_even_odd(
+                        point,
+                        &mut crossings,
+                        &mut current_pos,
+                        &mut subpath_start,
+                        &mut subpath_open,
+                    );
                     // Simple rectangle test
                     if rect.contains(point) {
                         crossings += 1;
                     }
                 }
                 PathCommand::AddCircle(center, radius) => {
+                    // Standalone shape — see the `AddRect` arm.
+                    Self::end_open_contour_even_odd(
+                        point,
+                        &mut crossings,
+                        &mut current_pos,
+                        &mut subpath_start,
+                        &mut subpath_open,
+                    );
                     // Simple circle test
                     let dx = point.x - center.x;
                     let dy = point.y - center.y;
@@ -621,6 +642,14 @@ impl Path {
                     }
                 }
                 PathCommand::AddOval(rect) => {
+                    // Standalone shape — see the `AddRect` arm.
+                    Self::end_open_contour_even_odd(
+                        point,
+                        &mut crossings,
+                        &mut current_pos,
+                        &mut subpath_start,
+                        &mut subpath_open,
+                    );
                     // Ellipse test
                     let cx = (rect.left() + rect.right()) * 0.5;
                     let cy = (rect.top() + rect.bottom()) * 0.5;
@@ -703,11 +732,29 @@ impl Path {
                     subpath_open = true;
                 }
                 PathCommand::AddRect(rect) => {
+                    // Standalone shape ends the open contour — see the
+                    // even-odd walker's `AddRect` arm.
+                    Self::end_open_contour_non_zero(
+                        point,
+                        &mut winding,
+                        &mut current_pos,
+                        &mut subpath_start,
+                        &mut subpath_open,
+                    );
                     if rect.contains(point) {
                         winding += 1;
                     }
                 }
                 PathCommand::AddCircle(center, radius) => {
+                    // Standalone shape ends the open contour — see the
+                    // even-odd walker's `AddRect` arm.
+                    Self::end_open_contour_non_zero(
+                        point,
+                        &mut winding,
+                        &mut current_pos,
+                        &mut subpath_start,
+                        &mut subpath_open,
+                    );
                     let dx = point.x - center.x;
                     let dy = point.y - center.y;
                     if dx.0 * dx.0 + dy.0 * dy.0 <= radius * radius {
@@ -715,6 +762,15 @@ impl Path {
                     }
                 }
                 PathCommand::AddOval(rect) => {
+                    // Standalone shape ends the open contour — see the
+                    // even-odd walker's `AddRect` arm.
+                    Self::end_open_contour_non_zero(
+                        point,
+                        &mut winding,
+                        &mut current_pos,
+                        &mut subpath_start,
+                        &mut subpath_open,
+                    );
                     let cx = (rect.left() + rect.right()) * 0.5;
                     let cy = (rect.top() + rect.bottom()) * 0.5;
                     let rx = rect.width() * 0.5;
@@ -786,6 +842,69 @@ impl Path {
         (p2.x - p1.x).get() * (point.y - p1.y).get() - (point.x - p1.x).get() * (p2.y - p1.y).get()
     }
 
+    /// Ends an open contour before a standalone shape, for the even-odd
+    /// walker.
+    ///
+    /// Fill semantics close an open contour implicitly, so the closing edge
+    /// is counted here rather than being deferred to the walk's tail — the
+    /// tail can no longer see it once the position resets. Resetting to the
+    /// origin restores the state the walk starts in, which is what a command
+    /// arriving with no current position already assumes.
+    #[inline]
+    fn end_open_contour_even_odd(
+        point: Point<Pixels>,
+        crossings: &mut usize,
+        current_pos: &mut Point<Pixels>,
+        subpath_start: &mut Point<Pixels>,
+        subpath_open: &mut bool,
+    ) {
+        if !*subpath_open {
+            return;
+        }
+        if Self::ray_intersects_segment(point, *current_pos, *subpath_start) {
+            *crossings += 1;
+        }
+        *current_pos = Point::new(px(0.0), px(0.0));
+        *subpath_start = *current_pos;
+        *subpath_open = false;
+    }
+
+    /// Non-zero counterpart of [`Self::end_open_contour_even_odd`].
+    #[inline]
+    fn end_open_contour_non_zero(
+        point: Point<Pixels>,
+        winding: &mut i32,
+        current_pos: &mut Point<Pixels>,
+        subpath_start: &mut Point<Pixels>,
+        subpath_open: &mut bool,
+    ) {
+        if !*subpath_open {
+            return;
+        }
+        *winding += Self::segment_winding(point, *current_pos, *subpath_start);
+        *current_pos = Point::new(px(0.0), px(0.0));
+        *subpath_start = *current_pos;
+        *subpath_open = false;
+    }
+
+    /// Largest gap, in local units, allowed between an arc and the chords
+    /// containment flattens it into.
+    ///
+    /// Matched to the renderer's own fill-flattening bound
+    /// (`DEVICE_FILL_TOLERANCE`, 0.1 device pixels in
+    /// `flui-engine`'s `wgpu::tessellator`) so the hittable region tracks
+    /// the painted one. The renderer pre-divides that bound by the paint
+    /// transform's scale; a local-space containment test cannot see the
+    /// transform, so this is the un-scaled figure — which means containment
+    /// is at least as fine as the raster wherever the path is not scaled
+    /// down.
+    const ARC_FLATTENING_TOLERANCE: f32 = 0.1;
+
+    /// Ceiling on chords per arc, so a pathological radius costs a bounded
+    /// walk instead of an unbounded one. Generous enough that the tolerance
+    /// above is met exactly for a full turn up to a radius near 85,000.
+    const MAX_ARC_CHORDS: usize = 2048;
+
     /// Samples the ellipse inscribed in `rect` at `angle` radians.
     ///
     /// Deliberately the same parametrization the tessellator rasterizes an
@@ -802,21 +921,47 @@ impl Path {
         Point::new(cx + rx * angle.cos(), cy + ry * angle.sin())
     }
 
-    /// How many chords to flatten an arc of `sweep` radians into.
+    /// How many chords to flatten an arc into, chosen from the arc's own
+    /// radius so the error stays bounded in *distance* rather than in angle.
     ///
-    /// One chord per 11.25° keeps a quarter-turn at eight chords (a full
-    /// turn at 32), so the worst-case gap between the chord and the true
-    /// curve is `r · (1 - cos(5.625°))` ≈ `r / 200` — well under a pixel
-    /// for the button-sized radii this gate actually decides. Clamped so a
-    /// degenerate or absurd sweep still costs a bounded walk.
+    /// A fixed angular step would under-approximate in proportion to the
+    /// radius — at one chord per 11.25° the gap is `r · (1 - cos(5.625°))` ≈
+    /// `r / 200`, which is a fifth of a pixel on a button and fifty pixels
+    /// on a 10,000-unit circle. `Path` is a general primitive, so the step
+    /// is derived from [`Self::ARC_FLATTENING_TOLERANCE`] instead: the sagitta of
+    /// a chord spanning `theta` on a circle of radius `r` is
+    /// `r · (1 - cos(theta / 2))`, so the widest chord within tolerance is
+    /// `theta = 2 · acos(1 - tolerance / r)`. Ellipses use the larger
+    /// semi-axis, which is conservative.
+    ///
+    /// Degenerate input (a zero or non-finite radius or sweep) costs one
+    /// chord; a radius large enough that `1 - tolerance / r` rounds to `1`
+    /// in `f32` saturates at [`Self::MAX_ARC_CHORDS`] rather than dividing by an
+    /// angle of zero.
     #[inline]
-    fn arc_chord_count(sweep: f32) -> usize {
-        const RADIANS_PER_CHORD: f32 = core::f32::consts::PI / 16.0;
-        let wanted = (sweep.abs() / RADIANS_PER_CHORD).ceil();
+    fn arc_chord_count(rect: Rect<Pixels>, sweep: f32) -> usize {
+        let radius = (rect.width() * 0.5)
+            .get()
+            .abs()
+            .max((rect.height() * 0.5).get().abs());
+        let sweep = sweep.abs();
+        if !radius.is_finite() || radius <= 0.0 || !sweep.is_finite() || sweep <= 0.0 {
+            return 1;
+        }
+
+        let cos_half_chord = (1.0 - Self::ARC_FLATTENING_TOLERANCE / radius).clamp(-1.0, 1.0);
+        let chord_angle = 2.0 * cos_half_chord.acos();
+        if !chord_angle.is_finite() || chord_angle <= f32::EPSILON {
+            return Self::MAX_ARC_CHORDS;
+        }
+
+        let wanted = (sweep / chord_angle).ceil();
         if wanted.is_finite() {
-            (wanted as usize).clamp(1, 64)
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let wanted = wanted as usize;
+            wanted.clamp(1, Self::MAX_ARC_CHORDS)
         } else {
-            1
+            Self::MAX_ARC_CHORDS
         }
     }
 
@@ -830,7 +975,7 @@ impl Path {
         start_angle: f32,
         sweep_angle: f32,
     ) -> usize {
-        let chords = Self::arc_chord_count(sweep_angle);
+        let chords = Self::arc_chord_count(rect, sweep_angle);
         let mut crossings = 0;
         let mut from = Self::eval_arc(rect, start_angle);
 
@@ -856,7 +1001,7 @@ impl Path {
         start_angle: f32,
         sweep_angle: f32,
     ) -> i32 {
-        let chords = Self::arc_chord_count(sweep_angle);
+        let chords = Self::arc_chord_count(rect, sweep_angle);
         let mut winding = 0;
         let mut from = Self::eval_arc(rect, start_angle);
 
@@ -1215,6 +1360,96 @@ mod tests {
             !path.contains(Point::new(px(50.0), px(50.0))),
             "a point back toward the origin is outside — a leading arc must \
              not chord to (0, 0)"
+        );
+    }
+
+    /// A standalone shape ends any open contour, so a following arc starts
+    /// its own instead of chording back across the shape.
+    ///
+    /// The renderer already behaves this way — every `AddRect`/`AddCircle`/
+    /// `AddOval` arm in `flui-engine`'s tessellator ends the builder's
+    /// contour and clears `has_begun`. If containment kept the contour open
+    /// it would chord from the stale pre-shape position to the arc's start,
+    /// and the wedge that chord encloses would hit-test as filled while
+    /// nothing paints it.
+    #[test]
+    fn a_standalone_shape_ends_the_open_contour_before_a_following_arc() {
+        use core::f32::consts::TAU;
+        for fill_type in [PathFillType::NonZero, PathFillType::EvenOdd] {
+            let mut path = Path::new();
+            path.set_fill_type(fill_type);
+            path.move_to(Point::new(px(0.0), px(0.0)));
+            path.line_to(Point::new(px(100.0), px(0.0)));
+            path.add_rect(Rect::from_xywh(px(0.0), px(0.0), px(10.0), px(10.0)));
+            path.add_arc(
+                Rect::from_xywh(px(200.0), px(200.0), px(40.0), px(40.0)),
+                0.0,
+                TAU,
+            );
+            path.close();
+
+            assert!(
+                path.contains(Point::new(px(5.0), px(5.0))),
+                "{fill_type:?}: the standalone rect is still filled"
+            );
+            assert!(
+                path.contains(Point::new(px(220.0), px(220.0))),
+                "{fill_type:?}: the arc's own circle is still filled"
+            );
+            assert!(
+                !path.contains(Point::new(px(150.0), px(100.0))),
+                "{fill_type:?}: the gap between the rect and the circle paints \
+                 nothing, so it must not hit-test as filled"
+            );
+        }
+    }
+
+    /// Flattening error is bounded in distance, not in angle: a large arc
+    /// gets proportionally more chords so containment keeps tracking the
+    /// curve the renderer draws.
+    ///
+    /// A fixed angular step fails here. At one chord per 11.25° the chord
+    /// sags `r * (1 - cos(5.625))` below the arc — a fifth of a pixel at
+    /// `r = 40`, but roughly 48 units at `r = 10_000`, which would reject a
+    /// wide band of pixels that are painted.
+    #[test]
+    fn a_large_arc_is_flattened_to_the_same_distance_tolerance_as_a_small_one() {
+        use core::f32::consts::TAU;
+        const RADIUS: f32 = 10_000.0;
+
+        let mut path = Path::new();
+        path.add_arc(
+            Rect::from_xywh(px(0.0), px(0.0), px(2.0 * RADIUS), px(2.0 * RADIUS)),
+            0.0,
+            TAU,
+        );
+        path.close();
+
+        // Probe midway between two chords, where a flattened polygon cuts
+        // deepest — at a vertex it touches the circle exactly and proves
+        // nothing. 5.625 degrees is the midpoint of the first 11.25-degree
+        // chord, so under a fixed angular step the polygon sits
+        // `RADIUS * (1 - cos(5.625 deg))`, about 48 units, inside the rim
+        // there. A probe 5 units in is painted, comfortably inside the
+        // 0.1-unit tolerance, and comfortably outside that 48.
+        const PROBE_ANGLE: f32 = core::f32::consts::PI / 32.0;
+        let inset = RADIUS - 5.0;
+        let probe = Point::new(
+            px(RADIUS + inset * PROBE_ANGLE.cos()),
+            px(RADIUS + inset * PROBE_ANGLE.sin()),
+        );
+
+        assert!(
+            path.contains(probe),
+            "a point 5 units inside a {RADIUS}-unit circle is painted, so it \
+             must hit-test as filled"
+        );
+        assert!(
+            !path.contains(Point::new(
+                px(RADIUS + (RADIUS + 5.0) * PROBE_ANGLE.cos()),
+                px(RADIUS + (RADIUS + 5.0) * PROBE_ANGLE.sin()),
+            )),
+            "a point 5 units outside the same rim stays outside"
         );
     }
 }

--- a/crates/flui-types/src/painting/path.rs
+++ b/crates/flui-types/src/painting/path.rs
@@ -319,9 +319,10 @@ impl Path {
     /// Uses a ray-casting algorithm for even-odd fill and a winding-number
     /// algorithm for non-zero fill.
     ///
-    /// Note: `AddArc` commands are currently ignored (conservative miss);
-    /// only line/quadratic/cubic segments, rects, circles, and ovals are
-    /// evaluated.
+    /// Arcs are flattened into chords at the same ellipse parametrization
+    /// the tessellator rasterizes them with, so a shape built from corner
+    /// arcs (`from_rrect`, a circular `CircleBorder`) is contained as the
+    /// curve it draws rather than as the polygon through its arc endpoints.
     #[must_use]
     #[inline]
     pub fn contains(&self, point: Point<Pixels>) -> bool {
@@ -556,6 +557,11 @@ impl Path {
         let mut crossings = 0;
         let mut current_pos = Point::new(px(0.0), px(0.0));
         let mut subpath_start = Point::new(px(0.0), px(0.0));
+        // Whether a contour is currently open. Only the arc arms read it:
+        // `add_arc` continues an open contour but starts a fresh one when
+        // nothing is open, and the two cases seed `subpath_start`
+        // differently.
+        let mut subpath_open = false;
 
         for cmd in &self.commands {
             match cmd {
@@ -571,29 +577,34 @@ impl Path {
                     }
                     current_pos = *p;
                     subpath_start = *p;
+                    subpath_open = true;
                 }
                 PathCommand::LineTo(p) => {
                     if Self::ray_intersects_segment(point, current_pos, *p) {
                         crossings += 1;
                     }
                     current_pos = *p;
+                    subpath_open = true;
                 }
                 PathCommand::Close => {
                     if Self::ray_intersects_segment(point, current_pos, subpath_start) {
                         crossings += 1;
                     }
                     current_pos = subpath_start;
+                    subpath_open = false;
                 }
                 PathCommand::QuadraticTo(c, e) => {
                     // Approximate with line segments
                     crossings += Self::count_curve_crossings_quad(point, current_pos, *c, *e);
                     current_pos = *e;
+                    subpath_open = true;
                 }
                 PathCommand::CubicTo(c1, c2, e) => {
                     // Approximate with line segments
                     crossings +=
                         Self::count_curve_crossings_cubic(point, current_pos, *c1, *c2, *e);
                     current_pos = *e;
+                    subpath_open = true;
                 }
                 PathCommand::AddRect(rect) => {
                     // Simple rectangle test
@@ -621,9 +632,21 @@ impl Path {
                         crossings += 1;
                     }
                 }
-                PathCommand::AddArc(..) => {
-                    // TODO: Implement arc containment
-                    // For now, skip arcs (conservative - may miss some points)
+                PathCommand::AddArc(rect, start, sweep) => {
+                    let arc_start = Self::eval_arc(*rect, *start);
+                    if subpath_open {
+                        // An arc appended to an open contour continues it,
+                        // chord-connected — the same shape the tessellator
+                        // draws (see `add_arc`'s divergence note).
+                        if Self::ray_intersects_segment(point, current_pos, arc_start) {
+                            crossings += 1;
+                        }
+                    } else {
+                        subpath_start = arc_start;
+                        subpath_open = true;
+                    }
+                    crossings += Self::count_arc_crossings(point, *rect, *start, *sweep);
+                    current_pos = Self::eval_arc(*rect, *start + *sweep);
                 }
             }
         }
@@ -642,6 +665,11 @@ impl Path {
         let mut winding = 0;
         let mut current_pos = Point::new(px(0.0), px(0.0));
         let mut subpath_start = Point::new(px(0.0), px(0.0));
+        // Whether a contour is currently open. Only the arc arms read it:
+        // `add_arc` continues an open contour but starts a fresh one when
+        // nothing is open, and the two cases seed `subpath_start`
+        // differently.
+        let mut subpath_open = false;
 
         for cmd in &self.commands {
             match cmd {
@@ -652,22 +680,27 @@ impl Path {
                     winding += Self::segment_winding(point, current_pos, subpath_start);
                     current_pos = *p;
                     subpath_start = *p;
+                    subpath_open = true;
                 }
                 PathCommand::LineTo(p) => {
                     winding += Self::segment_winding(point, current_pos, *p);
                     current_pos = *p;
+                    subpath_open = true;
                 }
                 PathCommand::Close => {
                     winding += Self::segment_winding(point, current_pos, subpath_start);
                     current_pos = subpath_start;
+                    subpath_open = false;
                 }
                 PathCommand::QuadraticTo(c, e) => {
                     winding += Self::curve_winding_quad(point, current_pos, *c, *e);
                     current_pos = *e;
+                    subpath_open = true;
                 }
                 PathCommand::CubicTo(c1, c2, e) => {
                     winding += Self::curve_winding_cubic(point, current_pos, *c1, *c2, *e);
                     current_pos = *e;
+                    subpath_open = true;
                 }
                 PathCommand::AddRect(rect) => {
                     if rect.contains(point) {
@@ -692,8 +725,18 @@ impl Path {
                         winding += 1;
                     }
                 }
-                PathCommand::AddArc(..) => {
-                    // TODO: Implement arc winding
+                PathCommand::AddArc(rect, start, sweep) => {
+                    let arc_start = Self::eval_arc(*rect, *start);
+                    if subpath_open {
+                        // See the even-odd arm: an arc continues an open
+                        // contour through a chord, it does not restart one.
+                        winding += Self::segment_winding(point, current_pos, arc_start);
+                    } else {
+                        subpath_start = arc_start;
+                        subpath_open = true;
+                    }
+                    winding += Self::arc_winding(point, *rect, *start, *sweep);
+                    current_pos = Self::eval_arc(*rect, *start + *sweep);
                 }
             }
         }
@@ -741,6 +784,91 @@ impl Path {
     #[inline]
     fn is_left(p1: Point<Pixels>, p2: Point<Pixels>, point: Point<Pixels>) -> f32 {
         (p2.x - p1.x).get() * (point.y - p1.y).get() - (point.x - p1.x).get() * (p2.y - p1.y).get()
+    }
+
+    /// Samples the ellipse inscribed in `rect` at `angle` radians.
+    ///
+    /// Deliberately the same parametrization the tessellator rasterizes an
+    /// arc with (`lyon::geom::Arc` at zero x-rotation: `center + (rx·cosθ,
+    /// ry·sinθ)`), so containment and the drawn pixels agree on where the
+    /// curve is. Angles are y-down, matching the rest of the geometry
+    /// vocabulary.
+    #[inline]
+    fn eval_arc(rect: Rect<Pixels>, angle: f32) -> Point<Pixels> {
+        let cx = (rect.left() + rect.right()) * 0.5;
+        let cy = (rect.top() + rect.bottom()) * 0.5;
+        let rx = rect.width() * 0.5;
+        let ry = rect.height() * 0.5;
+        Point::new(cx + rx * angle.cos(), cy + ry * angle.sin())
+    }
+
+    /// How many chords to flatten an arc of `sweep` radians into.
+    ///
+    /// One chord per 11.25° keeps a quarter-turn at eight chords (a full
+    /// turn at 32), so the worst-case gap between the chord and the true
+    /// curve is `r · (1 - cos(5.625°))` ≈ `r / 200` — well under a pixel
+    /// for the button-sized radii this gate actually decides. Clamped so a
+    /// degenerate or absurd sweep still costs a bounded walk.
+    #[inline]
+    fn arc_chord_count(sweep: f32) -> usize {
+        const RADIANS_PER_CHORD: f32 = core::f32::consts::PI / 16.0;
+        let wanted = (sweep.abs() / RADIANS_PER_CHORD).ceil();
+        if wanted.is_finite() {
+            (wanted as usize).clamp(1, 64)
+        } else {
+            1
+        }
+    }
+
+    /// Count ray crossings for an arc, flattened into chords. The chord from
+    /// the contour's current position to the arc's start is the caller's to
+    /// count — whether one exists depends on if a contour is open.
+    #[inline]
+    fn count_arc_crossings(
+        point: Point<Pixels>,
+        rect: Rect<Pixels>,
+        start_angle: f32,
+        sweep_angle: f32,
+    ) -> usize {
+        let chords = Self::arc_chord_count(sweep_angle);
+        let mut crossings = 0;
+        let mut from = Self::eval_arc(rect, start_angle);
+
+        for i in 1..=chords {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32 / chords as f32;
+            let to = Self::eval_arc(rect, start_angle + sweep_angle * t);
+            if Self::ray_intersects_segment(point, from, to) {
+                crossings += 1;
+            }
+            from = to;
+        }
+
+        crossings
+    }
+
+    /// Winding-number contribution of an arc, flattened into chords — the
+    /// non-zero counterpart of [`Self::count_arc_crossings`].
+    #[inline]
+    fn arc_winding(
+        point: Point<Pixels>,
+        rect: Rect<Pixels>,
+        start_angle: f32,
+        sweep_angle: f32,
+    ) -> i32 {
+        let chords = Self::arc_chord_count(sweep_angle);
+        let mut winding = 0;
+        let mut from = Self::eval_arc(rect, start_angle);
+
+        for i in 1..=chords {
+            #[allow(clippy::cast_precision_loss)]
+            let t = i as f32 / chords as f32;
+            let to = Self::eval_arc(rect, start_angle + sweep_angle * t);
+            winding += Self::segment_winding(point, from, to);
+            from = to;
+        }
+
+        winding
     }
 
     /// Count crossings for quadratic bezier curve (approximated).
@@ -988,5 +1116,105 @@ mod tests {
 
         let path = Path::rectangle(Rect::from_xywh(px(0.0), px(0.0), px(10.0), px(10.0)));
         assert!(path.rrect_hint().is_none());
+    }
+
+    /// The command shape a circular Material surface (`CircleBorder`, and
+    /// `from_rrect` for a fully-rounded box) actually produces: four
+    /// quadrant arcs over the same bounding rect, each preceded by a
+    /// degenerate `LineTo` to the arc's start.
+    fn quadrant_arc_circle(diameter: f32) -> Path {
+        use core::f32::consts::FRAC_PI_2;
+        let rect = Rect::from_xywh(px(0.0), px(0.0), px(diameter), px(diameter));
+        let mid = px(diameter / 2.0);
+        let end = px(diameter);
+
+        let mut path = Path::new();
+        path.move_to(Point::new(mid, px(0.0)));
+        path.line_to(Point::new(mid, px(0.0)));
+        path.add_arc(rect, -FRAC_PI_2, FRAC_PI_2);
+        path.line_to(Point::new(end, mid));
+        path.add_arc(rect, 0.0, FRAC_PI_2);
+        path.line_to(Point::new(mid, end));
+        path.add_arc(rect, FRAC_PI_2, FRAC_PI_2);
+        path.line_to(Point::new(px(0.0), mid));
+        path.add_arc(rect, core::f32::consts::PI, FRAC_PI_2);
+        path.close();
+        path
+    }
+
+    /// A circle assembled from quadrant arcs must contain the whole disc,
+    /// not just the diamond through the arc endpoints.
+    ///
+    /// `(9, 9)` on a 40px circle is the case that matters in practice: it is
+    /// 15.6px from the centre so it is comfortably inside the 20px radius,
+    /// but `|9-20| + |9-20| = 22 > 20` puts it outside the inscribed
+    /// diamond. Skipping the arcs left exactly that diamond — roughly 64% of
+    /// the disc — so the corner of every circular `IconButton` stopped
+    /// hit-testing.
+    #[test]
+    fn a_circle_built_from_quadrant_arcs_contains_its_whole_disc() {
+        for fill_type in [PathFillType::NonZero, PathFillType::EvenOdd] {
+            let mut path = quadrant_arc_circle(40.0);
+            path.set_fill_type(fill_type);
+
+            assert!(
+                path.contains(Point::new(px(9.0), px(9.0))),
+                "{fill_type:?}: (9,9) is 15.6px from the centre of a 20px \
+                 radius, inside the disc but outside the endpoint diamond"
+            );
+            assert!(
+                path.contains(Point::new(px(20.0), px(20.0))),
+                "{fill_type:?}: the centre is inside"
+            );
+            assert!(
+                path.contains(Point::new(px(38.0), px(20.0))),
+                "{fill_type:?}: a point just inside the right extreme"
+            );
+        }
+    }
+
+    /// The flattening must not over-claim either: a corner of the bounding
+    /// box is outside the disc and stays outside.
+    #[test]
+    fn a_circle_built_from_quadrant_arcs_rejects_its_bounding_box_corners() {
+        for fill_type in [PathFillType::NonZero, PathFillType::EvenOdd] {
+            let mut path = quadrant_arc_circle(40.0);
+            path.set_fill_type(fill_type);
+
+            for corner in [
+                Point::new(px(1.0), px(1.0)),
+                Point::new(px(39.0), px(1.0)),
+                Point::new(px(1.0), px(39.0)),
+                Point::new(px(39.0), px(39.0)),
+            ] {
+                assert!(
+                    !path.contains(corner),
+                    "{fill_type:?}: {corner:?} is 26.9px from the centre, \
+                     outside the 20px radius"
+                );
+            }
+        }
+    }
+
+    /// An arc that opens its own contour seeds that contour at the arc's
+    /// start rather than chording back to the origin.
+    #[test]
+    fn a_leading_arc_starts_its_own_contour() {
+        use core::f32::consts::TAU;
+        let rect = Rect::from_xywh(px(100.0), px(100.0), px(40.0), px(40.0));
+
+        let mut path = Path::new();
+        path.add_arc(rect, 0.0, TAU);
+        path.close();
+
+        assert!(
+            path.contains(Point::new(px(120.0), px(120.0))),
+            "the arc's own centre is inside"
+        );
+        assert!(
+            !path.contains(Point::new(px(50.0), px(50.0))),
+            "a point back toward the origin is outside — a leading arc must \
+             not chord to (0, 0)"
+        );
     }
 }

--- a/tests/material_demo.rs
+++ b/tests/material_demo.rs
@@ -197,9 +197,17 @@ impl MountedDemo {
     /// Taps the center of `id`'s rendered box — the standard way this test
     /// drives a button whose own on-screen glyph text was used only to find
     /// it (see [`find_text`](Self::find_text)'s callers).
+    ///
+    /// The center, not a corner: a Material button clips to its shape, so a
+    /// point just inside the bounding box of a *circular* one can sit outside
+    /// the circle and never reach the button at all.
     fn tap_node(&self, id: RenderId) {
         let position = self.absolute_position(id);
-        self.tap(position.dx.get() + 1.0, position.dy.get() + 1.0);
+        let size = self.size(id);
+        self.tap(
+            position.dx.get() + size.width.get() / 2.0,
+            position.dy.get() + size.height.get() / 2.0,
+        );
     }
 
     /// Hit-test at root-local `(x, y)` and dispatch a synthetic pointer-down,

--- a/tools/live-smoke/src/harness.rs
+++ b/tools/live-smoke/src/harness.rs
@@ -392,6 +392,13 @@ fn check_occlusion_gating(
     fake_motion(conn, root, center_x, fling_start_y)?;
     conn.sync()?;
     std::thread::sleep(Duration::from_millis(100));
+    // Witnesses for the premise below. The drag itself writes nothing to the
+    // log — only the wheel path logs `pointer-scroll tick` — so when the
+    // premise fails with a dead fling, the log alone cannot say whether the
+    // gesture engaged at all. These two make that distinction reportable
+    // instead of leaving the next reader to guess.
+    let before_drag_pixels = capture(conn, window, &geometry)?;
+    let gpu_before_drag = count(&read_log()?, GPU_PRESENT_MARKER);
     conn.xtest_fake_input(BUTTON_PRESS, 1, 0, root, 0, 0, 0)?;
     conn.sync()?;
     for step in 1..=6i16 {
@@ -401,6 +408,9 @@ fn check_occlusion_gating(
     }
     conn.xtest_fake_input(BUTTON_RELEASE, 1, 0, root, 0, 0, 0)?;
     conn.sync()?;
+    let after_drag_pixels = capture(conn, window, &geometry)?;
+    let drag_moved_content = after_drag_pixels != before_drag_pixels;
+    let drag_frames = count(&read_log()?, GPU_PRESENT_MARKER).saturating_sub(gpu_before_drag);
 
     // 4. Cover the app mid-fling — DEMAND-gated, never time-gated: a fixed
     //    gap between drag and cover is runner-speed-dependent (a slow CI
@@ -423,12 +433,29 @@ fn check_occlusion_gating(
             break;
         }
         if Instant::now() > fling_deadline {
+            // Two different defects reach this line, and the frame count alone
+            // does not separate them, so say which one this was. The drag
+            // either moved the content (the gesture engaged and the release
+            // simply carried no ballistic velocity) or it did not (the press
+            // never became a scroll gesture — hit-testing, arena, or event
+            // delivery), and a reader who cannot tell them apart is left
+            // guessing at the whole subsystem.
+            let verdict = if drag_moved_content {
+                "the drag DID move the content, so the gesture engaged and the \
+                 release carried no ballistic velocity — look at the drag's \
+                 velocity samples, not at delivery"
+            } else {
+                "the drag did NOT move the content at all, so the press never \
+                 became a scroll gesture — look at hit-testing, the gesture \
+                 arena, or event delivery, not at the fling"
+            };
             bail!(
                 "occlusion check FAILED (premise): the drag-fling presented only \
                  {frames} frame(s) beyond the quiesced post-arming baseline (or \
                  stopped producing) within 10s of the drag — no live animation \
                  exists for the gate to stop, so the zero-submissions assertion \
-                 would be vacuous"
+                 would be vacuous.\n  Drag itself presented {drag_frames} frame(s). \
+                 {verdict}."
             );
         }
         previous = sample;


### PR DESCRIPTION
## Summary

`Path::contains` carried `PathCommand::AddArc(..) => { /* TODO */ }` in **both** the even-odd and non-zero walkers, and the arm did not advance `current_pos` past the arc either.

`Path::from_rrect` builds a circular Material surface as four quadrant arcs joined by `LineTo`. With the arcs skipped and `current_pos` frozen at the pre-arc point, each following `LineTo` degenerated into a chord — so containment saw the **inscribed diamond** through the arc endpoints:

```
|x − r| + |y − r| ≤ r          instead of          (x − r)² + (y − r)² ≤ r²
```

That is ~64% of the true area. Every circular `IconButton`, `FloatingActionButton`, and stadium-bordered surface stopped hit-testing near its edge, and every rounded `Card`/`Dialog` lost its corners.

**This is a parity break, not a sanctioned divergence.** Both oracle gates evaluate the real curve: `RenderClipPath.hitTest` (`rendering/proxy_box.dart:2022`) and `RenderPhysicalShape.hitTest` (`:2312`) each test `_clip!.contains(position)` against a Skia-backed `Path`, which is exact for conics. (The separately documented `RenderPhysicalModel` bounding-box divergence — the oracle's `_clipper` is always null there — is a different thing and is untouched.)

### The fix

Arcs flatten into chords at the same ellipse parametrization the tessellator rasterizes them with (`lyon::geom::Arc` at zero x-rotation, `center + (rx·cosθ, ry·sinθ)`), so the hit region and the drawn pixels agree on where the curve is.

The chord count is derived from the arc's **radius**, not a fixed angle: a chord spanning `theta` on a circle of radius `r` sags `r · (1 − cos(theta/2))`, so the widest chord within tolerance is `theta = 2·acos(1 − tolerance/r)`, with ellipses taking the larger semi-axis. The tolerance matches the renderer's own `DEVICE_FILL_TOLERANCE`; that one is pre-divided by the paint transform's scale, which a local-space containment test cannot see, so this is the un-scaled figure. Degenerate radii and sweeps cost one chord; a radius large enough that `1 − tolerance/r` rounds to `1` in `f32` saturates at a 2048-chord ceiling rather than dividing by zero.

Contour bookkeeping now matches the renderer on both ends. `current_pos` advances to the arc endpoint. A new `subpath_open` flag distinguishes an arc *continuing* an open contour through a chord — the shape `add_arc`'s own divergence note describes, and what `from_rrect` relies on — from one *opening* its own. And a standalone `AddRect`/`AddCircle`/`AddOval` **ends** whatever contour is open, because every one of those arms in `flui-engine`'s tessellator does `builder.end(false)` and clears `has_begun`; the closing edge is counted at the shape rather than deferred to the walk's tail, which can no longer see it once the position resets.

### How it was found

`tests/material_demo.rs` was failing 5 of 13. I reported those as pre-existing in #793 and they were, but "pre-existing" was where I stopped, and that was the wrong place to stop.

The app bar's `IconButton` actions did not respond to taps while the FAB and cards did. Bisecting the tap offset put the threshold exactly between +1 and +2 px, which is the diamond boundary to the pixel: local `(9,9)` gives `11 + 11 = 22 > 20`, local `(10,10)` gives exactly `20`. The hit-test paths at both points were byte-identical, so routing was not involved. Probing down the chain — tap recognizer → `GestureDetector::handle_down` → the binding (`path_len=0`) → `RenderPhysicalShape` → a dump of the resolved path — landed on the four `AddArc` commands.

One detail worth recording, because it is genuinely confusing: **outside the owner lane** `resolve_path_clip_target` cannot resolve and `compute_clip` falls back to the full rect, so a hit test run outside the lane returns the whole 19-node path while the identical call inside the lane returns nothing.

## Verification

- [x] `just ci` — `fmt --all --check`, `clippy --workspace --all-targets -D warnings` (exit 0, zero diagnostics), `port-check` (22 triggers + FR-033 + ADR greps), `check-workspace-inventory` (28 crates, 143 edges), `check-runtime-conformance` (54 contracts), `check-panic-policy`. Tests: **169 suites, 9903 passed, 0 failed, 429 ignored**. Doctests: **664 passed, 0 failed**. CI on `ed53408`: all 14 checks green.
- [x] Flutter reference checked — `.flutter` present at tag `3.44.0`; both `hitTest` bodies read there, not recalled.
- [x] New or changed behavior has tests that would fail without this change — four pins, each red-checked in isolation (below).
- [x] Public API changes are documented — `Path::contains`'s doc no longer claims arcs are ignored and states what it now does instead.

**Red-checks.** Each fix was neutralized on its own, leaving the rest in place:

| Neutralized | Fails |
|---|---|
| arc evaluation | `a_circle_built_from_quadrant_arcs_contains_its_whole_disc`, `a_leading_arc_starts_its_own_contour` |
| contour teardown at standalone shapes | `a_standalone_shape_ends_the_open_contour_before_a_following_arc` |
| radius-derived chord count | `a_large_arc_is_flattened_to_the_same_distance_tolerance_as_a_small_one` |

`a_circle_built_from_quadrant_arcs_rejects_its_bounding_box_corners` stays green either way **by design** — it guards against the fix over-claiming, so it is not a regression pin and is not expected to flip.

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md` — the change is confined to a geometry primitive in `flui-types`; no new edges (`inventory-check` green over 143).
- [x] No new banned patterns from `docs/PORT.md` — `port-check` clean.
- [x] No new dependencies.

## Notes

**A test had pinned the bug as expected behavior.** The full workspace run surfaced exactly one failure out of 9900: `flui-material --test dialog`. Its own doc comment explained why the probe sat where it did —

> the corner's actual point-in-path test lands on the `x + y >= radius` side of a straight diagonal, not a true arc

— i.e. the chord behavior was observed and then written down as the contract. With arcs evaluated, `(13, 13)` is inside at both 28dp and 24dp, so the pair stopped discriminating, which is the only thing it exists to prove.

Re-derived rather than re-measured. A corner of radius `r` centres its arc at `(r, r)`, so a diagonal point `(p, p)` is inside exactly when `(r − p)·√2 ≤ r`, i.e. `p ≥ r·(1 − 1/√2)`: `8.20` at 28dp, `7.03` at 24dp. Any probe strictly between those is excluded at the default and included at the override. `7.6` sits mid-band with ~0.6px of clearance either way. Both tests now pass with the same probe and opposite expectations.

**`MountedDemo::tap_node` now taps the center its doc already promised** instead of the bounding box's top-left corner plus one pixel. A Material button clips to its shape, so on a circular one that corner point can sit outside the circle and never reach the button.

**Why CI never saw this.** The assertion landed on local `(10,10)` — *exactly* the degenerate diamond's boundary, counted as inside. It passed on a knife edge, and a single pixel of font-metric difference flips it; this container and CI genuinely disagreed. Ruled out features as the cause: the failure reproduces here under CI's own `--features cupertino,localizations`.

### Why a live-smoke commit is in this PR

`ed53408` touches `tools/live-smoke`, which is otherwise unrelated to `Path::contains`. It is here because `test (ubuntu-latest)` went red on the previous head with the occlusion check's dead-fling premise, and diagnosing that was blocked by the harness reporting a frame count and nothing else.

That failure is **not** caused by this diff, measured rather than asserted: swapping only `path.rs` and running six times each gives 16/9/8/15/14/9 on this branch against 8/11/16/14/9/15 on `origin/main` — indistinguishable, 6/6 pass both ways. An instrumented build shows the standalone-shape contour teardown never fires anywhere in the `sliver_demo` tree. Forty further runs all passed with a minimum of 8 frames, so a 2-frame outcome is a distinct failure mode rather than the tail of that distribution, and it is **still unexplained**. `ed53408` does not claim to fix it — it makes the next occurrence diagnosable, by capturing the window's pixels either side of the drag so the premise can say whether the press never became a gesture at all or the gesture engaged and carried no ballistic velocity. Both branches of that verdict were exercised against forced real failures. The assertion the check exists for — zero GPU submissions while covered — is untouched.

I also got this wrong once on the way: an initial pass concluded from *single* runs that the contour teardown was responsible, and separately floated a velocity-under-load hypothesis that a loaded eight-run comparison then contradicted. Both corrections are in the review threads.

**Adjacent but not claimed:** #543 covers clipper wiring and `transformHitTests`. This is the underlying `Path::contains` primitive rather than one of that issue's acceptance criteria, so it is related work, not a close.

**Two process notes, since both nearly cost a pin.** My first full-workspace run ended in `head -60`, which truncated the output and may have killed the run via SIGPIPE; I discarded it and re-ran untruncated, and every number above comes from the clean runs. And the first draft of the large-arc test probed at 45°, which is a polygon *vertex* at 11.25° subdivision (45/11.25 = 4) — the polygon touches the circle exactly there, so it passed without the fix and proved nothing. The probe now sits at 5.625°, the midpoint of the first chord.
